### PR TITLE
Fix build warnings:

### DIFF
--- a/prov/gni/src/gnix.h
+++ b/prov/gni/src/gnix.h
@@ -366,9 +366,9 @@ int gnix_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 		 struct fid_ep **ep, void *context);
 
-int gnix_mr_reg(struct fid_domain *domain, const void *buf, size_t len,
+int gnix_mr_reg(struct fid *fid, const void *buf, size_t len,
 		uint64_t access, uint64_t offset, uint64_t requested_key,
-		uint64_t flags, struct fid_mr **mr, void *context);
+		uint64_t flags, struct fid_mr **mr_o, void *context);
 
 
 #ifdef __cplusplus

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -35,6 +35,7 @@
 //
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 #include "gnix.h"
 #include "gnix_util.h"

--- a/prov/gni/src/gnix_mr.c
+++ b/prov/gni/src/gnix_mr.c
@@ -39,9 +39,9 @@
 #include "gnix.h"
 #include "gnix_util.h"
 
-int gnix_mr_reg(struct fid_domain *domain, const void *buf, size_t len,
+int gnix_mr_reg(struct fid *fid, const void *buf, size_t len,
 		uint64_t access, uint64_t offset, uint64_t requested_key,
-		uint64_t flags, struct fid_mr **mr, void *context)
+		uint64_t flags, struct fid_mr **mr_o, void *context)
 {
 	/* TODO: implement this puppy */
 	return -FI_ENOSYS;

--- a/prov/gni/src/gnix_nameserver.c
+++ b/prov/gni/src/gnix_nameserver.c
@@ -57,6 +57,7 @@
 #include <sys/socket.h>
 #include <netdb.h>
 #include <arpa/inet.h>
+#include <assert.h>
 
 #include "gnix.h"
 #include "gnix_util.h"
@@ -158,7 +159,7 @@ int gnix_resolve_name(IN const char *node, IN const char *service,
 	struct addrinfo *result = NULL;
 	struct addrinfo *rp = NULL;
 
-	struct ifreq ifr = {0};
+	struct ifreq ifr = {{{0}}};
 
 	struct sockaddr_in *sa = NULL;
 	struct sockaddr_in *sin = NULL;


### PR DESCRIPTION
- `#include <assert.h>`
- Add some curly braces to quiet gcc struct initialization warning
- Replace call to fi_allocinfo_internal() with inline code (Fixes #28)

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com
