### PR TITLE
Topic/localhost fix

### DIFF
--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -54,8 +54,8 @@
 #include "gnix_util.h"
 #include "gnix_nameserver.h"
 
-const char const gnix_fab_name[] = "gni";
-const char const gnix_dom_name[] = "/sys/class/gni/kgni0";
+const const char gnix_fab_name[] = "gni";
+const const char gnix_dom_name[] = "/sys/class/gni/kgni0";
 
 const struct fi_fabric_attr gnix_fabric_attr = {
 	.fabric = NULL,
@@ -347,21 +347,10 @@ struct fi_provider gnix_prov = {
 
 GNI_INI
 {
-	char *tmp;
 	struct fi_provider *provider = NULL;
 	gni_return_t status;
 	gni_version_info_t lib_version;
 	int num_devices;
-
-	/*
-	 * todo, may want to put other envariables here
-	 */
-	tmp = getenv("OFI_GNI_LOG_LEVEL");
-	if (tmp) {
-		gnix_log_level = atoi(tmp);
-	} else {
-		gnix_log_level = GNIX_ERROR;
-	}
 
 	/*
 	 * if no GNI devices available, don't register as provider

--- a/prov/gni/src/gnix_nameserver.c
+++ b/prov/gni/src/gnix_nameserver.c
@@ -41,6 +41,7 @@
 #include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <net/if.h>
 #include <poll.h>
 #include <stdarg.h>
 #include <stddef.h>
@@ -50,6 +51,7 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/time.h>
+#include <sys/ioctl.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <sys/socket.h>
@@ -112,7 +114,6 @@ static int gnixu_get_pe_from_ip(const char *ip_addr, uint32_t *gni_nic_addr)
 			 * check exact match of ip addr
 			 */
 			if (!strcmp(fnd_ip_addr, ip_addr)) {
-
 				scount =
 				    sscanf(mac_str, "00:01:01:%02x:%02x:%02x",
 					   &w, &x, &y);
@@ -138,51 +139,114 @@ err:
 }
 
 /*
- * gnixu name resolution function,
+ * gnix_resolve_name: given a node hint and a valid pointer to a gnix_ep_name
+ * will resolve the gnix specific address of node and fill the provided
+ * gnix_ep_name pointer with the information.
+ *
+ * node (IN) : Node name being resolved to gnix specific address
+ * resolved_addr (IN/OUT) : Pointer that must be provided to contain the
+ *	resolved address.
+ *
+ * TODO: consider a use for service.
  */
-int gnix_resolve_name(const char *node, const char *service,
-		      struct gnix_ep_name *resolved_addr)
+int gnix_resolve_name(IN const char *node, IN const char *service,
+		      INOUT struct gnix_ep_name *resolved_addr)
 {
-	int s, rc = 0;
-	struct addrinfo *result, *rp;
+	int sock = -1;
 	uint32_t pe = -1;
-	struct addrinfo hints;
-	struct sockaddr_in *sa;
+	uint32_t cpu_id = -1;
+	struct addrinfo *result = NULL;
+	struct addrinfo *rp = NULL;
 
-	if (resolved_addr == NULL) {
-		return -FI_EINVAL;
+	struct ifreq ifr = {0};
+
+	struct sockaddr_in *sa = NULL;
+	struct sockaddr_in *sin = NULL;
+
+	int ret = FI_SUCCESS;
+	gni_return_t status = GNI_RC_SUCCESS;
+
+	struct addrinfo hints = {
+		.ai_family = AF_INET,
+		.ai_socktype = SOCK_DGRAM,
+		.ai_flags = AI_CANONNAME
+	};
+
+	if (!resolved_addr) {
+		GNIX_LOG_ERROR("Resolved_addr must be a valid pointer.\n");
+		ret = -FI_EINVAL;
+		goto err;
 	}
 
-	memset(&hints, 0, sizeof hints);
+	sock = socket(AF_INET, SOCK_DGRAM, 0);
 
-	/* don't support IPv6 on XC internal networks */
-	hints.ai_family = AF_INET;
-	hints.ai_socktype = SOCK_DGRAM;
-	hints.ai_flags = AI_CANONNAME;
-
-	s = getaddrinfo(node, "domain", &hints, &result);
-	if (s != 0) {
-		fprintf(stderr, PFX "getaddrinfo: %s\n", gai_strerror(s));
-		rc = -FI_EINVAL;
+	if (sock == -1) {
+		GNIX_LOG_ERROR("Socket creation failed: %s\n", strerror(errno));
+		ret = -FI_EIO;
 		goto err;
+	}
+
+	/* Get the address for the ipogif0 interface */
+	ifr.ifr_addr.sa_family = AF_INET;
+	snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s", "ipogif0");
+
+	ret = ioctl(sock, SIOCGIFADDR, &ifr);
+	if (ret == -1) {
+		GNIX_LOG_ERROR("Failed to get address for ipogif0: %s\n",
+			       strerror(errno));
+		ret = -FI_EIO;
+		goto sock_cleanup;
+	}
+
+	sin = (struct sockaddr_in *) &ifr.ifr_addr;
+
+	ret = getaddrinfo(node, "domain", &hints, &result);
+	if (ret != 0) {
+		GNIX_LOG_ERROR("Failed to get address for node provided: %s\n",
+			       strerror(errno));
+		ret = -FI_EINVAL;
+		goto sock_cleanup;
 	}
 
 	for (rp = result; rp != NULL; rp = rp->ai_next) {
 		assert(rp->ai_addr->sa_family == AF_INET);
-		sa = (struct sockaddr_in *)rp->ai_addr;
-		rc = gnixu_get_pe_from_ip(inet_ntoa(sa->sin_addr), &pe);
-		if (!rc) {
-			break;
+		sa = (struct sockaddr_in *) rp->ai_addr;
+
+		/*
+		 * If we are trying to resolve localhost then use
+		 * CdmGetNicAddress.
+		 */
+		if (sa->sin_addr.s_addr == sin->sin_addr.s_addr) {
+			status = GNI_CdmGetNicAddress(0, &pe, &cpu_id);
+			if(status == GNI_RC_SUCCESS) {
+				break;
+			} else {
+				GNIX_LOG_ERROR("Unable to get NIC address.");
+				ret = -FI_EINVAL;
+				goto sock_cleanup;
+			}
+		} else {
+			ret =
+			    gnixu_get_pe_from_ip(inet_ntoa(sa->sin_addr), &pe);
+			if (ret == 0) {
+				break;
+			}
 		}
 	}
 
+	/*
+	 * Make sure address is valid.
+	 */
 	if (pe == -1) {
-		rc = -FI_EADDRNOTAVAIL;
-		goto err;
+		GNIX_LOG_ERROR("Unable to acquire valid address for node %s\n",
+			       node);
+		ret = -FI_EADDRNOTAVAIL;
+		goto sock_cleanup;
 	}
 
 	/*
-	 * try to fill in the gnix_ep_name struct with what we can now
+	 * Fill the INOUT parameter resolved_addr with the address information
+	 * acquired for the provided node parameter.
 	 */
 	memset(resolved_addr, 0, sizeof(struct gnix_ep_name));
 
@@ -191,7 +255,13 @@ int gnix_resolve_name(const char *node, const char *service,
 	resolved_addr->gnix_addr.cdm_id = 0;
 	/* TODO: likely depend on service? */
 	resolved_addr->name_type = 0;
-	freeaddrinfo(result);
+sock_cleanup:
+	if(close(sock) == -1) {
+		GNIX_LOG_ERROR("Unable to close socket: %s\n", strerror(errno));
+	}
 err:
-	return rc;
+	if (result != NULL) {
+		freeaddrinfo(result);
+	}
+	return ret;
 }

--- a/prov/gni/src/gnix_util.c
+++ b/prov/gni/src/gnix_util.c
@@ -55,5 +55,3 @@
 
 #include "gnix.h"
 #include "gnix_util.h"
-
-int gnix_log_level = GNIX_ERROR;

--- a/prov/gni/src/gnix_util.h
+++ b/prov/gni/src/gnix_util.h
@@ -38,38 +38,15 @@
 #define _GNIX_UTIL_H_
 
 #include <stdio.h>
+#include "fi_log.h"
 
-#define GNIX_ERROR (1)
-#define GNIX_WARN (2)
-#define GNIX_INFO (3)
+#define GNIX_DEBUG (2)
 
-extern int gnix_log_level;
+extern const char gnix_fab_name[];
+extern const char gnix_dom_name[];
 
-#define GNIX_LOG_INFO(...)                                                     \
-	do {                                                                   \
-		if (gnix_log_level >= GNIX_INFO) {                             \
-			fprintf(stderr, "[GNIX_INFO - %s:%d]: ", __func__,     \
-				__LINE__);                                     \
-			fprintf(stderr, __VA_ARGS__);                          \
-		}                                                              \
-	} while (0)
-
-#define GNIX_LOG_WARN(...)                                                     \
-	do {                                                                   \
-		if (gnix_log_level >= GNIX_WARN) {                             \
-			fprintf(stderr, "[GNIX_WARN - %s:%d]: ", __func__,     \
-				__LINE__);                                     \
-			fprintf(stderr, __VA_ARGS__);                          \
-		}                                                              \
-	} while (0)
-
-#define GNIX_LOG_ERROR(...)                                                    \
-	do {                                                                   \
-		if (gnix_log_level >= GNIX_ERROR) {                            \
-			fprintf(stderr, "[GNIX_ERROR - %s:%d]: ", __func__,    \
-				__LINE__);                                     \
-			fprintf(stderr, __VA_ARGS__);                          \
-		}                                                              \
-	} while (0)
+#define GNIX_LOG_INFO(...) FI_LOG(GNIX_DEBUG, gnix_fab_name, __VA_ARGS__)
+#define GNIX_LOG_WARN(...) FI_WARN(gnix_fab_name, __VA_ARGS__)
+#define GNIX_LOG_ERROR(...) FI_WARN(gnix_fab_name, __VA_ARGS__)
 
 #endif


### PR DESCRIPTION
- Change fprintf to new logging macros
- Fix acquiring localhost GNI address

Depending on the compiler it might give a warning from -Wmissing-braces about the initialization of the ifreq struct. This isn't a valid warning. See [here](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53119) for details. 

@sungeunchoi @hppritcha 
