### PR TITLE
prov/gni: explicit set av_type to FI_AV_UNSPEC

### DIFF
--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -284,6 +284,7 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 	gnix_info->domain_attr->threading = FI_THREAD_COMPLETION;
 	gnix_info->domain_attr->control_progress = FI_PROGRESS_AUTO;
 	gnix_info->domain_attr->data_progress = FI_PROGRESS_AUTO;
+	gnix_info->domain_attr->av_type = FI_AV_UNSPEC;
 	/* only one aries per node */
 	gnix_info->domain_attr->name = strdup(gnix_dom_name);
 


### PR DESCRIPTION
Explicitly set av_type in the domain_attr to FI_AV_UNSPEC.
Plan to support both FI_AV_TABLE and FI_AV_MAP avs in gni
provider.

@bturrubiates 
@sungeunchoi 

Signed-off-by: Howard Pritchard howardp@lanl.gov
