### PR TITLE
Fix issue where programs hang when atomic_t is defined as spinlock.

### DIFF
--- a/prov/gni/src/gnix.h
+++ b/prov/gni/src/gnix.h
@@ -228,6 +228,8 @@ struct gnix_fid_mem_desc {
 	gni_mem_handle_t mem_hndl;
 };
 
+extern atomic_t gnix_id_counter;
+
 /*
  *   gnix endpoint structure
  */

--- a/prov/gni/src/gnix_av.c
+++ b/prov/gni/src/gnix_av.c
@@ -522,6 +522,7 @@ int gnix_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	int_av->av_fid.fid.context = context;
 	int_av->av_fid.fid.ops = &gnix_fi_av_ops;
 	int_av->av_fid.ops = &gnix_av_ops;
+	atomic_init(&int_av->ref_cnt, 0);
 
 	*av = &int_av->av_fid;
 

--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -51,7 +51,7 @@ static int gnix_cq_close(fid_t fid)
 		return -FI_EBUSY;
 
 	atomic_dec(&cq->domain->ref_cnt);
-	assert(&cq->domain->ref_cnt > 0);
+	assert(atomic_get(&cq->domain->ref_cnt) > 0);
 
 #if 0
 	while (!slist_empty(&cq->free_list)) {

--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -227,7 +227,7 @@ int gnix_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	cq_priv->format = attr->format;
 	cq_priv->entry_size = entry_size;
 	cq_priv->flags = cq_flags;
-	atomic_set(&cq_priv->ref_cnt, 1);
+	atomic_init(&cq_priv->ref_cnt, 1);
 
 	cq_priv->cq_fid.fid.fclass = FI_CLASS_CQ;
 	cq_priv->cq_fid.fid.context = context;

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -252,7 +252,7 @@ int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		}
 
 		gnix_list_node_init(&cm_nic->list);
-		atomic_set(&cm_nic->ref_cnt,1);
+		atomic_init(&cm_nic->ref_cnt, 1);
 		list_head_init(&cm_nic->datagram_free_list);
 		list_head_init(&cm_nic->wc_datagram_active_list);
 		list_head_init(&cm_nic->wc_datagram_free_list);
@@ -298,7 +298,7 @@ int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	domain->gni_tx_cq_size = gnix_def_gni_tx_cq_size;
 	domain->gni_rx_cq_size = gnix_def_gni_rx_cq_size;
 	domain->gni_cq_modes = gnix_def_gni_cq_modes;
-	atomic_set(&domain->ref_cnt,0);
+	atomic_init(&domain->ref_cnt, 0);
 
 	domain->domain_fid.fid.fclass = FI_CLASS_DOMAIN;
 	domain->domain_fid.fid.context = context;

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -41,7 +41,6 @@
 #include "gnix_util.h"
 
 static LIST_HEAD(gnix_nic_list);
-static atomic_t gnix_id_counter;
 
 /*
  * Prototypes for method structs below
@@ -384,6 +383,7 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 	ep_priv->ep_fid.ops = &gnix_ep_ops;
 	ep_priv->domain = domain_priv;
 	ep_priv->type = info->ep_attr->type;
+	atomic_init(&ep_priv->active_fab_reqs, 0);
 
 	ep_priv->ep_fid.msg = &gnix_ep_msg_ops;
 	ep_priv->ep_fid.rma = &gnix_ep_rma_ops;
@@ -545,7 +545,8 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 		 * TODO: set up work queue
 		 */
 
-		atomic_set(&nic->ref_cnt,1);
+		atomic_init(&nic->ref_cnt, 1);
+		atomic_init(&nic->outstanding_fab_reqs_nic, 0);
 		list_add_tail(&gnix_nic_list,&nic->list);
 	}
 

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -286,12 +286,12 @@ static int gnix_ep_close(fid_t fid)
 	domain = ep->domain;
 	assert(domain != NULL);
 	atomic_dec(&domain->ref_cnt);
-	assert(domain->ref_cnt > 0);
+	assert(atomic_get(&domain->ref_cnt) > 0);
 
 	nic = ep->nic;
 	assert(nic != NULL);
 	atomic_dec(&nic->ref_cnt);
-	assert(nic->ref_cnt > 0);
+	assert(atomic_get(&nic->ref_cnt) > 0);
 
 	free(ep);
 

--- a/prov/gni/src/gnix_eq.c
+++ b/prov/gni/src/gnix_eq.c
@@ -291,6 +291,7 @@ int gnix_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 	gnix_eq->eq_fabric = container_of(fabric, struct gnix_fid_fabric,
 					  fab_fid);
 	atomic_inc(&gnix_eq->eq_fabric->ref_cnt);
+	atomic_init(&gnix_eq->ref_cnt, 0);
 
 	gnix_eq->eq_fid.fid.fclass = FI_CLASS_EQ;
 	gnix_eq->eq_fid.fid.context = context;
@@ -311,10 +312,6 @@ err:
 	return ret;
 }
 
-/*
- * TOOD:
- * - Decrement fabric ref_cnt.
- */
 static int gnix_eq_close(struct fid *fid)
 {
 	struct gnix_fid_eq *gnix_eq = NULL;

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -58,6 +58,7 @@
 
 const char gnix_fab_name[] = "gni";
 const char gnix_dom_name[] = "/sys/class/gni/kgni0";
+atomic_t gnix_id_counter;
 
 uint32_t gnix_cdm_modes =
 	(GNI_CDM_MODE_FAST_DATAGRAM_POLL | GNI_CDM_MODE_FMA_SHARED |
@@ -128,6 +129,7 @@ static int gnix_fabric_open(struct fi_fabric_attr *attr,
 	fab->fab_fid.fid.context = context;
 	fab->fab_fid.fid.ops = &gnix_fab_fi_ops;
 	fab->fab_fid.ops = &gnix_fab_ops;
+	atomic_init(&fab->ref_cnt, 0);
 	list_head_init(&fab->domain_list);
 	*fabric = &fab->fab_fid;
 
@@ -398,6 +400,8 @@ GNI_INI
 	     GNI_GET_MINOR(lib_version.ugni_version) >= GNI_MINOR_REV)) {
 		provider = &gnix_prov;
 	}
+
+	atomic_init(&gnix_id_counter, 0);
 
 	return (provider);
 }


### PR DESCRIPTION
Rather than using atomic_init, we've directly been using atomic_set to
initialize atomic variables. Due to my recent upstream change, libfabric now
prefers to define atomic_t as pthread_spinlock rather than pthread_mutex. When
defined as pthread_spinlock the atomic_init function needs to be called. This
was causing a hang upon the initial atomic_set and atomic_get if atomic_init
had not been called yet.

@hppritcha @sungeunchoi 

Signed-off-by: Ben Turrubiates bturrubiates@lanl.gov
