### PR TITLE
Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: c
+
+compiler:
+  - gcc
+
+before_install:
+  - git clone https://github.com/bturrubiates/ugni-build.git;
+    pushd ugni-build;
+    sudo tar -C / -xzvf ugni.build.tgz;
+    popd
+
+os:
+  - linux
+
+env:
+  - PKG_CONFIG_PATH="/opt/cray/ugni/default/lib64/pkgconfig:/opt/cray/gni-headers/default/lib64/pkgconfig"
+
+script: ./autogen.sh && ./configure && make V=1


### PR DESCRIPTION
This is a simple .travis.yml file to enable testing pushes to libfabric-cray. At the moment I am hosting the GNI headers in a github repository called ugni-build, but it'd be better if these could be acquired from a more permanent location. 
@hppritcha @sungeunchoi 
