### PR TITLE
prov/gni: initial structs for gni provider

### DIFF
--- a/prov/gni/src/ccan/BSD-MIT
+++ b/prov/gni/src/ccan/BSD-MIT
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/prov/gni/src/ccan/container_of.h
+++ b/prov/gni/src/ccan/container_of.h
@@ -1,0 +1,66 @@
+#ifndef CCAN_CONTAINER_OF_H
+#define CCAN_CONTAINER_OF_H
+#include <stddef.h>
+
+#include "config.h"
+
+#ifndef container_of
+/**
+ * container_of - get pointer to enclosing structure
+ * @member_ptr: pointer to the structure member
+ * @containing_type: the type this member is within
+ * @member: the name of this member within the structure.
+ *
+ * Given a pointer to a member of a structure, this macro does pointer
+ * subtraction to return the pointer to the enclosing type.
+ *
+ * Example:
+ *	struct info
+ *	{
+ *		int some_other_field;
+ *		struct foo my_foo;
+ *	};
+ *
+ *	struct info *foo_to_info(struct foo *foop)
+ *	{
+ *		return container_of(foo, struct info, my_foo);
+ *	}
+ */
+#define container_of(member_ptr, containing_type, member)		\
+	 ((containing_type *)						\
+	  ((char *)(member_ptr) - offsetof(containing_type, member))	\
+	  - check_types_match(*(member_ptr), ((containing_type *)0)->member))
+#endif
+
+
+/**
+ * container_of_var - get pointer to enclosing structure using a variable
+ * @member_ptr: pointer to the structure member
+ * @var: a pointer to a structure of same type as this member is within
+ * @member: the name of this member within the structure.
+ *
+ * Given a pointer to a member of a structure, this macro does pointer
+ * subtraction to return the pointer to the enclosing type.
+ *
+ * Example:
+ *	struct info
+ *	{
+ *		int some_other_field;
+ *		struct foo my_foo;
+ *	};
+ *
+ *	struct info *foo_to_info(struct foo *foop)
+ *	{
+ *		struct info *i = container_of_var(foo, i, my_foo);
+ *		return i;
+ *	}
+ */
+#ifdef HAVE_TYPEOF
+#define container_of_var(member_ptr, var, member) \
+	container_of(member_ptr, typeof(*var), member)
+#else
+#define container_of_var(member_ptr, var, member) \
+	((void *)((char *)(member_ptr) - offsetof(containing_type, member)))
+#endif
+
+#endif /* CCAN_CONTAINER_OF_H */

--- a/prov/gni/src/ccan/list.h
+++ b/prov/gni/src/ccan/list.h
@@ -1,0 +1,261 @@
+#ifndef CCAN_LIST_H
+#define CCAN_LIST_H
+#include <stdbool.h>
+
+#include "container_of.h"
+
+/**
+ * struct list_node - an entry in a doubly-linked list
+ * @next: next entry (self if empty)
+ * @prev: previous entry (self if empty)
+ *
+ * This is used as an entry in a linked list.
+ * Example:
+ *	struct child {
+ *		const char *name;
+ *		// Linked list of all us children.
+ *		struct list_node list;
+ *	};
+ */
+struct list_node
+{
+	struct list_node *next, *prev;
+};
+
+/**
+ * struct list_head - the head of a doubly-linked list
+ * @h: the list_head (containing next and prev pointers)
+ *
+ * This is used as the head of a linked list.
+ * Example:
+ *	struct parent {
+ *		const char *name;
+ *		struct list_head children;
+ *		unsigned int num_children;
+ *	};
+ */
+struct list_head
+{
+	struct list_node n;
+};
+
+/**
+ * list_check - check a list for consistency
+ * @h: the list_head
+ * @abortstr: the location to print on aborting, or NULL.
+ *
+ * Because list_nodes have redundant information, consistency checking between
+ * the back and forward links can be done.  This is useful as a debugging check.
+ * If @abortstr is non-NULL, that will be printed in a diagnostic if the list
+ * is inconsistent, and the function will abort.
+ *
+ * Returns the list head if the list is consistent, NULL if not (it
+ * can never return NULL if @abortstr is set).
+ *
+ * Example:
+ *	static void dump_parent(struct parent *p)
+ *	{
+ *		struct child *c;
+ *
+ *		printf("%s (%u children):\n", p->name, parent->num_children);
+ *		list_check(&p->children, "bad child list");
+ *		list_for_each(&p->children, c, list)
+ *			printf(" -> %s\n", c->name);
+ *	}
+ */
+struct list_head *list_check(const struct list_head *h, const char *abortstr);
+
+#ifdef CCAN_LIST_DEBUG
+#define debug_list(h) list_check((h), __func__)
+#else
+#define debug_list(h) (h)
+#endif
+
+/**
+ * list_head_init - initialize a list_head
+ * @h: the list_head to set to the empty list
+ *
+ * Example:
+ *	list_head_init(&parent->children);
+ *	parent->num_children = 0;
+ */
+static inline void list_head_init(struct list_head *h)
+{
+	h->n.next = h->n.prev = &h->n;
+}
+
+/**
+ * LIST_HEAD - define and initalized empty list_head
+ * @name: the name of the list.
+ *
+ * The LIST_HEAD macro defines a list_head and initializes it to an empty
+ * list.  It can be prepended by "static" to define a static list_head.
+ *
+ * Example:
+ *	// Header:
+ *	extern struct list_head my_list;
+ *
+ *	// C file:
+ *	LIST_HEAD(my_list);
+ */
+#define LIST_HEAD(name) \
+	struct list_head name = { { &name.n, &name.n } }
+
+/**
+ * list_add - add an entry at the start of a linked list.
+ * @h: the list_head to add the node to
+ * @n: the list_node to add to the list.
+ *
+ * The list_node does not need to be initialized; it will be overwritten.
+ * Example:
+ *	list_add(&parent->children, &child->list);
+ *	parent->num_children++;
+ */
+static inline void list_add(struct list_head *h, struct list_node *n)
+{
+	n->next = h->n.next;
+	n->prev = &h->n;
+	h->n.next->prev = n;
+	h->n.next = n;
+	(void)debug_list(h);
+}
+
+/**
+ * list_add_tail - add an entry at the end of a linked list.
+ * @h: the list_head to add the node to
+ * @n: the list_node to add to the list.
+ *
+ * The list_node does not need to be initialized; it will be overwritten.
+ * Example:
+ *	list_add_tail(&parent->children, &child->list);
+ *	parent->num_children++;
+ */
+static inline void list_add_tail(struct list_head *h, struct list_node *n)
+{
+	n->next = &h->n;
+	n->prev = h->n.prev;
+	h->n.prev->next = n;
+	h->n.prev = n;
+	(void)debug_list(h);
+}
+
+/**
+ * list_del - delete an entry from a linked list.
+ * @n: the list_node to delete from the list.
+ *
+ * Example:
+ *	list_del(&child->list);
+ *	parent->num_children--;
+ */
+static inline void list_del(struct list_node *n)
+{
+	n->next->prev = n->prev;
+	n->prev->next = n->next;
+	(void)debug_list(n->next);
+#ifdef CCAN_LIST_DEBUG
+	/* Catch use-after-del. */
+	n->next = n->prev = NULL;
+#endif
+}
+
+/**
+ * list_empty - is a list empty?
+ * @h: the list_head
+ *
+ * If the list is empty, returns true.
+ *
+ * Example:
+ *	assert(list_empty(&parent->children) == (parent->num_children == 0));
+ */
+static inline bool list_empty(const struct list_head *h)
+{
+	(void)debug_list(h);
+	return h->n.next == &h->n;
+}
+
+/**
+ * list_entry - convert a list_node back into the structure containing it.
+ * @n: the list_node
+ * @type: the type of the entry
+ * @member: the list_node member of the type
+ *
+ * Example:
+ *	struct child *c;
+ *	// First list entry is children.next; convert back to child.
+ *	c = list_entry(parent->children.next, struct child, list);
+ */
+#define list_entry(n, type, member) container_of(n, type, member)
+
+/**
+ * list_top - get the first entry in a list
+ * @h: the list_head
+ * @type: the type of the entry
+ * @member: the list_node member of the type
+ *
+ * If the list is empty, returns NULL.
+ *
+ * Example:
+ *	struct child *first;
+ *	first = list_top(&parent->children, struct child, list);
+ */
+#define list_top(h, type, member) \
+	(list_empty(h) ? NULL : list_entry((h)->n.next, type, member))
+
+/**
+ * list_tail - get the last entry in a list
+ * @h: the list_head
+ * @type: the type of the entry
+ * @member: the list_node member of the type
+ *
+ * If the list is empty, returns NULL.
+ *
+ * Example:
+ *	struct child *last;
+ *	last = list_tail(&parent->children, struct child, list);
+ */
+#define list_tail(h, type, member) \
+	(list_empty(h) ? NULL : list_entry((h)->n.prev, type, member))
+
+/**
+ * list_for_each - iterate through a list.
+ * @h: the list_head
+ * @i: the structure containing the list_node
+ * @member: the list_node member of the structure
+ *
+ * This is a convenient wrapper to iterate @i over the entire list.  It's
+ * a for loop, so you can break and continue as normal.
+ *
+ * Example:
+ *	struct child *c;
+ *	list_for_each(&parent->children, c, list)
+ *		printf("Name: %s\n", c->name);
+ */
+#define list_for_each(h, i, member)					\
+	for (i = container_of_var(debug_list(h)->n.next, i, member);	\
+	     &i->member != &(h)->n;					\
+	     i = container_of_var(i->member.next, i, member))
+
+/**
+ * list_for_each_safe - iterate through a list, maybe during deletion
+ * @h: the list_head
+ * @i: the structure containing the list_node
+ * @nxt: the structure containing the list_node
+ * @member: the list_node member of the structure
+ *
+ * This is a convenient wrapper to iterate @i over the entire list.  It's
+ * a for loop, so you can break and continue as normal.  The extra variable
+ * @nxt is used to hold the next element, so you can delete @i from the list.
+ *
+ * Example:
+ *	struct child *c, *n;
+ *	list_for_each_safe(&parent->children, c, n, list) {
+ *		list_del(&c->list);
+ *		parent->num_children--;
+ *	}
+ */
+#define list_for_each_safe(h, i, nxt, member)				\
+	for (i = container_of_var(debug_list(h)->n.next, i, member),	\
+		nxt = container_of_var(i->member.next, i, member);	\
+	     &i->member != &(h)->n;					\
+	     i = nxt, nxt = container_of_var(i->member.next, i, member))
+#endif /* CCAN_LIST_H */

--- a/prov/gni/src/gnix.h
+++ b/prov/gni/src/gnix.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Cray Inc.  All rights reserved.
- * Copyright (c) 2014 Los Alamos National Security, LLC. Allrights reserved.
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/prov/gni/src/gnix.h
+++ b/prov/gni/src/gnix.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2014 Los Alamos National Security, LLC. Allrights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -59,9 +60,218 @@ extern "C"
 #include <fi_indexer.h>
 #include <fi_rbuf.h>
 #include <fi_list.h>
+#include "gni_pub.h"
+#include "ccan/list.h"
 
 #define GNI_MAJOR_VERSION 0
 #define GNI_MINOR_VERSION 5
+
+/*
+ * useful macros
+ */
+
+#ifndef likely
+#define likely(x)   __builtin_expect((x),1)
+#endif
+#ifndef unlikely
+#define unlikely(x) __builtin_expect((x),0)
+#endif
+
+#ifndef FLOOR
+#define FLOOR(a,b)      ((long long)(a) - ( ((long long)(a)) %(b)))
+#endif
+
+#ifndef CEILING
+#define CEILING(a,b)    ((long long)(a) <= 0LL ? 0 :  (FLOOR((a)-1,b) + (b)))
+#endif
+
+#ifndef IN
+#define IN
+#endif
+
+#ifndef OUT
+#define OUT
+#endif
+
+#ifndef INOUT
+#define INOUT
+#endif
+
+/*
+ * Cray gni provider supported flags for fi_getinfo argument for now, needs refining (see fi_getinfo.3 man page)
+ */
+
+#define GNIX_SUPPORTED_FLAGS (  FI_NUMERICHOST | FI_SOURCE )
+
+#define GNIX_DEFAULT_FLAGS   (0)
+
+/*
+ * Cray gni provider will try to support the fabric interface capabilities (see fi_getinfo.3 man page)
+ * for RDM and MSG (future) endpoint types.
+ */
+
+#define GNIX_EP_RDM_CAPS         (FI_MSG | \
+                                  FI_RMA | \
+                                  FI_TAGGED | \
+                                  FI_ATOMICS | \
+                                  FI_BUFFERED_RECV | \
+                                  FI_DIRECTED_RECV | \
+                                  FI_MULTI_RECV | \
+                                  FI_SOURCE | \
+                                  FI_READ | FI_WRITE | \
+                                  FI_SEND | FI_RECV | \
+                                  FI_REMOTE_READ | FI_REMOTE_WRITE | \
+                                  FI_REMOTE_COMPLETE | \
+                                  FI_CANCEL |\
+                                  FI_MORE )               /* optimization, see fi_msg.3 */
+      
+
+#define GNIX_EP_MSG_CAPS          GNIX_EP_RDM_CAPS
+
+/*
+ * Cray gni provider will support the following fabric interface modes (see fi_getinfo.3 man page)
+ */
+#define GNIX_FAB_MODES           (FI_CONTEXT |  \
+                                  FI_LOCAL_MR | \
+                                  FI_PROV_MR_ATTR)
+
+/*
+ * gnix address format - used for fi_send/fi_recv, etc.
+ */
+
+struct gnix_address {
+        uint32_t               device_addr;
+        uint32_t               cdm_id;
+};
+
+/*
+ * info returned by fi_getname/fi_getpeer - has enough
+ * side band info for RDM ep's to be able to connect, etc.
+ */
+
+struct gnix_ep_name {
+        struct gnix_address    gnix_addr;
+        struct {
+            uint32_t           name_type:8;
+            uint32_t           unused   :24;
+        };
+        uint64_t               reserved[4];
+};
+
+       
+/*
+ * enum for blocking/non-blocking progress
+ */
+
+enum gnix_progress_type {
+        GNIX_PRG_BLOCKING,
+        GNIX_PRG_NON_BLOCKING
+};
+
+
+/*
+ * a gnix_domain is associated with one cdm and one nic
+ * since a single cdm with a given cookie/cdm_id can only
+ * be bound once to a given physical aries nic
+ */
+
+struct gnix_domain {
+	struct fid_domain	domain_fid;
+	struct gnix_cdm 	*cdm;
+	struct gnix_nic 	*nic;
+        struct list_head        domain_wq;
+	uint32_t 		device_id;                 
+ 	uint32_t		device_addr;
+};
+
+struct gnix_cdm {
+        struct list_node        list;
+        gni_cdm_handle_t        gni_cdm_hndl;
+        struct list_head        nic_list;                  /* list nics this cdm is attached to, TODO: thread safety */
+        uint32_t                inst_id;
+        uint8_t                 ptag;
+        uint32_t                cookie;
+        uint32_t                modes;
+        int                     ref_cnt;                   /* TODO: thread safety */
+};
+
+struct gnix_nic {
+        struct list_node        list;
+	gni_nic_handle_t 	gni_nic_hndl;
+        gni_cq_handle_t         rx_cq;                     /* receive completion queue for hndl */
+        gni_cq_handle_t         rx_cq_blk;                 /* receive completion queue for hndl (blocking) */
+        gni_cq_handle_t         tx_cq;                     /* local(tx) completion queue for hndl */
+        gni_cq_handle_t         tx_cq_blk;                 /* local(tx) completion queue for hndl (blocking) */
+        struct list_head        wqe_active_list;           /* list of wqe's */
+        struct gnix_wqe_list    *wqe_list;                 /* list for managing wqe's */
+        struct list_head        smsg_active_req_list;      /* list of active smsg req's */
+        struct gnix_smsg_req_list *smsg_req_list;            /* list for managing smsg req's */
+        struct list_head        datagram_active_list;      /* list of active datagrams */
+        struct list_head        datagram_free_list;        /* free list of datagrams   */
+        struct list_head        wc_datagram_active_list;   /* list of active wc datagrams   */
+        struct list_head        wc_datagram_free_list;     /* free list of wc datagrams   */
+        struct gnix_cdm         *cdm;                      /* pointer to cdm this nic is attached to */
+        struct gnix_datagram    *datagram_base;            
+        uint32_t                device_id;
+        uint32_t                device_addr;
+        int                     ref_cnt;
+};
+
+/*
+ * CQE struct definitions
+ */
+
+struct gnix_cq_entry {
+        struct list_node          list;
+        struct fi_cq_entry        the_entry;
+};
+
+struct gnix_cq_msg_entry {
+        struct list_node          list;
+        struct fi_cq_msg_entry    the_entry;
+};
+
+struct gnix_cq_tagged_entry {
+        struct list_node          list;
+        struct fi_cq_tagged_entry the_entry;
+};
+
+struct gnix_cq {
+	struct fid_cq		fid;
+	uint64_t		flags;
+	struct gnix_domain	*domain;
+        void                    *free_list_base;
+        struct list_head        entry;
+        struct list_head        err_entry;
+        struct list_head        entry_free_list;
+        int                     (*progress_fn)(struct gnix_cq *);
+        enum fi_cq_format       format;
+};
+
+struct gnix_mem_desc {
+	struct fid_mr		mr_fid;
+	struct gnix_domain	*domain;
+	gni_mem_handle_t        mem_hndl;
+};
+
+/*
+ *   gnix_rdm_ep - FI_EP_RDM type ep
+ */
+
+struct gnix_rdm_ep {
+	struct fid_ep		ep_fid;
+	struct gnix_domain	*domain;              
+        void                    *vc_cache_hndl; 
+        int                     (*progress_fn)(struct gnix_rdm_ep *, enum gnix_progress_type);        
+        int                     (*rx_progress_fn)(struct gnix_rdm_ep *, 
+                                                  gni_return_t *rc);  /* RX specific progress fn */
+        int                      enabled;
+        uint32_t                 active_post_descs;     /* num. active post descs associated with this ep */
+};
+
+/*
+ * prototypes 
+ */
 
 int gnix_rdm_getinfo(uint32_t version, const char *node, const char *service,
 		     uint64_t flags, struct fi_info *hints,

--- a/prov/gni/src/gnix_init.c
+++ b/prov/gni/src/gnix_init.c
@@ -38,15 +38,6 @@
 #include "fi.h"
 #include "prov.h"
 
-// This is useful for making sure we have the gni headers and lib
-// paths right.  Remove when we get some real code in here.
-int gnix_foobar(void){
-       uint32_t version;
-       GNI_GetVersion(&version);
-       return 0;
-}
-
-
 static int
 gnix_getinfo(uint32_t version, const char *node, const char *service,
              uint64_t flags, struct fi_info *hints, struct fi_info **info)


### PR DESCRIPTION
Initial definitions of gnix_domain/gnix_cdm/gnix_nic.

delete foobar function from gnix_init.c since no longer needed.

Add the ccan linked list header files.  We may eventually
move to using libfabric internal linked list functionality.

ccan uses a BSD-like license

@sungeunchoi 
@jshimek
@ztiffany
