### PR TITLE
Topic/whitespace fix

### DIFF
--- a/prov/gni/src/gnix.h
+++ b/prov/gni/src/gnix.h
@@ -35,8 +35,7 @@
 #define _GNIX_H_
 
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
 #if HAVE_CONFIG_H
@@ -70,22 +69,21 @@ extern "C"
 /*
  * useful macros
  */
-
 #define PFX "libfabric:gni"
 
 #ifndef likely
-#define likely(x)   __builtin_expect((x),1)
+#define likely(x) __builtin_expect((x), 1)
 #endif
 #ifndef unlikely
-#define unlikely(x) __builtin_expect((x),0)
+#define unlikely(x) __builtin_expect((x), 0)
 #endif
 
 #ifndef FLOOR
-#define FLOOR(a,b)      ((long long)(a) - ( ((long long)(a)) %(b)))
+#define FLOOR(a, b) ((long long)(a) - (((long long)(a)) % (b)))
 #endif
 
 #ifndef CEILING
-#define CEILING(a,b)    ((long long)(a) <= 0LL ? 0 :  (FLOOR((a)-1,b) + (b)))
+#define CEILING(a, b) ((long long)(a) <= 0LL ? 0 : (FLOOR((a)-1, b) + (b)))
 #endif
 
 #ifndef IN
@@ -101,115 +99,90 @@ extern "C"
 #endif
 
 /*
- * Cray gni provider supported flags for fi_getinfo argument for now, needs refining (see fi_getinfo.3 man page)
+ * Cray gni provider supported flags for fi_getinfo argument for now, needs
+ * refining (see fi_getinfo.3 man page)
  */
+#define GNIX_SUPPORTED_FLAGS (FI_NUMERICHOST | FI_SOURCE)
 
-#define GNIX_SUPPORTED_FLAGS (  FI_NUMERICHOST | FI_SOURCE )
-
-#define GNIX_DEFAULT_FLAGS   (0)
+#define GNIX_DEFAULT_FLAGS (0)
 
 /*
- * Cray gni provider will try to support the fabric interface capabilities (see fi_getinfo.3 man page)
+ * Cray gni provider will try to support the fabric interface capabilities (see
+ * fi_getinfo.3 man page)
  * for RDM and MSG (future) endpoint types.
  */
 
 /*
  * see capabilities section in fi_getinfo.3
  */
-
-#define GNIX_EP_RDM_CAPS         (FI_MSG | \
-                                  FI_RMA | \
-                                  FI_TAGGED | \
-                                  FI_ATOMICS | \
-                                  FI_BUFFERED_RECV | \
-                                  FI_DIRECTED_RECV | \
-                                  FI_MULTI_RECV | \
-                                  FI_INJECT | \
-                                  FI_SOURCE | \
-                                  FI_READ | FI_WRITE | \
-                                  FI_SEND | FI_RECV | \
-                                  FI_REMOTE_READ | FI_REMOTE_WRITE | \
-                                  FI_REMOTE_COMPLETE | \
-                                  FI_CANCEL |\
-                                  FI_FENCE )
+#define GNIX_EP_RDM_CAPS                                                       \
+	(FI_MSG | FI_RMA | FI_TAGGED | FI_ATOMICS | FI_BUFFERED_RECV |         \
+	 FI_DIRECTED_RECV | FI_MULTI_RECV | FI_INJECT | FI_SOURCE | FI_READ |  \
+	 FI_WRITE | FI_SEND | FI_RECV | FI_REMOTE_READ | FI_REMOTE_WRITE |     \
+	 FI_REMOTE_COMPLETE | FI_CANCEL | FI_FENCE)
 
 /*
  * see Operations flags in fi_endpoint.3
  */
-
-#define GNIX_EP_OP_FLAGS          ( FI_MULTI_RECV |\
-                                    FI_BUFFERED_RECV |\
-                                    FI_COMPLETION |\
-                                    FI_REMOTE_COMPLETE |\
-                                    FI_READ |\
-                                    FI_WRITE |\
-                                    FI_SEND |\
-                                    FI_RECV |\
-                                    FI_REMOTE_READ |\
-                                    FI_REMOTE_WRITE) 
+#define GNIX_EP_OP_FLAGS                                                       \
+	(FI_MULTI_RECV | FI_BUFFERED_RECV | FI_COMPLETION |                    \
+	 FI_REMOTE_COMPLETE | FI_READ | FI_WRITE | FI_SEND | FI_RECV |         \
+	 FI_REMOTE_READ | FI_REMOTE_WRITE)
 
 /*
  * if this has to be changed, check gnix_getinfo, etc.
  */
-#define GNIX_EP_MSG_CAPS          GNIX_EP_RDM_CAPS
+#define GNIX_EP_MSG_CAPS GNIX_EP_RDM_CAPS
 
-#define GNIX_MAX_MSG_SIZE         ((0x1ULL << 32) - 1)
-#define GNIX_INJECT_SIZE          64
-
-/*
- * Cray gni provider will require the following fabric interface modes (see fi_getinfo.3 man page)
- */
-#define GNIX_FAB_MODES           (FI_CONTEXT |  \
-                                  FI_LOCAL_MR | \
-                                  FI_PROV_MR_ATTR)
+#define GNIX_MAX_MSG_SIZE ((0x1ULL << 32) - 1)
+#define GNIX_INJECT_SIZE 64
 
 /*
- * fabric modes that GNI provider doesn't need 
+ * Cray gni provider will require the following fabric interface modes (see
+ * fi_getinfo.3 man page)
  */
+#define GNIX_FAB_MODES (FI_CONTEXT | FI_LOCAL_MR | FI_PROV_MR_ATTR)
 
-#define GNIX_FAB_MODES_CLEAR      (FI_MSG_PREFIX | FI_ASYNC_IOV)
+/*
+ * fabric modes that GNI provider doesn't need
+ */
+#define GNIX_FAB_MODES_CLEAR (FI_MSG_PREFIX | FI_ASYNC_IOV)
 
 /*
  * gnix address format - used for fi_send/fi_recv, etc.
  */
-
 struct gnix_address {
-        uint32_t               device_addr;
-        uint32_t               cdm_id;
+	uint32_t device_addr;
+	uint32_t cdm_id;
 };
 
 /*
  * info returned by fi_getname/fi_getpeer - has enough
  * side band info for RDM ep's to be able to connect, etc.
  */
-
 struct gnix_ep_name {
-        struct gnix_address    gnix_addr;
-        struct {
-            uint32_t           name_type:8;
-            uint32_t           unused   :24;
-        };
-        uint64_t               reserved[4];
+	struct gnix_address gnix_addr;
+	struct {
+		uint32_t name_type : 8;
+		uint32_t unused : 24;
+	};
+	uint64_t reserved[4];
 };
 
-       
 /*
  * enum for blocking/non-blocking progress
  */
-
 enum gnix_progress_type {
-        GNIX_PRG_BLOCKING,
-        GNIX_PRG_NON_BLOCKING
+	GNIX_PRG_BLOCKING,
+	GNIX_PRG_NON_BLOCKING
 };
-
 
 /*
  * simple struct for gnix fabric, may add more stuff here later
  */
-
 struct gnix_fabric {
-    struct fid_fabric fab_fid;
-    atomic_t ref;
+	struct fid_fabric fab_fid;
+	atomic_t ref;
 };
 
 /*
@@ -217,119 +190,131 @@ struct gnix_fabric {
  * since a single cdm with a given cookie/cdm_id can only
  * be bound once to a given physical aries nic
  */
-
 struct gnix_domain {
-	struct fid_domain	domain_fid;
-	struct gnix_cdm 	*cdm;
-	struct gnix_nic 	*nic;
-        struct list_head        domain_wq;
-	uint32_t 		device_id;                 
- 	uint32_t		device_addr;
+	struct fid_domain domain_fid;
+	struct gnix_cdm *cdm;
+	struct gnix_nic *nic;
+	struct list_head domain_wq;
+	uint32_t device_id;
+	uint32_t device_addr;
 };
 
 struct gnix_cdm {
-        struct list_node        list;
-        gni_cdm_handle_t        gni_cdm_hndl;
-        struct list_head        nic_list;                  /* list nics this cdm is attached to, TODO: thread safety */
-        uint32_t                inst_id;
-        uint8_t                 ptag;
-        uint32_t                cookie;
-        uint32_t                modes;
-        int                     ref_cnt;                   /* TODO: thread safety */
+	struct list_node list;
+	gni_cdm_handle_t gni_cdm_hndl;
+	/* list nics this cdm is attached to, TODO: thread safety */
+	struct list_head nic_list;
+	uint32_t inst_id;
+	uint8_t ptag;
+	uint32_t cookie;
+	uint32_t modes;
+	/* TODO: thread safety */
+	int ref_cnt;
 };
 
 struct gnix_nic {
-        struct list_node        list;
-	gni_nic_handle_t 	gni_nic_hndl;
-        gni_cq_handle_t         rx_cq;                     /* receive completion queue for hndl */
-        gni_cq_handle_t         rx_cq_blk;                 /* receive completion queue for hndl (blocking) */
-        gni_cq_handle_t         tx_cq;                     /* local(tx) completion queue for hndl */
-        gni_cq_handle_t         tx_cq_blk;                 /* local(tx) completion queue for hndl (blocking) */
-        struct list_head        wqe_active_list;           /* list of wqe's */
-        struct gnix_wqe_list    *wqe_list;                 /* list for managing wqe's */
-        struct list_head        smsg_active_req_list;      /* list of active smsg req's */
-        struct gnix_smsg_req_list *smsg_req_list;            /* list for managing smsg req's */
-        struct list_head        datagram_active_list;      /* list of active datagrams */
-        struct list_head        datagram_free_list;        /* free list of datagrams   */
-        struct list_head        wc_datagram_active_list;   /* list of active wc datagrams   */
-        struct list_head        wc_datagram_free_list;     /* free list of wc datagrams   */
-        struct gnix_cdm         *cdm;                      /* pointer to cdm this nic is attached to */
-        struct gnix_datagram    *datagram_base;            
-        uint32_t                device_id;
-        uint32_t                device_addr;
-        int                     ref_cnt;
+	struct list_node list;
+	gni_nic_handle_t gni_nic_hndl;
+	/* receive completion queue for hndl */
+	gni_cq_handle_t rx_cq;
+	/* receive completion queue for hndl (blocking) */
+	gni_cq_handle_t rx_cq_blk;
+	/* local(tx) completion queue for hndl */
+	gni_cq_handle_t tx_cq;
+	/* local(tx) completion queue for hndl (blocking) */
+	gni_cq_handle_t tx_cq_blk;
+	/* list of wqe's */
+	struct list_head wqe_active_list;
+	/* list for managing wqe's */
+	struct gnix_wqe_list *wqe_list;
+	/* list of active smsg req's */
+	struct list_head smsg_active_req_list;
+	/* list for managing smsg req's */
+	struct gnix_smsg_req_list *smsg_req_list;
+	/* list of active datagrams */
+	struct list_head datagram_active_list;
+	/* free list of datagrams   */
+	struct list_head datagram_free_list;
+	/* list of active wc datagrams   */
+	struct list_head wc_datagram_active_list;
+	/* free list of wc datagrams */
+	struct list_head wc_datagram_free_list;
+	/* pointer to cdm this nic is attached to */
+	struct gnix_cdm *cdm;
+	struct gnix_datagram *datagram_base;
+	uint32_t device_id;
+	uint32_t device_addr;
+	int ref_cnt;
 };
 
 /*
  * CQE struct definitions
  */
-
 struct gnix_cq_entry {
-        struct list_node          list;
-        struct fi_cq_entry        the_entry;
+	struct list_node list;
+	struct fi_cq_entry the_entry;
 };
 
 struct gnix_cq_msg_entry {
-        struct list_node          list;
-        struct fi_cq_msg_entry    the_entry;
+	struct list_node list;
+	struct fi_cq_msg_entry the_entry;
 };
 
 struct gnix_cq_tagged_entry {
-        struct list_node          list;
-        struct fi_cq_tagged_entry the_entry;
+	struct list_node list;
+	struct fi_cq_tagged_entry the_entry;
 };
 
 struct gnix_cq {
-	struct fid_cq		fid;
-	uint64_t		flags;
-	struct gnix_domain	*domain;
-        void                    *free_list_base;
-        struct list_head        entry;
-        struct list_head        err_entry;
-        struct list_head        entry_free_list;
-        int                     (*progress_fn)(struct gnix_cq *);
-        enum fi_cq_format       format;
+	struct fid_cq fid;
+	uint64_t flags;
+	struct gnix_domain *domain;
+	void *free_list_base;
+	struct list_head entry;
+	struct list_head err_entry;
+	struct list_head entry_free_list;
+	int (*progress_fn)(struct gnix_cq *);
+	enum fi_cq_format format;
 };
 
 struct gnix_mem_desc {
-	struct fid_mr		mr_fid;
-	struct gnix_domain	*domain;
-	gni_mem_handle_t        mem_hndl;
+	struct fid_mr mr_fid;
+	struct gnix_domain *domain;
+	gni_mem_handle_t mem_hndl;
 };
 
 /*
  *   gnix_rdm_ep - FI_EP_RDM type ep
  */
-
 struct gnix_rdm_ep {
-	struct fid_ep		ep_fid;
-	struct gnix_domain	*domain;              
-        void                    *vc_cache_hndl; 
-        int                     (*progress_fn)(struct gnix_rdm_ep *, enum gnix_progress_type);        
-        int                     (*rx_progress_fn)(struct gnix_rdm_ep *, 
-                                                  gni_return_t *rc);  /* RX specific progress fn */
-        int                      enabled;
-        uint32_t                 active_post_descs;     /* num. active post descs associated with this ep */
+	struct fid_ep ep_fid;
+	struct gnix_domain *domain;
+	void *vc_cache_hndl;
+	int (*progress_fn)(struct gnix_rdm_ep *, enum gnix_progress_type);
+	/* RX specific progress fn */
+	int (*rx_progress_fn)(struct gnix_rdm_ep *, gni_return_t *rc);
+	int enabled;
+	/* num. active post descs associated with this ep */
+	uint32_t active_post_descs;
 };
 
 /*
  * globals
  */
-
 extern const char const gnix_fab_name[];
 
 /*
- * prototypes 
+ * prototypes
  */
-
 int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
-                     struct fid_domain **domain, void *context);
+		     struct fid_domain **domain, void *context);
 int gnix_rdm_getinfo(uint32_t version, const char *node, const char *service,
-		     uint64_t flags, struct fi_info *hints, struct fi_info **info);
+		     uint64_t flags, struct fi_info *hints,
+		     struct fi_info **info);
 struct fi_info *gnix_fi_info(enum fi_ep_type ep_type, struct fi_info *hints);
 int gnix_verify_domain_attr(struct fi_domain_attr *attr);
 
-#ifdef __cplusplus 
+#ifdef __cplusplus
 } /* extern "C" */
 #endif
 

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -33,7 +33,7 @@
  */
 
 #if HAVE_CONFIG_H
-#  include <config.h>
+#include <config.h>
 #endif /* HAVE_CONFIG_H */
 
 #include <stdlib.h>
@@ -45,6 +45,6 @@
 int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		     struct fid_domain **dom, void *context)
 {
-	return -FI_ENOSYS;  /* TODO: need to implement */
+	/* TODO: need to implement */
+	return -FI_ENOSYS;
 }
-

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -33,11 +33,8 @@
 //
 // Endpoint common code
 //
-
 #include <stdlib.h>
 #include <string.h>
 
 #include "gnix.h"
 #include "gnix_util.h"
-
-

--- a/prov/gni/src/gnix_ep_rdm.c
+++ b/prov/gni/src/gnix_ep_rdm.c
@@ -34,4 +34,3 @@
 #include <string.h>
 
 #include "gnix.h"
-

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -67,9 +67,12 @@ const struct fi_fabric_attr gnix_fabric_attr = {
 static struct fi_ops_fabric gnix_fab_ops = {
 	.size = sizeof(struct fi_ops_fabric),
 	.domain = gnix_domain_open,
-	.passive_ep = NULL, /* TODO: need to define for FI_EP_MSG */
-	.eq_open = NULL,    /* TODO: need to define for FI_EP_MSG */
-	.wait_open = NULL,  /* TODO: what's this about */
+	/* TODO: need to define for FI_EP_MSG */
+	.passive_ep = NULL,
+	/* TODO: need to define for FI_EP_MSG */
+	.eq_open = NULL,
+	/* TODO: what's this about */
+	.wait_open = NULL,
 };
 
 static int gnix_fabric_close(fid_t fid)
@@ -96,18 +99,19 @@ static struct fi_ops gnix_fab_fi_ops = {
 /*
  * define methods needed for the GNI fabric provider
  */
-
 static int gnix_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 		       void *context)
 {
 	struct gnix_fabric *fab;
 
-	if (strcmp(attr->name, gnix_fab_name))
+	if (strcmp(attr->name, gnix_fab_name)) {
 		return -FI_ENODATA;
+	}
 
 	fab = calloc(1, sizeof(*fab));
-	if (!fab)
+	if (!fab) {
 		return -FI_ENOMEM;
+	}
 
 	fab->fab_fid.fid.fclass = FI_CLASS_FABRIC;
 	fab->fab_fid.fid.context = context;
@@ -154,11 +158,9 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 	}
 
 	if (hints) {
-
 		/*
 		 * check for endpoint type, only support FI_EP_RDM for now
 		 */
-
 		switch (hints->ep_type) {
 		case FI_EP_UNSPEC:
 		case FI_EP_RDM:
@@ -171,7 +173,6 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 		/*
 		 * check the mode field
 		 */
-
 		if (hints->mode) {
 			if ((hints->mode & GNIX_FAB_MODES) != GNIX_FAB_MODES) {
 				ret = -FI_ENODATA;
@@ -245,8 +246,8 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 			}
 			/*
 			 * TODO: tag matching
-			 max_tag_value =
-			 fi_tag_bits(hints->ep_attr->mem_tag_format);
+			 * max_tag_value =
+			 * fi_tag_bits(hints->ep_attr->mem_tag_format);
 			 */
 		}
 	}
@@ -254,7 +255,6 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 	/*
 	 * fill in the gnix_info struct
 	 */
-
 	gnix_info = fi_allocinfo_internal();
 	if (gnix_info == NULL) {
 		ret = -FI_ENOMEM;
@@ -264,12 +264,12 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 	gnix_info->ep_attr->protocol = FI_PROTO_GNI;
 	gnix_info->ep_attr->max_msg_size = GNIX_MAX_MSG_SIZE;
 	gnix_info->ep_attr->inject_size = GNIX_INJECT_SIZE;
-	gnix_info->ep_attr->total_buffered_recv =
-	    ~(0ULL); /* TODO: need to work on this */
-	gnix_info->ep_attr->mem_tag_format =
-	    0x0; /* TODO: need to work on this */
-	gnix_info->ep_attr->msg_order =
-	    FI_ORDER_SAS; /* TODO: remember this when implementing sends */
+	/* TODO: need to work on this */
+	gnix_info->ep_attr->total_buffered_recv = ~(0ULL);
+	/* TODO: need to work on this */
+	gnix_info->ep_attr->mem_tag_format = 0x0;
+	/* TODO: remember this when implementing sends */
+	gnix_info->ep_attr->msg_order = FI_ORDER_SAS;
 	gnix_info->ep_attr->comp_order = FI_ORDER_NONE;
 	gnix_info->ep_attr->tx_ctx_cnt = 1;
 	gnix_info->ep_attr->rx_ctx_cnt = 1;
@@ -277,8 +277,8 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 	gnix_info->domain_attr->threading = FI_THREAD_COMPLETION;
 	gnix_info->domain_attr->control_progress = FI_PROGRESS_AUTO;
 	gnix_info->domain_attr->data_progress = FI_PROGRESS_AUTO;
-	gnix_info->domain_attr->name =
-	    strdup(gnix_dom_name); /* only one aries per node */
+	/* only one aries per node */
+	gnix_info->domain_attr->name = strdup(gnix_dom_name);
 
 	gnix_info->next = NULL;
 	gnix_info->ep_type = FI_EP_RDM;
@@ -290,8 +290,8 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 	gnix_info->src_addr = src_addr;
 	gnix_info->dest_addr = dest_addr;
 	gnix_info->fabric_attr->name = strdup(gnix_fab_name);
-	gnix_info->fabric_attr->prov_name =
-	    strdup(gnix_fab_name); /* let's consider gni copyrighted :) */
+	/* let's consider gni copyrighted :) */
+	gnix_info->fabric_attr->prov_name = strdup(gnix_fab_name);
 
 	gnix_info->tx_attr->caps = gnix_info->caps;
 	gnix_info->tx_attr->mode = gnix_info->mode;
@@ -302,8 +302,8 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 	gnix_info->tx_attr->msg_order = gnix_info->ep_attr->msg_order;
 	gnix_info->tx_attr->comp_order = gnix_info->ep_attr->comp_order;
 	gnix_info->tx_attr->inject_size = gnix_info->ep_attr->inject_size;
-	gnix_info->tx_attr->size =
-	    UINT64_MAX; /* TODO: probably something else here */
+	/* TODO: probably something else here */
+	gnix_info->tx_attr->size = UINT64_MAX;
 	gnix_info->tx_attr->iov_limit = 1;
 
 	gnix_info->rx_attr->caps = gnix_info->caps;
@@ -316,8 +316,8 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 	gnix_info->rx_attr->comp_order = gnix_info->ep_attr->comp_order;
 	gnix_info->rx_attr->total_buffered_recv =
 	    gnix_info->ep_attr->total_buffered_recv;
-	gnix_info->rx_attr->size =
-	    UINT64_MAX; /* TODO: probably something else here */
+	/* TODO: probably something else here */
+	gnix_info->rx_attr->size = UINT64_MAX;
 	gnix_info->rx_attr->iov_limit = 1;
 
 	*info = gnix_info;
@@ -336,7 +336,8 @@ struct fi_provider gnix_prov = {
 	.fi_version = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION),
 	.getinfo = gnix_getinfo,
 	.fabric = gnix_fabric,
-	.cleanup = gnix_fini};
+	.cleanup = gnix_fini
+};
 
 GNI_INI
 {
@@ -349,7 +350,6 @@ GNI_INI
 	/*
 	 * todo, may want to put other envariables here
 	 */
-
 	tmp = getenv("OFI_GNI_LOG_LEVEL");
 	if (tmp) {
 		gnix_log_level = atoi(tmp);
@@ -360,19 +360,18 @@ GNI_INI
 	/*
 	 * if no GNI devices available, don't register as provider
 	 */
-
 	status = GNI_GetNumLocalDevices(&num_devices);
 	if ((status != GNI_RC_SUCCESS) || (num_devices == 0)) {
 		return NULL;
 	}
 
-	assert(num_devices == 1); /* sanity check that the 1 aries/node holds */
+	/* sanity check that the 1 aries/node holds */
+	assert(num_devices == 1);
 
 	/*
 	 * don't register if available ugni is older than one libfabric was
 	 * built against
 	 */
-
 	status = GNI_GetVersionInformation(&lib_version);
 	if ((GNI_GET_MAJOR(lib_version.ugni_version) > GNI_MAJOR_REV) ||
 	    ((GNI_GET_MAJOR(lib_version.ugni_version) == GNI_MAJOR_REV) &&

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -295,10 +295,13 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 
 	gnix_info->tx_attr->caps = gnix_info->caps;
 	gnix_info->tx_attr->mode = gnix_info->mode;
-	gnix_info->tx_attr->op_flags =
-	    (hints && hints->tx_attr && hints->tx_attr->op_flags)
-		? hints->tx_attr->op_flags
-		: GNIX_EP_OP_FLAGS;
+
+	if(hints && hints->tx_attr && hints->tx_attr->op_flags) {
+		gnix_info->tx_attr->op_flags = hints->tx_attr->op_flags;
+	} else {
+		gnix_info->tx_attr->op_flags = GNIX_EP_OP_FLAGS;
+	}
+
 	gnix_info->tx_attr->msg_order = gnix_info->ep_attr->msg_order;
 	gnix_info->tx_attr->comp_order = gnix_info->ep_attr->comp_order;
 	gnix_info->tx_attr->inject_size = gnix_info->ep_attr->inject_size;
@@ -308,10 +311,13 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 
 	gnix_info->rx_attr->caps = gnix_info->caps;
 	gnix_info->rx_attr->mode = gnix_info->mode;
-	gnix_info->rx_attr->op_flags =
-	    (hints && hints->rx_attr && hints->tx_attr->op_flags)
-		? hints->tx_attr->op_flags
-		: GNIX_EP_OP_FLAGS;
+
+	if(hints && hints->rx_attr && hints->rx_attr->op_flags) {
+		gnix_info->rx_attr->op_flags = hints->rx_attr->op_flags;
+	} else {
+		gnix_info->rx_attr->op_flags = GNIX_EP_OP_FLAGS;
+	}
+
 	gnix_info->rx_attr->msg_order = gnix_info->ep_attr->msg_order;
 	gnix_info->rx_attr->comp_order = gnix_info->ep_attr->comp_order;
 	gnix_info->rx_attr->total_buffered_recv =

--- a/prov/gni/src/gnix_init.c
+++ b/prov/gni/src/gnix_init.c
@@ -37,4 +37,3 @@
 #include "gnix.h"
 #include "fi.h"
 #include "prov.h"
-

--- a/prov/gni/src/gnix_nameserver.h
+++ b/prov/gni/src/gnix_nameserver.h
@@ -35,8 +35,7 @@
 #define _GNIX_NAMESERVER_H_
 
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
 #include "gnix.h"
@@ -49,7 +48,8 @@ extern "C"
  * prototypes
  */
 
-int gnix_resolve_name(const char *node, const char *service, struct gnix_ep_name *dest_addr);
+int gnix_resolve_name(const char *node, const char *service,
+		      struct gnix_ep_name *dest_addr);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/prov/gni/src/gnix_util.c
+++ b/prov/gni/src/gnix_util.c
@@ -33,7 +33,7 @@
  */
 
 #if HAVE_CONFIG_H
-#  include <config.h>
+#include <config.h>
 #endif /* HAVE_CONFIG_H */
 
 #include <errno.h>

--- a/prov/gni/src/gnix_util.h
+++ b/prov/gni/src/gnix_util.h
@@ -31,7 +31,7 @@
  */
 
 #if HAVE_CONFIG_H
-#  include <config.h>
+#include <config.h>
 #endif /* HAVE_CONFIG_H */
 
 #ifndef _GNIX_UTIL_H_
@@ -45,26 +45,31 @@
 
 extern int gnix_log_level;
 
-#define GNIX_LOG_INFO(...) do {						\
-		if (gnix_log_level >= GNIX_INFO) {			\
-			fprintf(stderr, "[GNIX_INFO - %s:%d]: ", __func__, __LINE__); \
-			fprintf(stderr, __VA_ARGS__);			\
-		}							\
+#define GNIX_LOG_INFO(...)                                                     \
+	do {                                                                   \
+		if (gnix_log_level >= GNIX_INFO) {                             \
+			fprintf(stderr, "[GNIX_INFO - %s:%d]: ", __func__,     \
+				__LINE__);                                     \
+			fprintf(stderr, __VA_ARGS__);                          \
+		}                                                              \
 	} while (0)
 
-#define GNIX_LOG_WARN(...) do {						\
-		if (gnix_log_level >= GNIX_WARN) {			\
-			fprintf(stderr, "[GNIX_WARN - %s:%d]: ", __func__, __LINE__); \
-			fprintf(stderr, __VA_ARGS__);			\
-		}							\
+#define GNIX_LOG_WARN(...)                                                     \
+	do {                                                                   \
+		if (gnix_log_level >= GNIX_WARN) {                             \
+			fprintf(stderr, "[GNIX_WARN - %s:%d]: ", __func__,     \
+				__LINE__);                                     \
+			fprintf(stderr, __VA_ARGS__);                          \
+		}                                                              \
 	} while (0)
 
-#define GNIX_LOG_ERROR(...) do {					\
-		if (gnix_log_level >= GNIX_ERROR) {			\
-			fprintf(stderr, "[GNIX_ERROR - %s:%d]: ", __func__, __LINE__); \
-			fprintf(stderr, __VA_ARGS__);			\
-		}							\
+#define GNIX_LOG_ERROR(...)                                                    \
+	do {                                                                   \
+		if (gnix_log_level >= GNIX_ERROR) {                            \
+			fprintf(stderr, "[GNIX_ERROR - %s:%d]: ", __func__,    \
+				__LINE__);                                     \
+			fprintf(stderr, __VA_ARGS__);                          \
+		}                                                              \
 	} while (0)
 
 #endif
-


### PR DESCRIPTION
Change whitespace to more closely conform to the Linux Style guide. 
- Linux style guide suggests having braces around all if/else statements unless it's a single if with no else and a single statement following (in this case braces are optional) e.g.

```
if(condition)
        action
```

For consistency I just added braces around every if and if/else structure independent of whether it can be a single statement or not.
- Fixed minor bug in gnix_getinfo where rx_attr was being assigned tx_attr op flags.

Build results can be viewed [here](https://travis-ci.org/bturrubiates/libfabric/builds/51287658)
@sungeunchoi @hppritcha 
