### PR TITLE
Fix behavior in map_lookup to more closely match table_lookup.

### DIFF
--- a/prov/gni/src/gnix_av.c
+++ b/prov/gni/src/gnix_av.c
@@ -294,7 +294,10 @@ static int map_lookup(struct gnix_fid_av *int_av, fi_addr_t fi_addr, void *addr,
 	}
 
 	if (!addr) {
-		ret = -FI_ETOOSMALL;
+		if (copy_size >= *addrlen) {
+			ret = -FI_EINVAL;
+		}
+
 		goto err;
 	}
 


### PR DESCRIPTION
I realized yesterday while reading through the already merged commit that I
neglected to change map_lookup to reflect table_lookup and gnix_getname. 

Both should return -FI_ETOOSMALL in the case that the destination address
passed in is NULL and the size is less than the size necessary. When the
correct size is specified and the destination is NULL then -FI_EINVAL should be
returned.

Signed-off-by: Ben Turrubiates bturrubiates@lanl.gov
