### PR TITLE
Topic/nic counting

### DIFF
--- a/prov/gni/src/gnix.h
+++ b/prov/gni/src/gnix.h
@@ -347,6 +347,8 @@ struct gnix_cm_nic {
 
 struct gnix_nic {
 	struct list_node list;
+	/* for the gnix_nic_list */
+	struct list_node gnix_nic_list;
 	gni_cdm_handle_t gni_cdm_hndl;
 	gni_nic_handle_t gni_nic_hndl;
 	/* receive completion queue for hndl */
@@ -559,6 +561,10 @@ struct gnix_work_req {
 extern const char gnix_fab_name[];
 extern const char gnix_dom_name[];
 extern uint32_t gnix_cdm_modes;
+extern uint32_t gnix_def_max_nics_per_ptag;
+extern int gnix_nics_per_ptag[GNI_PTAG_USER_END];
+extern pthread_mutex_t gnix_nic_list_lock;
+extern struct list_head gnix_nic_list;
 
 /*
  * linked list helpers

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -107,7 +107,8 @@ static int gnix_domain_close(fid_t fid)
 			gnix_list_node_init(&p->gnix_nic_list);
 			status = GNI_CdmDestroy(p->gni_cdm_hndl);
 			if (status != GNI_RC_SUCCESS)
-				GNIX_LOG_ERROR("oops, cdm destroy failed\n");
+				GNIX_ERR(FI_LOG_DOMAIN,
+					 "oops, cdm destroy failed\n");
 			free(p);
 		}
 	}

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -41,7 +41,7 @@
 #include "gnix.h"
 #include "gnix_util.h"
 
-LIST_HEAD(cm_nic_list);
+LIST_HEAD(gnix_cm_nic_list);
 
 uint32_t gnix_def_gni_tx_cq_size = 2048;
 /* rx cq bigger to avoid having to deal with rx overruns so much */
@@ -51,7 +51,7 @@ gni_cq_mode_t gnix_def_gni_cq_modes = GNI_CQ_PHYS_PAGES;
 
 static int gnix_domain_close(fid_t fid)
 {
-	int ret = FI_SUCCESS;
+	int ret = FI_SUCCESS, v;
 	struct gnix_fid_domain *domain;
 	struct gnix_cm_nic *cm_nic;
 	struct gnix_nic *p, *next;
@@ -77,9 +77,10 @@ static int gnix_domain_close(fid_t fid)
 
 	if (domain->cm_nic) {
 		cm_nic = domain->cm_nic;
-		atomic_dec(&domain->cm_nic->ref_cnt);
+		v = atomic_dec(&domain->cm_nic->ref_cnt);
+		assert(v >= 0);
 		if (cm_nic->gni_cdm_hndl &&
-		    (atomic_get(&cm_nic->ref_cnt) == 0)) {
+		    (v == 0)) {
 			status = GNI_CdmDestroy(cm_nic->gni_cdm_hndl);
 			if (status != GNI_RC_SUCCESS) {
 				GNIX_ERR(FI_LOG_DOMAIN,
@@ -89,15 +90,30 @@ static int gnix_domain_close(fid_t fid)
 		}
 	}
 
+	/*
+	 *  remove nics from the domain's nic list,
+	 *  decrement ref_cnt on each nic.  If ref_cnt
+	 *  drops to 0, destroy the cdm, remove from
+	 *  the global nic list.
+	 */
 	list_for_each_safe(&domain->nic_list, p, next, list)
 	{
 		list_del(&p->list);
 		gnix_list_node_init(&p->list);
-		/* TODO: free nic here */
+		v = atomic_dec(&p->ref_cnt);
+		assert(v >= 0);
+		if (v == 0) {
+			list_del(&p->gnix_nic_list);
+			gnix_list_node_init(&p->gnix_nic_list);
+			status = GNI_CdmDestroy(p->gni_cdm_hndl);
+			if (status != GNI_RC_SUCCESS)
+				GNIX_LOG_ERROR("oops, cdm destroy failed\n");
+			free(p);
+		}
 	}
 
-	atomic_dec(&domain->fabric->ref_cnt);
-	assert(atomic_get(&domain->fabric->ref_cnt) >= 0);
+	v = atomic_dec(&domain->fabric->ref_cnt);
+	assert(v >= 0);
 
 	/*
 	 * remove from the list of cdms attached to fabric
@@ -118,7 +134,7 @@ err:
  * better control allocation of underlying aries resources associated
  * with the domain.  Examples will include controlling size of underlying
  * hardware CQ sizes, max size of RX ring buffers, etc.
- * 
+ *
  * Currently this function is not implemented, so just return -FI_ENOSYS
  */
 
@@ -225,7 +241,7 @@ int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	 * TODO: thread safety, this iterator is not thread safe
 	 */
 
-        list_for_each(&cm_nic_list,elem,list) {
+	list_for_each(&gnix_cm_nic_list, elem, list) {
 		if ((elem->ptag == ptag) &&
 			(elem->cookie == cookie) &&
 			(elem->cdm_id == getpid())) {
@@ -286,7 +302,7 @@ int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 
 		cm_nic->device_addr = device_addr;
 
-	        list_add_tail(&cm_nic_list,&cm_nic->list);
+		list_add_tail(&gnix_cm_nic_list, &cm_nic->list);
 	}
 
 	domain->fabric = fabric_priv;

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -40,11 +40,7 @@
 #include "gnix.h"
 #include "gnix_util.h"
 
-<<<<<<< HEAD
-static LIST_HEAD(gnix_nic_list);
-=======
-static atomic_t gnix_id_counter;
->>>>>>> prov/gni: add nic counting
+atomic_t gnix_id_counter;
 
 /*
  * Prototypes for method structs below
@@ -568,7 +564,7 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 		atomic_init(&nic->ref_cnt, 1);
 		atomic_init(&nic->outstanding_fab_reqs_nic, 0);
 
-		list_add_tail(&gnix_nic_list,&nic->list);
+		list_add_tail(&gnix_nic_list, &nic->gnix_nic_list);
 		++gnix_nics_per_ptag[domain_priv->ptag];
 
 		list_add_tail(&domain_priv->nic_list, &nic->list);

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -60,6 +60,13 @@ const char gnix_fab_name[] = "gni";
 const char gnix_dom_name[] = "/sys/class/gni/kgni0";
 atomic_t gnix_id_counter;
 
+/* TODO: this will need to be adjustable - probably set in GNI_INI*/
+uint32_t gnix_def_max_nics_per_ptag = 4;
+
+int gnix_nics_per_ptag[GNI_PTAG_USER_END];
+LIST_HEAD(gnix_nic_list);
+pthread_mutex_t gnix_nic_list_lock = PTHREAD_MUTEX_INITIALIZER;
+
 uint32_t gnix_cdm_modes =
 	(GNI_CDM_MODE_FAST_DATAGRAM_POLL | GNI_CDM_MODE_FMA_SHARED |
 	GNI_CDM_MODE_FMA_SMALL_WINDOW | GNI_CDM_MODE_FORK_PARTCOPY |
@@ -131,6 +138,7 @@ static int gnix_fabric_open(struct fi_fabric_attr *attr,
 	fab->fab_fid.ops = &gnix_fab_ops;
 	atomic_init(&fab->ref_cnt, 0);
 	list_head_init(&fab->domain_list);
+
 	*fabric = &fab->fab_fid;
 
 	return FI_SUCCESS;


### PR DESCRIPTION
Use the ptag for tracking number of nics opened using a given ptag.
There are only up to GNI_PTAG_USER_END (253) possible ptags
so we can use a simple global array to track number of nics opened
for a given ptag.

The max # of nics/ptag will need to be determined using the number
of ranks in a job running on the node, as well as limits placed
by the job launcher on total number of FMA descriptors available
to the ranks in the job on the local node.

Keep the allocated nics in a global list to allow for multiple domains
with same ptag/cookie to use previously allocated nics.  Each domain
keeps a linked list of the domains it is using.

When the domain is closed, loop through the domain specific list of
gni nics being used, decrementing reference count.  If reference count
for a nic drops to zero, destroy the cdm, remove from the global list.

Start adding locks for thread safety support for managing global
nic list and ptag array.

@ztiffany 
@sungeunchoi 
@bturrubiates 

Signed-off-by: Howard Pritchard howardp@lanl.gov
