### PR TITLE
prov/gni: fix getinfo return code

### DIFF
--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -348,7 +348,13 @@ err:
 		if (gnix_info->fabric_attr) free(gnix_info->fabric_attr);
 		free(gnix_info);
 	}
-	return ret;
+
+	/*
+	 *  for the getinfo method, we need to return -FI_ENODATA  otherwise
+	 *  the fi_getinfo call will make an early exit without querying
+	 *  other providers which may be avaialble.
+	 */
+	return -FI_ENODATA;
 }
 
 static void gnix_fini(void)


### PR DESCRIPTION
Turns out the way the upper level fi_getinfo is
implemented, a provider that isn't available for
a given input address, etc. must return FI_ENODATA.
Otherwise, the fi_getinfo will return early and not
probe other potential providers.

@bturrubiates 

Fixes #51

Signed-off-by: Howard Pritchard howardp@lanl.gov
