### PR TITLE
prov/gni: improve error diagnostics for alps lli

### DIFF
--- a/prov/gni/src/gnix_util.c
+++ b/prov/gni/src/gnix_util.c
@@ -88,23 +88,25 @@ int gnixu_get_rdma_credentials(void *addr, uint8_t *ptag, uint32_t *cookie)
 	 */
 	ret = alps_app_lli_put_request(ALPS_APP_LLI_ALPS_REQ_APID, NULL, 0);
 	if (ret != ALPS_APP_LLI_ALPS_STAT_OK) {
-		GNIX_LOG_ERROR("lli put failed, ret=%s\n", strerror(ret));
+		GNIX_LOG_ERROR("lli put failed, ret=%d(%s)\n", ret,
+			       strerror(errno));
 		ret = -FI_EIO;
 		goto err;
 	}
 
 	ret = alps_app_lli_get_response(&alps_status, &alps_count);
 	if (alps_status != ALPS_APP_LLI_ALPS_STAT_OK) {
-		GNIX_LOG_ERROR("lli get response failed, ret=%s\n",
-			       strerror(ret));
+		GNIX_LOG_ERROR("lli get response failed, "
+			       "alps_status=%d(%s)\n",alps_status,
+			       strerror(errno));
 		ret = -FI_EIO;
 		goto err;
 	}
 
 	ret = alps_app_lli_get_response_bytes(&apid, sizeof(apid));
 	if (ret != ALPS_APP_LLI_ALPS_STAT_OK) {
-		GNIX_LOG_ERROR("lli get response failed, ret=%s\n",
-			       strerror(ret));
+		GNIX_LOG_ERROR("lli get response failed, ret=%d(%s)\n",
+			       ret, strerror(errno));
 		ret = -FI_EIO;
 		goto err;
 	}
@@ -114,15 +116,16 @@ int gnixu_get_rdma_credentials(void *addr, uint8_t *ptag, uint32_t *cookie)
 	 */
 	ret = alps_app_lli_put_request(ALPS_APP_LLI_ALPS_REQ_GNI, NULL, 0);
 	if (ret != ALPS_APP_LLI_ALPS_STAT_OK) {
-		GNIX_LOG_ERROR("lli put failed, ret=%s\n", strerror(ret));
+		GNIX_LOG_ERROR("lli put failed, ret=%d(%s)\n",
+			       ret, strerror(errno));
 		ret = -FI_EIO;
 		goto err;
 	}
 
 	ret = alps_app_lli_get_response(&alps_status, &alps_count);
 	if (alps_status != ALPS_APP_LLI_ALPS_STAT_OK) {
-		GNIX_LOG_ERROR("lli get response failed, ret=%s\n",
-			       strerror(ret));
+		GNIX_LOG_ERROR("lli get response failed, alps_status=%d(%s)\n",
+			       alps_status, strerror(errno));
 		ret = -FI_EIO;
 		goto err;
 	}
@@ -137,8 +140,8 @@ int gnixu_get_rdma_credentials(void *addr, uint8_t *ptag, uint32_t *cookie)
 
 	ret = alps_app_lli_get_response_bytes(rdmacred_rsp, alps_count);
 	if (ret != ALPS_APP_LLI_ALPS_STAT_OK) {
-		GNIX_LOG_ERROR("lli get response failed, ret=%s\n",
-			       strerror(ret));
+		GNIX_LOG_ERROR("lli get response failed, ret=%d(%s)\n",
+			       ret, strerror(errno));
 		ret = -FI_EIO;
 		goto err;
 	}


### PR DESCRIPTION
Since the alps lli api is not entirely clear, in error messages
print both the return value as well as  errno since the later may
be set and provide more info than just the alps lli function's
return value.

Signed-off-by: Howard Pritchard hppritcha@gmail.com

Conflicts:
    prov/gni/src/gnix_util.c
