### PR TITLE
Rename addr_entry to gnix_addr_entry to distinguish between GNI specific...

### DIFF
--- a/prov/gni/src/gnix.h
+++ b/prov/gni/src/gnix.h
@@ -268,7 +268,7 @@ struct gnix_fid_ep {
 	atomic_t active_fab_reqs;
 };
 
-struct addr_entry {
+struct gnix_addr_entry {
 	struct gnix_address* addr;
 	bool valid;
 };
@@ -280,7 +280,7 @@ struct gnix_fid_av {
 	struct fid_av av_fid;
 	struct gnix_fid_domain *domain;
 	enum fi_av_type type;
-	struct addr_entry* table;
+	struct gnix_addr_entry* table;
 	size_t addrlen;
 	/* How many addresses AV can hold before it needs to be resized */
 	size_t capacity;

--- a/prov/gni/src/gnix_av.c
+++ b/prov/gni/src/gnix_av.c
@@ -78,7 +78,7 @@ static int gnix_verify_av_attr(struct fi_av_attr *attr)
  */
 static int gnix_check_capacity(struct gnix_fid_av *av, size_t count)
 {
-	struct addr_entry *addrs = NULL;
+	struct gnix_addr_entry *addrs = NULL;
 	size_t capacity = av->capacity;
 
 	/*
@@ -189,7 +189,7 @@ static int table_lookup(struct gnix_fid_av *int_av, fi_addr_t fi_addr,
 {
 	struct gnix_address *found = NULL;
 	struct gnix_ep_name *out = NULL;
-	struct addr_entry *entry = NULL;
+	struct gnix_addr_entry *entry = NULL;
 	int ret = FI_SUCCESS;
 	size_t copy_size;
 	size_t index;


### PR DESCRIPTION
... code and libfabric specific code.

I just remembered to do this.
@sungeunchoi @hppritcha 

Signed-off-by: Ben Turrubiates bturrubiates@lanl.gov
