### PR TITLE
prov/gni: fix fi_domain for gni

### DIFF
--- a/prov/gni/src/gnix.h
+++ b/prov/gni/src/gnix.h
@@ -183,8 +183,8 @@ enum gnix_progress_type {
  */
 struct gnix_fabric {
 	struct fid_fabric fab_fid;
-	/* llist of cdm's opened from fabric */
-	struct list_head cdm_list;
+	/* llist of domains's opened from fabric */
+	struct list_head domain_list;
 };
 
 /*
@@ -204,7 +204,7 @@ struct gnix_domain {
 	uint32_t cookie;
 	/* work queue for domain */
 	struct list_head domain_wq;
-	int ref_cnt;
+	atomic_t ref_cnt;
 };
 
 struct gnix_cdm {
@@ -238,9 +238,11 @@ struct gnix_cm_nic {
 	struct gnix_domain *domain;
 	struct gnix_datagram *datagram_base;
 	uint32_t inst_id;
+	uint8_t ptag;
+	uint32_t cookie;
 	uint32_t device_id;
 	uint32_t device_addr;
-	int ref_cnt;
+	atomic_t ref_cnt;
 };
 
 struct gnix_nic {
@@ -277,7 +279,7 @@ struct gnix_nic {
 	struct gnix_datagram *datagram_base;
 	uint32_t device_id;
 	uint32_t device_addr;
-	int ref_cnt;
+	atomic_t ref_cnt;
 };
 
 /*

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -274,11 +274,18 @@ struct fi_ops_tagged gnix_ep_tagged_ops = {
 static int gnix_ep_close(fid_t fid)
 {
 	struct gnix_ep *ep;
+	struct gnix_domain *domain;
 
 	ep = container_of(fid, struct gnix_ep, ep_fid.fid);
 	/* TODO: lots more stuff to do here */
 
+	domain = ep->domain;
+	assert(domain != NULL);
+
+	atomic_dec(&domain->ref_cnt);
+
 	free(ep);
+
 	return FI_SUCCESS;
 }
 
@@ -389,6 +396,7 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
  	 *  fi_tx_context, etc. is invoked on this endpoing
  	 */
 
+	atomic_inc(&domain_priv->ref_cnt);
         *ep = &ep_priv->ep_fid;
         return FI_SUCCESS;
 }

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -85,7 +85,11 @@ static int gnix_fabric_close(fid_t fid)
 	struct gnix_fabric *fab;
 	fab = container_of(fid, struct gnix_fabric, fab_fid);
 
-	if (!list_empty(&fab->cdm_list)) {
+	/*
+ 	 * TODO: is this really right thing to do?
+ 	 */
+
+	if (!list_empty(&fab->domain_list)) {
 		return -FI_EBUSY;
 	}
 
@@ -122,7 +126,7 @@ static int gnix_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 	fab->fab_fid.fid.context = context;
 	fab->fab_fid.fid.ops = &gnix_fab_fi_ops;
 	fab->fab_fid.ops = &gnix_fab_ops;
-	list_head_init(&fab->cdm_list);
+	list_head_init(&fab->domain_list);
 	*fabric = &fab->fab_fid;
 
 	return FI_SUCCESS;


### PR DESCRIPTION
Allow for multiple gni domains per fabric handle.
Use a single connection management (cm) nic for domains
sharing the same ptag/cookie for a given process.

Minor fixes in the ep code to increment the domain
ref cnt when an ep is created from a given domain
handle.

Switch to using the atomic functions for handling ref counts
on objects.

@sungeunchoi 
@bturrubiates 

Signed-off-by: Howard Pritchard howardp@lanl.gov
