### PR TITLE
prov/gni: initial gnix ep work

### DIFF
--- a/prov/gni/src/gnix.h
+++ b/prov/gni/src/gnix.h
@@ -299,7 +299,7 @@ struct gnix_cq_tagged_entry {
 };
 
 struct gnix_cq {
-	struct fid_cq fid;
+	struct fid_cq cq_fid;
 	uint64_t flags;
 	struct gnix_domain *domain;
 	void *free_list_base;
@@ -317,16 +317,31 @@ struct gnix_mem_desc {
 };
 
 /*
- *   gnix_rdm_ep - FI_EP_RDM type ep
+ * TODO: need a lot more fields for AV support
  */
-struct gnix_rdm_ep {
-	struct fid_ep ep_fid;
+
+struct gnix_av {
+	struct fid_av av_fid;
 	struct gnix_domain *domain;
-	void *vc_cache_hndl;
-	int (*progress_fn)(struct gnix_rdm_ep *, enum gnix_progress_type);
+};
+
+/*
+ *   gnix endpoint structure
+ */
+struct gnix_ep {
+	struct fid_ep ep_fid;
+	enum fi_ep_type type;
+	struct gnix_domain *domain;
+	struct gnix_cq *send_cq;
+	struct gnix_cq *recv_cq;
+	struct gnix_av *av;
+	void *vc_hash_hndl;
+	void *vc;
+	int (*progress_fn)(struct gnix_ep *, enum gnix_progress_type);
 	/* RX specific progress fn */
-	int (*rx_progress_fn)(struct gnix_rdm_ep *, gni_return_t *rc);
+	int (*rx_progress_fn)(struct gnix_ep *, gni_return_t *rc);
 	int enabled;
+	int no_want_cqes;
 	/* num. active post descs associated with this ep */
 	uint32_t active_post_descs;
 };
@@ -368,6 +383,7 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 int gnix_mr_reg(struct fid_domain *domain, const void *buf, size_t len,
 		uint64_t access, uint64_t offset, uint64_t requested_key,
 		uint64_t flags, struct fid_mr **mr, void *context);
+
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -39,9 +39,356 @@
 #include "gnix.h"
 #include "gnix_util.h"
 
+/*
+ * Prototypes for method structs below
+ */
+
+static int gnix_ep_close(fid_t fid);
+static int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags);
+
+static struct fi_ops gnix_ep_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = gnix_ep_close,
+	.bind = gnix_ep_bind,
+	.control = fi_no_control
+};
+
+static struct fi_ops_ep gnix_ep_ops = {
+	.size = sizeof(struct fi_ops_ep),
+	.cancel = fi_no_cancel,
+	.getopt = fi_no_getopt,
+	.setopt = fi_no_setopt,
+	.tx_ctx = fi_no_tx_ctx,
+	.rx_ctx = fi_no_rx_ctx,
+	.rx_size_left = fi_no_rx_size_left,
+	.tx_size_left = fi_no_tx_size_left,
+};
+
+/*
+ * EP messaging ops
+ */
+static ssize_t gnix_ep_recv(struct fid_ep *ep, void *buf, size_t len,
+			    void *desc, fi_addr_t src_addr, void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_recvv(struct fid_ep *ep, const struct iovec *iov,
+			     void **desc, size_t count, fi_addr_t src_addr,
+			     void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
+			uint64_t flags)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_send(struct fid_ep *ep, const void *buf, size_t len,
+			    void *desc, fi_addr_t dest_addr, void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_sendv(struct fid_ep *ep, const struct iovec *iov,
+			     void **desc, size_t count, fi_addr_t dest_addr,
+			     void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
+			uint64_t flags)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_msg_inject(struct fid_ep *ep, const void *buf,
+				  size_t len, fi_addr_t dest_addr)
+{
+	return -FI_ENOSYS;
+}
+ssize_t gnix_ep_senddata(struct fid_ep *ep, const void *buf, size_t len,
+				uint64_t data, fi_addr_t dest_addr)
+{
+	return -FI_ENOSYS;
+}
+
+static struct fi_ops_msg gnix_ep_msg_ops = {
+	.size = sizeof(struct fi_ops_msg),
+	.recv = gnix_ep_recv,
+	.recvv = gnix_ep_recvv,
+	.recvmsg = gnix_ep_recvmsg,
+	.send = gnix_ep_send,
+	.sendv = gnix_ep_sendv,
+	.sendmsg = gnix_ep_sendmsg,
+	.inject = gnix_ep_msg_inject,
+	.senddata = fi_no_msg_senddata,
+	.injectdata = fi_no_msg_injectdata,
+};
+
+/*
+ * EP rma ops
+ */
+
+static ssize_t gnix_ep_read(struct fid_ep *ep, void *buf, size_t len,
+			    void *desc, fi_addr_t src_addr, uint64_t addr,
+			    uint64_t key, void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_readv(struct fid_ep *ep, const struct iovec *iov,
+				void **desc, size_t count, fi_addr_t src_addr,
+				uint64_t addr, uint64_t key, void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
+				uint64_t flags)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_write(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+				fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+				void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_writev(struct fid_ep *ep, const struct iovec *iov,
+				void **desc, size_t count, fi_addr_t dest_addr,
+				uint64_t addr, uint64_t key, void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
+				uint64_t flags)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_rma_inject(struct fid_ep *ep, const void *buf, size_t len,
+			fi_addr_t dest_addr, uint64_t addr, uint64_t key)
+{
+	return -FI_ENOSYS;
+}
+
+
+static struct fi_ops_rma gnix_ep_rma_ops = {
+	.size = sizeof(struct fi_ops_rma),
+	.read = gnix_ep_read,
+	.readv = gnix_ep_readv,
+	.readmsg = gnix_ep_readmsg,
+	.write = gnix_ep_write,
+	.writev = gnix_ep_writev,
+	.writemsg = gnix_ep_writemsg,
+	.inject = gnix_ep_rma_inject,
+	.writedata = fi_no_rma_writedata,
+	.injectdata = fi_no_rma_injectdata,
+};
+
+/*
+ * EP tag matching ops
+ */
+
+static ssize_t gnix_ep_trecv(struct fid_ep *ep, void *buf, size_t len,
+			     void *desc, fi_addr_t src_addr, uint64_t tag,
+			     uint64_t ignore, void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_trecvv(struct fid_ep *ep, const struct iovec *iov,
+			      void **desc, size_t count, fi_addr_t src_addr,
+			      uint64_t tag, uint64_t ignore, void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_trecvmsg(struct fid_ep *ep,
+				const struct fi_msg_tagged *msg, uint64_t flags)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_tsend(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+			fi_addr_t dest_addr, uint64_t tag, void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_tsendv(struct fid_ep *ep, const struct iovec *iov,
+			      void **desc, size_t count, fi_addr_t dest_addr,
+			      uint64_t tag, void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_tsendmsg(struct fid_ep *ep,
+				const struct fi_msg_tagged *msg, uint64_t flags)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_tinject(struct fid_ep *ep, const void *buf, size_t len,
+				fi_addr_t dest_addr, uint64_t tag)
+{
+	return -FI_ENOSYS;
+}
+
+ssize_t gnix_ep_tsenddata(struct fid_ep *ep, const void *buf, size_t len,
+			void *desc, uint64_t data, fi_addr_t dest_addr,
+			uint64_t tag, void *context)
+{
+	return -FI_ENOSYS;
+}
+
+ssize_t gnix_ep_tsearch(struct fid_ep *ep, uint64_t *tag, uint64_t ignore,
+			uint64_t flags, fi_addr_t *src_addr, size_t *len,
+			void *context)
+{
+	return -FI_ENOSYS;
+}
+
+struct fi_ops_tagged gnix_ep_tagged_ops = {
+	.size = sizeof(struct fi_ops_tagged),
+	.recv = gnix_ep_trecv,
+	.recvv = gnix_ep_trecvv,
+	.recvmsg = gnix_ep_trecvmsg,
+	.send = gnix_ep_tsend,
+	.sendv = gnix_ep_tsendv,
+	.sendmsg = gnix_ep_tsendmsg,
+	.inject = gnix_ep_tinject,
+	.senddata = fi_no_tagged_senddata,
+	.senddata = gnix_ep_tsenddata,
+	.injectdata = fi_no_tagged_injectdata,
+	.search = gnix_ep_tsearch,
+};
+
+static int gnix_ep_close(fid_t fid)
+{
+	struct gnix_ep *ep;
+
+	ep = container_of(fid, struct gnix_ep, ep_fid.fid);
+	/* TODO: lots more stuff to do here */
+
+	free(ep);
+	return FI_SUCCESS;
+}
+
+static int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
+{
+	int ret = FI_SUCCESS;
+	struct gnix_ep  *ep;
+	struct gnix_av  *av;
+	struct gnix_cq  *cq;
+
+	ep = container_of(fid, struct gnix_ep, ep_fid.fid);
+
+	if (!bfid)
+		return -FI_EINVAL;
+
+	switch (bfid->fclass) {
+	case FI_CLASS_EQ:
+		ret = -FI_ENOSYS;
+		goto err;
+		break;
+	case FI_CLASS_CQ:
+		cq = container_of(bfid, struct gnix_cq, cq_fid.fid);
+		if (ep->domain != cq->domain) {
+			ret = -FI_EINVAL;
+			break;
+		}
+		if (flags & FI_SEND) {
+			ep->send_cq = cq;
+		}
+		if (flags & FI_RECV) {
+			ep->recv_cq = cq;
+		}
+		if (flags & FI_COMPLETION) {
+			ep->no_want_cqes = 1;
+		}
+		break;
+	case FI_CLASS_AV:
+		av = container_of(bfid, struct gnix_av, av_fid.fid);
+		if (ep->domain != av->domain) {
+			ret = -FI_EINVAL;
+			break;
+		}
+		ep->av = av;
+		break;
+	case FI_CLASS_MR:/*TODO: got to figure this one out */
+	case FI_CLASS_CNTR: /* TODO: need to support cntrs someday */
+	default:
+		ret = -FI_ENOSYS;
+		break;
+	}
+
+err:
+        return ret;
+}
+
+
 int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 		 struct fid_ep **ep, void *context)
 {
-	/* TODO: implement this puppy */
-	return -FI_ENOSYS;
+	struct gnix_domain *domain_priv;
+	struct gnix_ep *ep_priv;
+
+	if ((domain == NULL) || (info == NULL) || (ep == NULL))
+		return -FI_EINVAL;
+
+	if (info->ep_type != FI_EP_RDM)
+		return -FI_ENOSYS;
+
+	domain_priv = container_of(domain, struct gnix_domain, domain_fid);
+
+	ep_priv = calloc(1, sizeof *ep_priv);
+	if (!ep) {
+		return -FI_ENOMEM;
+	}
+
+	ep_priv->ep_fid.fid.fclass = FI_CLASS_EP;
+	ep_priv->ep_fid.fid.context = context;
+
+	ep_priv->ep_fid.fid.ops = &gnix_ep_fi_ops;
+	ep_priv->ep_fid.ops = &gnix_ep_ops;
+	ep_priv->domain = domain_priv;
+	ep_priv->type = info->ep_type;
+
+	ep_priv->ep_fid.msg = &gnix_ep_msg_ops;
+	ep_priv->ep_fid.rma = &gnix_ep_rma_ops;
+	ep_priv->ep_fid.tagged = &gnix_ep_tagged_ops;
+	ep_priv->ep_fid.atomic = NULL;
+
+	/*
+	 * TODO, initialize vc hash table
+	 */
+	if (ep_priv->type == FI_EP_RDM) {
+		ep_priv->vc_hash_hndl = NULL;
+		ep_priv->ep_fid.cm = NULL;
+	} else {
+		ep_priv->vc = NULL;
+	}
+
+	/*
+	 * TODO: hookup the progress functions
+	 */
+
+	ep_priv->progress_fn = NULL;
+	ep_priv->rx_progress_fn = NULL;
+
+	/*
+ 	 * TODO: hookup a nic to this ep, may add more later if
+ 	 *  fi_tx_context, etc. is invoked on this endpoing
+ 	 */
+
+        *ep = &ep_priv->ep_fid;
+        return FI_SUCCESS;
 }


### PR DESCRIPTION
Initial ep work.  Drop use of different gnix_ep structs for rdm vs. msg type.  
There are not going to be enough underlying differences between the
two endpoint types to require different endpoint types.

Minor rename of fields in gnix_cq to improve code readability.

@bturrubiates  please look at this and we can rework per our discussion
today.

Signed-off-by: Howard Pritchard hppritcha@gmail.com
