### PR TITLE
Changes for moving ep_type to ep_attr (upstream pull request #698)

### DIFF
--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -352,7 +352,7 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 	if ((domain == NULL) || (info == NULL) || (ep == NULL))
 		return -FI_EINVAL;
 
-	if (info->ep_type != FI_EP_RDM)
+	if (info->ep_attr->type != FI_EP_RDM)
 		return -FI_ENOSYS;
 
 	domain_priv = container_of(domain, struct gnix_domain, domain_fid);
@@ -368,7 +368,7 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 	ep_priv->ep_fid.fid.ops = &gnix_ep_fi_ops;
 	ep_priv->ep_fid.ops = &gnix_ep_ops;
 	ep_priv->domain = domain_priv;
-	ep_priv->type = info->ep_type;
+	ep_priv->type = info->ep_attr->type;
 
 	ep_priv->ep_fid.msg = &gnix_ep_msg_ops;
 	ep_priv->ep_fid.rma = &gnix_ep_rma_ops;

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -173,13 +173,15 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 		/*
 		 * check for endpoint type, only support FI_EP_RDM for now
 		 */
-		switch (hints->ep_type) {
-		case FI_EP_UNSPEC:
-		case FI_EP_RDM:
-			break;
-		default:
-			ret = -FI_ENODATA;
-			goto err;
+		if (hints->ep_attr) {
+			switch (hints->ep_attr->type) {
+			case FI_EP_UNSPEC:
+			case FI_EP_RDM:
+				break;
+			default:
+				ret = -FI_ENODATA;
+				goto err;
+			}
 		}
 
 		/*
@@ -297,7 +299,7 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 	gnix_info->domain_attr->name = strdup(gnix_dom_name);
 
 	gnix_info->next = NULL;
-	gnix_info->ep_type = FI_EP_RDM;
+	gnix_info->ep_attr->type = FI_EP_RDM;
 	gnix_info->caps = GNIX_EP_RDM_CAPS;
 	gnix_info->mode = mode;
 	gnix_info->addr_format = FI_ADDR_GNI;


### PR DESCRIPTION
Changed `ep_type` to `ep_attr->type` as needed by merged pull request #698)

It's an arms race to try and get a stable build today.
@bturrubiates 
@hppritcha 

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com
