### PR TITLE
Set cdm_id and device_addr fields of nic in gnix_domain_open.

### DIFF
--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -274,6 +274,9 @@ int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 			ret = -FI_EACCES;
 			goto err;
 		}
+
+		cm_nic->device_addr = device_addr;
+
 	        list_add_tail(&cm_nic_list,&cm_nic->list);
 	}
 

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -536,6 +536,9 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 			goto err_w_inc;
 		}
 
+		nic->cdm_id = ep_priv->domain->cm_nic->cdm_id;
+		nic->device_addr = ep_priv->domain->cm_nic->device_addr;
+
 		/*
 		 * TODO: set up work queue
 		 */


### PR DESCRIPTION
This minor bug resulted in cm_nic->device_addr and cm_nic->cdm_id always being 0. 

Signed-off-by: Ben Turrubiates bturrubiates@lanl.gov
