### PR TITLE
prov/gni: add fid to struct names

### DIFF
--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -51,12 +51,12 @@ gni_cq_mode_t gnix_def_gni_cq_modes = GNI_CQ_PHYS_PAGES;
 static int gnix_domain_close(fid_t fid)
 {
 	int ret = FI_SUCCESS;
-	struct gnix_domain *domain;
+	struct gnix_fid_domain *domain;
 	struct gnix_cm_nic *cm_nic;
 	struct gnix_nic *p, *next;
 	gni_return_t status;
 
-	domain = container_of(fid, struct gnix_domain, domain_fid.fid);
+	domain = container_of(fid, struct gnix_fid_domain, domain_fid.fid);
 	if (domain->domain_fid.fid.fclass != FI_CLASS_DOMAIN) {
 		ret = -FI_EINVAL;
 		goto err;
@@ -122,9 +122,9 @@ gnix_domain_ops_open(struct fid *fid, const char *ops_name, uint64_t flags,
 			void **ops, void *context)
 {
 	int ret = -FI_ENOSYS;
-	struct gnix_domain *domain;
+	struct gnix_fid_domain *domain;
 
-	domain = container_of(fid, struct gnix_domain, domain_fid.fid);
+	domain = container_of(fid, struct gnix_fid_domain, domain_fid.fid);
 	if (domain->domain_fid.fid.fclass != FI_CLASS_DOMAIN) {
 		ret = -FI_EINVAL;
 		goto err;
@@ -162,17 +162,17 @@ static struct fi_ops_mr gnix_domain_mr_ops = {
 int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		     struct fid_domain **dom, void *context)
 {
-	struct gnix_domain *domain = NULL;
+	struct gnix_fid_domain *domain = NULL;
 	int ret = FI_SUCCESS;
 	uint8_t ptag;
 	uint32_t cookie, device_addr;
 	struct gnix_cm_nic *cm_nic = NULL, *elem;
-	struct gnix_fabric *fabric_priv;
+	struct gnix_fid_fabric *fabric_priv;
 	gni_return_t status;
 
 	GNIX_LOG_INFO("%s\n", __func__);
 
-	fabric_priv = container_of(fabric, struct gnix_fabric, fab_fid);
+	fabric_priv = container_of(fabric, struct gnix_fid_fabric, fab_fid);
 	if (!info->domain_attr->name ||
 	    strncmp(info->domain_attr->name, gnix_dom_name,
 		    strlen(gnix_dom_name))) {

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -277,11 +277,11 @@ struct fi_ops_tagged gnix_ep_tagged_ops = {
 
 static int gnix_ep_close(fid_t fid)
 {
-	struct gnix_ep *ep;
-	struct gnix_domain *domain;
+	struct gnix_fid_ep *ep;
+	struct gnix_fid_domain *domain;
 	struct gnix_nic *nic;
 
-	ep = container_of(fid, struct gnix_ep, ep_fid.fid);
+	ep = container_of(fid, struct gnix_fid_ep, ep_fid.fid);
 	/* TODO: lots more stuff to do here */
 
 	domain = ep->domain;
@@ -302,11 +302,11 @@ static int gnix_ep_close(fid_t fid)
 static int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 {
 	int ret = FI_SUCCESS;
-	struct gnix_ep  *ep;
-	struct gnix_av  *av;
-	struct gnix_cq  *cq;
+	struct gnix_fid_ep  *ep;
+	struct gnix_fid_av  *av;
+	struct gnix_fid_cq  *cq;
 
-	ep = container_of(fid, struct gnix_ep, ep_fid.fid);
+	ep = container_of(fid, struct gnix_fid_ep, ep_fid.fid);
 
 	if (!bfid)
 		return -FI_EINVAL;
@@ -317,7 +317,7 @@ static int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 		goto err;
 		break;
 	case FI_CLASS_CQ:
-		cq = container_of(bfid, struct gnix_cq, cq_fid.fid);
+		cq = container_of(bfid, struct gnix_fid_cq, cq_fid.fid);
 		if (ep->domain != cq->domain) {
 			ret = -FI_EINVAL;
 			break;
@@ -333,7 +333,7 @@ static int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 		}
 		break;
 	case FI_CLASS_AV:
-		av = container_of(bfid, struct gnix_av, av_fid.fid);
+		av = container_of(bfid, struct gnix_fid_av, av_fid.fid);
 		if (ep->domain != av->domain) {
 			ret = -FI_EINVAL;
 			break;
@@ -356,8 +356,8 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 		 struct fid_ep **ep, void *context)
 {
 	int ret = FI_SUCCESS;
-	struct gnix_domain *domain_priv;
-	struct gnix_ep *ep_priv;
+	struct gnix_fid_domain *domain_priv;
+	struct gnix_fid_ep *ep_priv;
 	struct gnix_nic *elem, *nic = NULL;
 	gni_return_t status;
 	uint32_t device_addr;
@@ -369,7 +369,7 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 	if (info->ep_attr->type != FI_EP_RDM)
 		return -FI_ENOSYS;
 
-	domain_priv = container_of(domain, struct gnix_domain, domain_fid);
+	domain_priv = container_of(domain, struct gnix_fid_domain, domain_fid);
 
 	ep_priv = calloc(1, sizeof *ep_priv);
 	if (!ep) {

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -84,8 +84,8 @@ static struct fi_ops_fabric gnix_fab_ops = {
 
 static int gnix_fabric_close(fid_t fid)
 {
-	struct gnix_fabric *fab;
-	fab = container_of(fid, struct gnix_fabric, fab_fid);
+	struct gnix_fid_fabric *fab;
+	fab = container_of(fid, struct gnix_fid_fabric, fab_fid);
 
 	/*
  	 * TODO: is this really right thing to do?
@@ -110,10 +110,11 @@ static struct fi_ops gnix_fab_fi_ops = {
 /*
  * define methods needed for the GNI fabric provider
  */
-static int gnix_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
-		       void *context)
+static int gnix_fabric_open(struct fi_fabric_attr *attr,
+			    struct fid_fabric **fabric,
+			    void *context)
 {
-	struct gnix_fabric *fab;
+	struct gnix_fid_fabric *fab;
 
 	if (strcmp(attr->name, gnix_fab_name)) {
 		return -FI_ENODATA;
@@ -353,7 +354,7 @@ struct fi_provider gnix_prov = {
 	.version = FI_VERSION(GNI_MAJOR_VERSION, GNI_MINOR_VERSION),
 	.fi_version = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION),
 	.getinfo = gnix_getinfo,
-	.fabric = gnix_fabric,
+	.fabric = gnix_fabric_open,
 	.cleanup = gnix_fini
 };
 


### PR DESCRIPTION
For those gni provider structs which use embedded libfabric
fid's - i.e. those that map directly to libfabric objects,
add a _fid_ to the struct name, for instance gnix_fid_domain,
gnix_fid_av, etc.

Also rename the method for creating a gni fabric object to
gnix_fabric_open.

@bturrubiates 
@sungeunchoi 

Signed-off-by: Howard Pritchard hppritcha@gmail.com
