### PR TITLE
Gnix getinfo fl

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -271,8 +271,12 @@ if HAVE_GNI
 _gni_files = \
 	prov/gni/src/gnix.h \
 	prov/gni/src/gnix_init.c \
+	prov/gni/src/gnix_fabric.c \
+	prov/gni/src/gnix_dom.c \
 	prov/gni/src/gnix_ep.c \
-	prov/gni/src/gnix_ep_rdm.c
+	prov/gni/src/gnix_ep_rdm.c \
+	prov/gni/src/gnix_nameserver.c \
+	prov/gni/src/gnix_util.c 
 
 if HAVE_GNI_DL
 pkglib_LTLIBRARIES += libgnix-fi.la

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -152,6 +152,7 @@ enum {
 	FI_SOCKADDR_IN6,	/* struct sockaddr_in6 */
 	FI_SOCKADDR_IB,		/* struct sockaddr_ib */
 	FI_ADDR_PSMX,		/* uint64_t */
+	FI_ADDR_GNI,		/* TODO: don't know yet */
 };
 
 #define FI_ADDR_UNSPEC		UINT64_MAX
@@ -214,7 +215,8 @@ enum {
 	FI_PROTO_IB_UD,
 	FI_PROTO_PSMX,
 	FI_PROTO_UDP,
-	FI_PROTO_SOCK_TCP
+	FI_PROTO_SOCK_TCP,
+	FI_PROTO_GNI
 };
 
 /* Mode bits */

--- a/prov/gni/configure.m4
+++ b/prov/gni/configure.m4
@@ -17,13 +17,13 @@ m4_include([config/pkg.m4])
 	      [PKG_CHECK_MODULES([CRAY_UGNI], [cray-ugni],
                                  [ugni_lib_happy=1
                                   CPPFLAGS="$CRAY_UGNI_CFLAGS $CPPFLAGS"
-                                  LDFLAGS="$CRAY_UGNI_LIBS $CPPFLAGS"
+                                  LDFLAGS="$CRAY_UGNI_LIBS $LDFLAGS"
                                  ],
                                  [ugni_lib_happy=0])
                PKG_CHECK_MODULES([CRAY_GNI_HEADERS], [cray-gni-headers],
                                  [gni_header_happy=1
                                   CPPFLAGS="$CRAY_GNI_HEADERS_CFLAGS $CPPFLAGS"
-                                  LDFLAGS="$CRAY_GNI_HEADER_LIBS $CPPFLAGS"
+                                  LDFLAGS="$CRAY_GNI_HEADER_LIBS $LDFLAGS"
                                  ],
                                  [gni_header_happy=0])
 	       ])

--- a/prov/gni/src/gnix.h
+++ b/prov/gni/src/gnix.h
@@ -62,6 +62,7 @@ extern "C"
 #include <fi_list.h>
 #include "gni_pub.h"
 #include "ccan/list.h"
+#include "gnix_util.h"
 
 #define GNI_MAJOR_VERSION 0
 #define GNI_MINOR_VERSION 5
@@ -69,6 +70,8 @@ extern "C"
 /*
  * useful macros
  */
+
+#define PFX "libfabric:gni"
 
 #ifndef likely
 #define likely(x)   __builtin_expect((x),1)
@@ -110,6 +113,10 @@ extern "C"
  * for RDM and MSG (future) endpoint types.
  */
 
+/*
+ * see capabilities section in fi_getinfo.3
+ */
+
 #define GNIX_EP_RDM_CAPS         (FI_MSG | \
                                   FI_RMA | \
                                   FI_TAGGED | \
@@ -117,23 +124,47 @@ extern "C"
                                   FI_BUFFERED_RECV | \
                                   FI_DIRECTED_RECV | \
                                   FI_MULTI_RECV | \
+                                  FI_INJECT | \
                                   FI_SOURCE | \
                                   FI_READ | FI_WRITE | \
                                   FI_SEND | FI_RECV | \
                                   FI_REMOTE_READ | FI_REMOTE_WRITE | \
                                   FI_REMOTE_COMPLETE | \
                                   FI_CANCEL |\
-                                  FI_MORE )               /* optimization, see fi_msg.3 */
-      
+                                  FI_FENCE )
+
+/*
+ * see Operations flags in fi_endpoint.3
+ */
+
+#define GNIX_EP_OP_FLAGS          ( FI_MULTI_RECV |\
+                                    FI_BUFFERED_RECV |\
+                                    FI_COMPLETION |\
+                                    FI_REMOTE_COMPLETE |\
+                                    FI_READ |\
+                                    FI_WRITE |\
+                                    FI_SEND |\
+                                    FI_RECV |\
+                                    FI_REMOTE_READ |\
+                                    FI_REMOTE_WRITE) 
 
 #define GNIX_EP_MSG_CAPS          GNIX_EP_RDM_CAPS
 
+#define GNIX_MAX_MSG_SIZE         ((0x1ULL << 32) - 1)
+#define GNIX_INJECT_SIZE          64
+
 /*
- * Cray gni provider will support the following fabric interface modes (see fi_getinfo.3 man page)
+ * Cray gni provider will require the following fabric interface modes (see fi_getinfo.3 man page)
  */
 #define GNIX_FAB_MODES           (FI_CONTEXT |  \
                                   FI_LOCAL_MR | \
                                   FI_PROV_MR_ATTR)
+
+/*
+ * fabric modes that GNI provider doesn't need 
+ */
+
+#define GNIX_FAB_MODES_CLEAR      (FI_MSG_PREFIX | FI_ASYNC_IOV)
 
 /*
  * gnix address format - used for fi_send/fi_recv, etc.
@@ -168,6 +199,15 @@ enum gnix_progress_type {
         GNIX_PRG_NON_BLOCKING
 };
 
+
+/*
+ * simple struct for gnix fabric, may add more stuff here later
+ */
+
+struct gnix_fabric {
+    struct fid_fabric fab_fid;
+    atomic_t ref;
+};
 
 /*
  * a gnix_domain is associated with one cdm and one nic
@@ -270,14 +310,21 @@ struct gnix_rdm_ep {
 };
 
 /*
+ * globals
+ */
+
+extern const char const gnix_fab_name[];
+
+/*
  * prototypes 
  */
 
+int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
+                     struct fid_domain **domain, void *context);
 int gnix_rdm_getinfo(uint32_t version, const char *node, const char *service,
-		     uint64_t flags, struct fi_info *hints,
-                     struct fi_info **info);
-
+		     uint64_t flags, struct fi_info *hints, struct fi_info **info);
 struct fi_info *gnix_fi_info(enum fi_ep_type ep_type, struct fi_info *hints);
+int gnix_verify_domain_attr(struct fi_domain_attr *attr);
 
 #ifdef __cplusplus 
 } /* extern "C" */

--- a/prov/gni/src/gnix.h
+++ b/prov/gni/src/gnix.h
@@ -148,6 +148,9 @@ extern "C"
                                     FI_REMOTE_READ |\
                                     FI_REMOTE_WRITE) 
 
+/*
+ * if this has to be changed, check gnix_getinfo, etc.
+ */
 #define GNIX_EP_MSG_CAPS          GNIX_EP_RDM_CAPS
 
 #define GNIX_MAX_MSG_SIZE         ((0x1ULL << 32) - 1)

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) 2014 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2015 Los Alamos National Security, LLC. Allrights reserved.
  * Copyright (c) 2015 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -30,9 +32,9 @@
  * SOFTWARE.
  */
 
-//
-// Endpoint common code
-//
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
 
 #include <stdlib.h>
 #include <string.h>
@@ -40,4 +42,9 @@
 #include "gnix.h"
 #include "gnix_util.h"
 
+int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
+		     struct fid_domain **dom, void *context)
+{
+	return -FI_ENOSYS;  /* TODO: need to implement */
+}
 

--- a/prov/gni/src/gnix_ep_rdm.c
+++ b/prov/gni/src/gnix_ep_rdm.c
@@ -35,19 +35,3 @@
 
 #include "gnix.h"
 
-int
-gnix_rdm_getinfo(uint32_t version, const char *node, const char *service,
-                 uint64_t flags, struct fi_info *hints,
-                 struct fi_info **info)
-{
-  struct fi_info *_info = gnix_fi_info(FI_EP_RDM, hints);
-  if (!_info) return FI_ENOMEM;
-
-  // fill in RDM attributes
-
-  *info = _info;
-
-  return 0;
-}
-
-

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -124,7 +124,6 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 			uint64_t flags, struct fi_info *hints, struct fi_info **info)
 {
 	int ret = 0;
-	int caps = 0;
 	int mode = GNIX_FAB_MODES;
 	struct fi_info *gnix_info;
 	struct gnix_ep_name *dest_addr = NULL;
@@ -239,7 +238,6 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 */
         	}
 
-                caps = hints->caps;
 	}
 
 	/*
@@ -269,7 +267,7 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 
 	gnix_info->next = NULL;
 	gnix_info->ep_type = FI_EP_RDM;
-	gnix_info->caps = (hints && hints->caps) ? hints->caps : caps;
+	gnix_info->caps = GNIX_EP_RDM_CAPS;
 	gnix_info->mode = mode;
 	gnix_info->addr_format = FI_ADDR_GNI;
 	gnix_info->src_addrlen = 0;

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) 2014 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <rdma/fabric.h>
+#include <rdma/fi_cm.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_rma.h>
+#include <rdma/fi_errno.h>
+#include "prov.h"
+
+#include "gnix.h"
+#include "gnix_util.h"
+#include "gnix_nameserver.h"
+
+const char const gnix_fab_name[] = "gni";
+const char const gnix_dom_name[] = "/sys/class/gni/kgni0";
+
+const struct fi_fabric_attr gnix_fabric_attr = {
+	.fabric = NULL,
+	.name = NULL,
+	.prov_name = NULL,
+	.prov_version = FI_VERSION(GNI_MAJOR_VERSION, GNI_MINOR_VERSION),
+};
+
+static struct fi_ops_fabric gnix_fab_ops = {
+	.size = sizeof(struct fi_ops_fabric),
+	.domain = gnix_domain_open,
+	.passive_ep = NULL,          /* TODO: need to define for FI_EP_MSG */
+	.eq_open = NULL,             /* TODO: need to define for FI_EP_MSG */
+	.wait_open = NULL,           /* TODO: what's this about */
+};
+
+static int gnix_fabric_close(fid_t fid)
+{
+	struct gnix_fabric *fab;
+	fab = container_of(fid, struct gnix_fabric, fab_fid);
+
+	if (atomic_get(&fab->ref)) {
+		return -FI_EBUSY;
+	}
+
+	free(fab);
+	return 0;
+}
+
+static struct fi_ops gnix_fab_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = gnix_fabric_close,
+	.bind = fi_no_bind,
+	.control = fi_no_control,
+	.ops_open = fi_no_ops_open,
+};
+
+/*
+ * define methods needed for the GNI fabric provider
+ */
+
+static int gnix_fabric(struct fi_fabric_attr *attr,
+		       struct fid_fabric **fabric, void *context)
+{
+	struct gnix_fabric *fab;
+
+	if (strcmp(attr->name, gnix_fab_name))
+		return -FI_ENODATA;
+
+	fab = calloc(1, sizeof(*fab));
+	if (!fab)
+		return -FI_ENOMEM;
+
+	fab->fab_fid.fid.fclass = FI_CLASS_FABRIC;
+	fab->fab_fid.fid.context = context;
+	fab->fab_fid.fid.ops = &gnix_fab_fi_ops;
+	fab->fab_fid.ops = &gnix_fab_ops;
+	*fabric = &fab->fab_fid;
+#if 0
+	atomic_init(&fab->ref, 0);
+#endif
+	return 0;
+}
+
+static int gnix_getinfo(uint32_t version, const char *node, const char *service,
+			uint64_t flags, struct fi_info *hints, struct fi_info **info)
+{
+	int ret = 0;
+	int caps = 0;
+	int mode = GNIX_FAB_MODES;
+	struct fi_info *gnix_info;
+	struct gnix_ep_name *dest_addr = NULL;
+
+        /*
+         * the code below for resolving a node/service to what
+         * will be a gnix_ep_name address is not fully implemented,
+         * but put a place holder in place 
+         */
+
+	if (node && !(flags & FI_SOURCE)) {
+		dest_addr = (struct gnix_ep_name *)malloc(sizeof(*dest_addr));
+                if (dest_addr == NULL) {
+                	ret = -FI_ENOMEM;
+			goto err;
+		}
+		ret = gnix_resolve_name(node,service,dest_addr);
+		if (ret) goto err;
+	}
+
+        if (hints) {
+
+                /*
+                 * check for endpoint type, only support FI_EP_RDM for now
+                 */
+
+                switch (hints->ep_type) {
+                case FI_EP_UNSPEC:
+                case FI_EP_RDM:
+                        break;
+                default:
+			ret = -FI_ENODATA;
+                        goto err;
+                }
+
+		/*
+		 * check the mode field
+		 */
+
+		if (hints->mode) {
+		        if ((hints->mode & GNIX_FAB_MODES) != GNIX_FAB_MODES) {
+		        	ret = -FI_ENODATA;
+		        	goto err;
+		        }
+			mode = hints->mode & ~GNIX_FAB_MODES_CLEAR;
+    		}
+
+		if ((hints->caps & GNIX_EP_RDM_CAPS) != hints->caps) {
+			goto err;
+		}
+
+		if (hints->ep_attr) {
+			switch (hints->ep_attr->protocol) {
+			case FI_PROTO_UNSPEC:
+			case FI_PROTO_GNI:
+				break;
+			default:
+				ret = -FI_ENODATA;
+				goto err;
+			}
+
+			if (hints->ep_attr->tx_ctx_cnt > 1) {
+				ret = -FI_ENODATA;
+				goto err;
+			}
+
+			if (hints->ep_attr->rx_ctx_cnt > 1) {
+				ret = -FI_ENODATA;
+				goto err;
+       	  		}
+   		}
+
+		if (hints->tx_attr &&
+			(hints->tx_attr->op_flags & GNIX_EP_OP_FLAGS) !=
+				hints->tx_attr->op_flags) {
+			ret = -FI_ENODATA;
+			goto err;
+    		}
+
+		if (hints->rx_attr &&
+			(hints->rx_attr->op_flags & GNIX_EP_OP_FLAGS) !=
+			hints->rx_attr->op_flags) {
+			ret = -FI_ENODATA;
+			goto err;
+		}
+
+		if (hints->fabric_attr && hints->fabric_attr->name &&
+			strncmp(hints->fabric_attr->name, gnix_fab_name, strlen(gnix_fab_name))) {
+			ret = -FI_ENODATA;
+			goto err;
+		}
+
+		/* TODO: use hardwared kgni const string */
+		if (hints->domain_attr && hints->domain_attr->name &&
+			strncmp(hints->domain_attr->name, gnix_dom_name, strlen(gnix_dom_name))) {
+                        ret = -FI_ENODATA;
+                        goto err;
+		}
+
+		if (hints->ep_attr) {
+	                if (hints->ep_attr->max_msg_size > GNIX_MAX_MSG_SIZE) {
+	                        ret = -FI_ENODATA;
+	                        goto err;
+	                }
+                	if (hints->ep_attr->inject_size > GNIX_INJECT_SIZE) {
+                        	ret = -FI_ENODATA;
+                        	goto err;
+                	}
+/*
+ * TODO: tag matching
+                max_tag_value = fi_tag_bits(hints->ep_attr->mem_tag_format);
+*/
+        	}
+
+                caps = hints->caps;
+	}
+
+	/*
+	 * fill in the gnix_info struct
+	 */
+
+	gnix_info = fi_allocinfo_internal();
+	if (gnix_info == NULL) {
+		ret = -FI_ENOMEM;
+	        goto err;
+	}
+
+	gnix_info->ep_attr->protocol = FI_PROTO_GNI;
+	gnix_info->ep_attr->max_msg_size = GNIX_MAX_MSG_SIZE;
+	gnix_info->ep_attr->inject_size = GNIX_INJECT_SIZE;
+	gnix_info->ep_attr->total_buffered_recv = ~(0ULL); /* TODO: need to work on this */
+	gnix_info->ep_attr->mem_tag_format = 0x0;          /* TODO: need to work on this */
+	gnix_info->ep_attr->msg_order = FI_ORDER_SAS;      /* TODO: remember this when implementing sends */
+	gnix_info->ep_attr->comp_order = FI_ORDER_NONE;
+	gnix_info->ep_attr->tx_ctx_cnt = 1;
+	gnix_info->ep_attr->rx_ctx_cnt = 1;
+
+	gnix_info->domain_attr->threading = FI_THREAD_COMPLETION;
+	gnix_info->domain_attr->control_progress = FI_PROGRESS_AUTO;
+	gnix_info->domain_attr->data_progress = FI_PROGRESS_AUTO;
+	gnix_info->domain_attr->name = strdup(gnix_dom_name);  /* only one aries per node */
+
+	gnix_info->next = NULL;
+	gnix_info->ep_type = FI_EP_RDM;
+	gnix_info->caps = (hints && hints->caps) ? hints->caps : caps;
+	gnix_info->mode = mode;
+	gnix_info->addr_format = FI_ADDR_GNI;
+	gnix_info->src_addrlen = 0;
+	gnix_info->dest_addrlen = sizeof(struct gnix_ep_name);
+	gnix_info->src_addr = NULL;
+	gnix_info->dest_addr = dest_addr;
+	gnix_info->fabric_attr->name = strdup(gnix_fab_name);
+	gnix_info->fabric_attr->prov_name = strdup(gnix_fab_name); /* let's consider gni copyrighted :) */
+
+	gnix_info->tx_attr->caps = gnix_info->caps;
+	gnix_info->tx_attr->mode = gnix_info->mode;
+	gnix_info->tx_attr->op_flags = (hints && hints->tx_attr && hints->tx_attr->op_flags)
+                    ? hints->tx_attr->op_flags : GNIX_EP_OP_FLAGS;
+	gnix_info->tx_attr->msg_order = gnix_info->ep_attr->msg_order;
+	gnix_info->tx_attr->comp_order = gnix_info->ep_attr->comp_order;
+	gnix_info->tx_attr->inject_size = gnix_info->ep_attr->inject_size;
+	gnix_info->tx_attr->size = UINT64_MAX;    /* TODO: probably something else here */
+	gnix_info->tx_attr->iov_limit = 1;
+
+	gnix_info->rx_attr->caps = gnix_info->caps;
+	gnix_info->rx_attr->mode = gnix_info->mode;
+	gnix_info->rx_attr->op_flags = (hints && hints->rx_attr && hints->tx_attr->op_flags)
+                    ? hints->tx_attr->op_flags : GNIX_EP_OP_FLAGS;
+	gnix_info->rx_attr->msg_order = gnix_info->ep_attr->msg_order;
+	gnix_info->rx_attr->comp_order = gnix_info->ep_attr->comp_order;
+	gnix_info->rx_attr->total_buffered_recv = gnix_info->ep_attr->total_buffered_recv;
+	gnix_info->rx_attr->size = UINT64_MAX;   /* TODO: probably something else here */
+	gnix_info->rx_attr->iov_limit = 1;
+
+	*info = gnix_info;
+	return 0;
+err:
+	return ret;
+}
+
+
+
+static void gnix_fini(void)
+{
+}
+
+struct fi_provider gnix_prov = {
+	.name = "gni",
+	.version = FI_VERSION(GNI_MAJOR_VERSION, GNI_MINOR_VERSION), 
+	.fi_version = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION),
+	.getinfo = gnix_getinfo,
+	.fabric = gnix_fabric,
+	.cleanup = gnix_fini
+};
+
+
+GNI_INI
+{
+	char *tmp;
+	struct fi_provider *provider = NULL;
+	gni_return_t status;
+	gni_version_info_t lib_version;
+	int num_devices;
+
+	/*
+	 * todo, may want to put other envariables here
+	 */
+
+	tmp = getenv("OFI_GNI_LOG_LEVEL");
+	if (tmp) {
+		gnix_log_level = atoi(tmp);
+	} else {
+		gnix_log_level = GNIX_ERROR;
+	}
+
+	/*
+	 * if no GNI devices available, don't register as provider
+	 */
+
+	status = GNI_GetNumLocalDevices(&num_devices);
+	if ((status != GNI_RC_SUCCESS) || (num_devices == 0)) {
+		return NULL;
+	}
+
+	assert(num_devices == 1);  /* sanity check that the 1 aries/node holds */
+
+	/*
+	 * don't register if available ugni is older than one libfabric was built against
+	 */
+
+	status = GNI_GetVersionInformation(&lib_version);
+	if ((GNI_GET_MAJOR(lib_version.ugni_version) > GNI_MAJOR_REV) ||
+		((GNI_GET_MAJOR(lib_version.ugni_version) == GNI_MAJOR_REV) &&
+		GNI_GET_MINOR(lib_version.ugni_version) >= GNI_MINOR_REV)) {
+		provider = &gnix_prov;
+	}
+
+        fprintf(stderr,"returning provider %p\n",provider);
+	return (provider);
+}

--- a/prov/gni/src/gnix_init.c
+++ b/prov/gni/src/gnix_init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Los Alamos National Security, LLC. Allrights reserved.
+ * Copyright (c) 2015 Los Alamos National Security, LLC. Allrights reserved.
  * Copyright (c) 2015 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -38,57 +38,3 @@
 #include "fi.h"
 #include "prov.h"
 
-static int
-gnix_getinfo(uint32_t version, const char *node, const char *service,
-             uint64_t flags, struct fi_info *hints, struct fi_info **info)
-{
-  // Do some verification of hints here
-
-  int err = -FI_ENODATA;
-  
-  if (hints) {
-    switch (hints->ep_type) {
-    case FI_EP_RDM:
-      return gnix_rdm_getinfo(version, node, service, flags, hints, info);
-    case FI_EP_DGRAM:
-      return err;
-    case FI_EP_MSG:
-      return err;
-    default:
-      break;
-    }
-  }
-
-  // Chain together info from all supported endpoint types
-  // Currently, we only support RDM
-  err = gnix_rdm_getinfo(version, node, service, flags, hints, info);
-
-  return err;
-}
-
-static int
-gnix_fabric(struct fi_fabric_attr *attr,
-            struct fid_fabric **fabric, void *context)
-{
-  return 0;
-}
-
-static void
-gnix_fini(void)
-{
-  return;
-}
-
-struct fi_provider gnix_prov = {
-  .name = "GNI",
-  .version = FI_VERSION(GNI_MAJOR_VERSION, GNI_MINOR_VERSION), 
-  .fi_version = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION),
-  .getinfo = gnix_getinfo,
-  .fabric = gnix_fabric,
-  .cleanup = gnix_fini
-};
-
-GNI_INI
-{
-  return (&gnix_prov);
-}

--- a/prov/gni/src/gnix_nameserver.c
+++ b/prov/gni/src/gnix_nameserver.c
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2014 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2015 Los Alamos National Security, LLC. Allrights reserved.
+ * Copyright (c) 2015 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <poll.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <arpa/inet.h>
+
+#include "gnix.h"
+#include "gnix_util.h"
+
+#define BUF_SIZE 256
+
+/*
+ * get gni nic addr from AF_INET  ip addr, also return local device id on same subnet
+ * as the input ip_addr.
+ *
+ * returns 0 if ipogif entry found
+ * otherwise  -errno
+ */
+
+static int gnixu_get_pe_from_ip(const char *ip_addr, uint32_t *gni_nic_addr)
+{
+        int scount;
+        int ret = -FI_ENODATA;   /* return this if no ipgogif for this ip-addr found */
+        FILE *fd=NULL;
+        char line[BUF_SIZE], *tmp;
+        char dummy[64],iface[64];
+        char mac_str[64];
+        int w,x,y;
+
+        fd = fopen("/proc/net/arp", "r");
+        if (fd == NULL) return -errno;
+
+        if (fd == NULL) return -errno;
+
+        while (1) {
+                tmp = fgets(line,BUF_SIZE,fd);
+                if (!tmp) break;
+
+                /*
+                 * check for a match
+                 */
+
+                if ((strstr(line,ip_addr) != NULL) && (strstr(line,"ipogif") != NULL)) {
+
+                        ret = 0;
+                        scount = sscanf(line,"%s%s%s%s%s%s",dummy,dummy,dummy,mac_str,dummy,iface);
+                        if (scount != 6) {
+                                ret = -EIO;
+                                goto err;
+                        }
+
+                        scount = sscanf(mac_str, "00:01:01:%02x:%02x:%02x", &w, &x, &y);
+                        if (scount != 3) {
+                                ret = -EIO;
+                                goto err;
+                        }
+
+                        /*
+                         * mysteries of XE/XC mac to nid mapping, see nid2mac in xt sysutils
+                         */
+
+                        *gni_nic_addr = (w << 16) | (x << 8) | y;
+                }
+        }
+
+err:
+        fclose(fd);
+        return ret;
+}
+
+/*
+ * gnixu name resolution function,
+ */
+
+int gnix_resolve_name(const char *node, const char *service, struct gnix_ep_name *resolved_addr)
+{
+        int s, rc = 0;
+        struct addrinfo *result, *rp;
+        uint32_t pe = -1;
+        struct addrinfo hints;
+        struct sockaddr_in *sa;
+
+        if (resolved_addr == NULL) {
+                return -FI_EINVAL;
+        }
+
+        memset(&hints,0,sizeof hints);
+
+        hints.ai_family = AF_INET;           /* don't support IPv6 on XC internal networks */
+        hints.ai_socktype = SOCK_DGRAM;
+        hints.ai_flags = AI_CANONNAME;
+
+        s = getaddrinfo(node, "domain", &hints, &result);
+        if (s != 0) {
+                fprintf(stderr, PFX"getaddrinfo: %s\n", gai_strerror(s));
+                rc = -FI_EINVAL;
+                goto err;
+        }
+
+        for (rp = result; rp != NULL; rp = rp->ai_next) {
+                assert (rp->ai_addr->sa_family == AF_INET);
+                sa = (struct sockaddr_in *)rp->ai_addr;
+                rc = gnixu_get_pe_from_ip(inet_ntoa(sa->sin_addr),&pe);
+                if (!rc) {
+                        break;
+                }
+        }
+
+        if (pe == -1) {
+                rc = -FI_EADDRNOTAVAIL;
+                goto err;
+        }
+
+        /*
+         * try to fill in the gnix_ep_name struct with what we can now
+         */
+
+        memset(resolved_addr,0,sizeof(struct gnix_ep_name));
+
+        resolved_addr->gnix_addr.device_addr = pe;
+        resolved_addr->gnix_addr.cdm_id = 0; /* TODO: have to write a nameserver to get this info */
+        resolved_addr->name_type = 0;        /* TODO: likely depend on service? */
+        freeaddrinfo(result);
+err:
+        return rc;
+}
+
+

--- a/prov/gni/src/gnix_nameserver.h
+++ b/prov/gni/src/gnix_nameserver.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -30,14 +31,28 @@
  * SOFTWARE.
  */
 
-//
-// Endpoint common code
-//
+#ifndef _GNIX_NAMESERVER_H_
+#define _GNIX_NAMESERVER_H_
 
-#include <stdlib.h>
-#include <string.h>
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
 #include "gnix.h"
-#include "gnix_util.h"
 
+/*
+ * defines, data structs, and prototypes for gnix nameserver
+ */
 
+/*
+ * prototypes
+ */
+
+int gnix_resolve_name(const char *node, const char *service, struct gnix_ep_name *dest_addr);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* _GNIX_NAMESERVER_H_ */

--- a/prov/gni/src/gnix_util.c
+++ b/prov/gni/src/gnix_util.c
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) 2014 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2015 Los Alamos National Security, LLC. Allrights reserved.
  * Copyright (c) 2015 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -30,14 +32,28 @@
  * SOFTWARE.
  */
 
-//
-// Endpoint common code
-//
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
 
-#include <stdlib.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <poll.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdio.h>
 #include <string.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <stdlib.h>
 
 #include "gnix.h"
 #include "gnix_util.h"
 
-
+int gnix_log_level = GNIX_ERROR;

--- a/prov/gni/src/gnix_util.h
+++ b/prov/gni/src/gnix_util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2014 Intel Corporation, Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -30,14 +30,41 @@
  * SOFTWARE.
  */
 
-//
-// Endpoint common code
-//
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
 
-#include <stdlib.h>
-#include <string.h>
+#ifndef _GNIX_UTIL_H_
+#define _GNIX_UTIL_H_
 
-#include "gnix.h"
-#include "gnix_util.h"
+#include <stdio.h>
 
+#define GNIX_ERROR (1)
+#define GNIX_WARN (2)
+#define GNIX_INFO (3)
+
+extern int gnix_log_level;
+
+#define GNIX_LOG_INFO(...) do {						\
+		if (gnix_log_level >= GNIX_INFO) {			\
+			fprintf(stderr, "[GNIX_INFO - %s:%d]: ", __func__, __LINE__); \
+			fprintf(stderr, __VA_ARGS__);			\
+		}							\
+	} while (0)
+
+#define GNIX_LOG_WARN(...) do {						\
+		if (gnix_log_level >= GNIX_WARN) {			\
+			fprintf(stderr, "[GNIX_WARN - %s:%d]: ", __func__, __LINE__); \
+			fprintf(stderr, __VA_ARGS__);			\
+		}							\
+	} while (0)
+
+#define GNIX_LOG_ERROR(...) do {					\
+		if (gnix_log_level >= GNIX_ERROR) {			\
+			fprintf(stderr, "[GNIX_ERROR - %s:%d]: ", __func__, __LINE__); \
+			fprintf(stderr, __VA_ARGS__);			\
+		}							\
+	} while (0)
+
+#endif
 

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -120,6 +120,7 @@ static void fi_tostr_addr_format(char *buf, uint32_t addr_format)
 	CASEENUMSTR(FI_SOCKADDR_IN6);
 	CASEENUMSTR(FI_SOCKADDR_IB);
 	CASEENUMSTR(FI_ADDR_PSMX);
+	CASEENUMSTR(FI_ADDR_GNI);
 	default:
 		if (addr_format & FI_PROV_SPECIFIC)
 			strcatf(buf, "Provider specific");


### PR DESCRIPTION
Add code for implementing the gni fi_getinfo method.  Moved some code around.  The PSMX getinfo method seemed
to be a better template for the gni getinfo method.

Verified on an XC system (edison CLE 5.2 UP02) 
