### PR TITLE
prov/gni: add datagram subsystem

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -293,6 +293,7 @@ _gni_files = \
 	prov/gni/src/gnix_cm.c \
 	prov/gni/src/gnix_ep_rdm.c \
 	prov/gni/src/gnix_nameserver.c \
+	prov/gni/src/gnix_datagram.c \
 	prov/gni/src/gnix_util.c
 
 if HAVE_GNI_DL

--- a/prov/gni/src/gnix.h
+++ b/prov/gni/src/gnix.h
@@ -186,6 +186,15 @@ struct gnix_fid_fabric {
 	struct fid_fabric fab_fid;
 	/* llist of domains's opened from fabric */
 	struct list_head domain_list;
+	/* number of directed datagrams for domains opened from
+	 * this fabric object - used by cm nic*/
+	int n_dgrams;
+	/* number of wildcard datagrams for domains opened from
+	 * this fabric object - used by cm nic*/
+	int n_wc_dgrams;
+	/* timeout datagram completion - see
+	 * GNI_PostdataProbeWaitById in gni_pub.h */
+	uint64_t datagram_timeout;
 	atomic_t ref_cnt;
 };
 
@@ -317,21 +326,16 @@ struct gnix_fid_cq {
  * gnix cm nic struct - to be used only for GNI_EpPostData, etc.
  */
 
+
 struct gnix_cm_nic {
 	struct list_node list;
+	fastlock_t lock;
 	gni_cdm_handle_t gni_cdm_hndl;
 	gni_nic_handle_t gni_nic_hndl;
-	/* free list of datagrams   */
-	struct list_head datagram_free_list;
-	/* list of active wc datagrams   */
-	struct list_head wc_datagram_active_list;
-	/* free list of wc datagrams   */
-	struct list_head wc_datagram_free_list;
-	/* pointer to domain this nic is attached to */
+	struct gnix_dgram_hndl *dgram_hndl;
 	struct gnix_fid_domain *domain;
 	/* work queue for cm nic */
 	struct list_head cm_nic_wq;
-	struct gnix_datagram *datagram_base;
 	uint32_t cdm_id;
 	uint8_t ptag;
 	uint32_t cookie;
@@ -556,6 +560,58 @@ struct gnix_work_req {
 };
 
 /*
+ * GNI datagram related structs and defines.
+ * The GNI_EpPostData, etc. are used to manage
+ * connecting VC's for the FI_EP_RDM endpoint
+ * type.
+ */
+
+struct gnix_dgram_hndl {
+	struct gnix_cm_nic *nic;
+	/* free list of datagrams   */
+	struct list_head datagram_free_list;
+	/* list of active datagrams   */
+	struct list_head datagram_active_list;
+	/* free list of wc datagrams   */
+	struct list_head wc_datagram_free_list;
+	/* list of active wc datagrams   */
+	struct list_head wc_datagram_active_list;
+	struct gnix_datagram *datagram_base;
+	uint64_t datagram_timeout;
+	int n_dgrams;
+	int n_wc_dgrams;
+};
+
+enum gnix_dgram_type {
+	GNIX_DGRAM_WC = 100,
+	GNIX_DGRAM_BND
+};
+
+enum gnix_dgram_state {
+	GNIX_DGRAM_STATE_FREE,
+	GNIX_DGRAM_STATE_CONNECTING,
+	GNIX_DGRAM_STATE_LISTENING,
+	GNIX_DGRAM_STATE_CONNECTED,
+	GNIX_DGRAM_STATE_ALREADY_CONNECTING
+};
+
+struct gnix_datagram {
+	struct list_node        list;
+	struct list_head        *free_list_head;
+	gni_ep_handle_t         gni_ep;
+	struct gnix_cm_nic      *nic;
+	struct gnix_address     target_addr;
+	enum gnix_dgram_state   state;
+	enum gnix_dgram_type    type;
+	struct gnix_dgram_hndl  *d_hndl;
+	int  (*callback_fn)(struct gnix_datagram *,
+			    struct gnix_address,
+			    gni_post_state_t);
+	char dgram_in_buf[GNI_DATAGRAM_MAXSIZE];
+	char dgram_out_buf[GNI_DATAGRAM_MAXSIZE];
+};
+
+/*
  * globals
  */
 extern const char gnix_fab_name[];
@@ -582,7 +638,7 @@ static inline void gnix_list_del_init(struct list_node *node)
 }
 
 /*
- * prototypes
+ * prototypes for fi ops methods
  */
 int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		     struct fid_domain **domain, void *context);
@@ -598,6 +654,22 @@ int gnix_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 int gnix_mr_reg(struct fid *fid, const void *buf, size_t len,
 		uint64_t access, uint64_t offset, uint64_t requested_key,
 		uint64_t flags, struct fid_mr **mr_o, void *context);
+
+/*
+ * prototypes for gni provider internal functions
+ */
+
+int gnix_dgram_hndl_alloc(const struct gnix_fid_fabric *fabric,
+				struct gnix_cm_nic *cm_nic,
+				struct gnix_dgram_hndl **hndl_ptr);
+int gnix_dgram_hndl_free(struct gnix_dgram_hndl *hndl);
+int gnix_dgram_alloc(struct gnix_dgram_hndl *hndl, enum gnix_dgram_type type,
+			struct gnix_datagram **d_ptr);
+int gnix_dgram_unbnd_post(struct gnix_datagram *d,
+			gni_return_t *status_ptr);
+int gnix_dgram_connect_post(struct gnix_datagram *d,
+				gni_return_t *status_ptr);
+void gnix_dgram_prog_thread_fn(void *the_arg);
 
 
 #ifdef __cplusplus

--- a/prov/gni/src/gnix_datagram.c
+++ b/prov/gni/src/gnix_datagram.c
@@ -1,0 +1,425 @@
+/*
+ * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <assert.h>
+
+#include <rdma/fabric.h>
+#include <rdma/fi_cm.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_prov.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_rma.h>
+#include <rdma/fi_errno.h>
+
+#include "gnix.h"
+#include "gnix_util.h"
+
+int gnix_dgram_alloc(struct gnix_dgram_hndl *hndl, enum gnix_dgram_type type,
+			struct gnix_datagram **d_ptr)
+{
+	int ret = -FI_ENOMEM;
+	struct gnix_datagram *d = NULL;
+	struct list_head *the_free_list;
+	struct list_head *the_active_list;
+
+	if (type == GNIX_DGRAM_WC) {
+		the_free_list = &hndl->wc_datagram_free_list;
+		the_active_list = &hndl->wc_datagram_active_list;
+	} else {
+		the_free_list = &hndl->datagram_free_list;
+		the_active_list = &hndl->datagram_active_list;
+	}
+
+	if (!list_empty(the_free_list)) {
+		d = list_top(the_free_list, struct gnix_datagram, list);
+		if (d != NULL) {
+			gnix_list_del_init(&d->list);
+			list_add(the_active_list, &d->list);
+			d->type = type;
+			ret = FI_SUCCESS;
+		}
+	}
+
+	*d_ptr = d;
+	return ret;
+}
+
+int gnix_datagram_free(struct gnix_datagram *d)
+{
+	int ret = 0;
+	gni_return_t status;
+
+	if (d->type == GNIX_DGRAM_BND) {
+		status = GNI_EpUnbind(d->gni_ep);
+		if (status != GNI_RC_SUCCESS)
+			assert(0);
+			/* TODO: have to handle this */
+	}
+
+	gnix_list_del_init(&d->list);
+	memset(d, 0, sizeof(struct gnix_datagram));
+	d->state = GNIX_DGRAM_STATE_FREE;
+	list_add(d->free_list_head, &d->list);
+	return ret;
+}
+
+int gnix_dgram_wc_post(struct gnix_datagram *d, gni_return_t *status_ptr)
+{
+	int ret = FI_SUCCESS;
+	gni_return_t status;
+
+	status = GNI_EpPostDataWId(d->gni_ep,
+				   d->dgram_in_buf,
+				   GNI_DATAGRAM_MAXSIZE,
+				   d->dgram_out_buf,
+				   GNI_DATAGRAM_MAXSIZE,
+				   (uint64_t)d);
+	if (status != GNI_RC_SUCCESS) {
+		ret = gnixu_to_fi_errno(status);
+	} else {
+		/*
+		 * datagram is active now, listening
+		 */
+		d->state = GNIX_DGRAM_STATE_LISTENING;
+	}
+
+	return ret;
+}
+
+int gnix_dgram_connect_post(struct gnix_datagram *d, gni_return_t *status_ptr)
+{
+	gni_return_t status;
+	int ret = FI_SUCCESS;
+
+	/*
+	 * bind the datagram ep
+	 */
+
+	status = GNI_EpBind(d->gni_ep,
+			    d->target_addr.device_addr,
+			    d->target_addr.cdm_id);
+	if (status != GNI_RC_SUCCESS) {
+		ret = gnixu_to_fi_errno(status);
+		goto err;
+	}
+
+	/*
+	 * if we get GNI_RC_ERROR_RESOURCE status return from
+	 * GNI_EpPostDataWId  that means that a previously posted wildcard
+	 * datagram has matched up with an incoming connect
+	 * request from the rank we are trying to send a connect
+	 * request to.  Don't treat this case as an error.
+	 */
+
+	fastlock_acquire(&d->nic->lock);
+	status = GNI_EpPostDataWId(d->gni_ep,
+				   d->dgram_in_buf,
+				   GNI_DATAGRAM_MAXSIZE,
+				   d->dgram_out_buf,
+				   GNI_DATAGRAM_MAXSIZE,
+				   (uint64_t)d);
+	fastlock_release(&d->nic->lock);
+	if ((status != GNI_RC_SUCCESS) &&
+		(status != GNI_RC_ERROR_RESOURCE)) {
+			ret = gnixu_to_fi_errno(status);
+			goto err;
+	}
+
+	if (status_ptr != NULL)
+		*status_ptr = status;
+
+	/*
+	 * datagram is active now, connecting
+	 */
+	if (status == GNI_RC_SUCCESS)
+		d->state = GNIX_DGRAM_STATE_CONNECTING;
+	else if (status == GNI_RC_ERROR_RESOURCE)
+		d->state = GNIX_DGRAM_STATE_ALREADY_CONNECTING;
+
+err:
+	return ret;
+}
+
+/*
+ * this function is intended to be invoked as an argument to pthread_create,
+ */
+void gnix_dgram_prog_thread_fn(void *the_arg)
+{
+	int ret = FI_SUCCESS;
+	gni_return_t status;
+	gni_post_state_t post_state = GNI_POST_PENDING;
+	uint32_t responding_remote_id;
+	unsigned int responding_remote_addr;
+	struct gnix_datagram *dg_ptr;
+	uint64_t datagram_id = 0UL;
+	struct gnix_cm_nic *nic = (struct gnix_cm_nic *)the_arg;
+	struct gnix_address responding_addr;
+
+	/*
+	 * block waiting for datagrams - no need for a lock here
+	 */
+
+	status = GNI_PostdataProbeWaitById(nic->gni_nic_hndl,
+					   -1,
+					   &datagram_id);
+	if ((status != GNI_RC_SUCCESS) && (status  != GNI_RC_TIMEOUT)) {
+		ret = gnixu_to_fi_errno(status);
+		/* TODO: need to post something on event queue */
+	}
+
+	if (status == GNI_RC_SUCCESS) {
+
+		dg_ptr = (struct gnix_datagram *)datagram_id;
+		assert(dg_ptr != NULL);
+
+		assert((dg_ptr->state == GNIX_DGRAM_STATE_CONNECTING) ||
+			(dg_ptr->state = GNIX_DGRAM_STATE_LISTENING));
+
+		/*
+		 * do need to take lock here
+		 */
+		fastlock_acquire(&nic->lock);
+		status = GNI_EpPostDataTestById(dg_ptr->gni_ep,
+						datagram_id,
+						&post_state,
+						&responding_remote_addr,
+						&responding_remote_id);
+		fastlock_release(&nic->lock);
+		if (status != GNI_RC_SUCCESS) {
+			ret = gnixu_to_fi_errno(status);
+			/* TODO: need to post something on event queue */
+		}
+
+		switch (post_state) {
+		case GNI_POST_COMPLETED:
+			if (dg_ptr->callback_fn != NULL) {
+				responding_addr.device_addr =
+					responding_remote_addr;
+				responding_addr.cdm_id =
+					responding_remote_id;
+				ret = dg_ptr->callback_fn((void *)datagram_id,
+							responding_addr,
+							post_state);
+				if (ret != FI_SUCCESS) {
+					ret = gnixu_to_fi_errno(status);
+					/* TODO: need to post something
+					 * on event queue
+					 * */
+				}
+			}
+			break;
+		case GNI_POST_TIMEOUT:
+		case GNI_POST_TERMINATED:
+		case GNI_POST_ERROR:
+			ret = -FI_EIO;
+			break;
+		case GNI_POST_PENDING:
+		case GNI_POST_REMOTE_DATA:
+			break;
+		default:
+			assert(0);
+			break;
+		}
+	}
+}
+
+int gnix_dgram_hndl_alloc(const struct gnix_fid_fabric *fabric,
+				struct gnix_cm_nic *cm_nic,
+				struct gnix_dgram_hndl **hndl_ptr)
+{
+	int i, ret = FI_SUCCESS;
+	int n_dgrams_tot;
+	struct gnix_datagram *dgram_base = NULL, *dg_ptr;
+	struct gnix_dgram_hndl *the_hndl = NULL;
+	gni_return_t status;
+
+	the_hndl = calloc(1, sizeof(struct gnix_dgram_hndl));
+	if (the_hndl == NULL) {
+		ret = -FI_ENOMEM;
+		goto err;
+	}
+
+	the_hndl->nic = cm_nic;
+
+	list_head_init(&the_hndl->datagram_free_list);
+	list_head_init(&the_hndl->datagram_active_list);
+
+	list_head_init(&the_hndl->wc_datagram_free_list);
+	list_head_init(&the_hndl->wc_datagram_active_list);
+
+	/*
+	 * inherit some stuff from the fabric object being
+	 * used to open the domain which will use this cm nic.
+	 */
+
+	the_hndl->n_dgrams = fabric->n_dgrams;
+	the_hndl->n_wc_dgrams = fabric->n_wc_dgrams;
+	the_hndl->datagram_timeout = fabric->datagram_timeout;
+
+	n_dgrams_tot = the_hndl->n_dgrams + the_hndl->n_wc_dgrams;
+
+	/*
+	 * set up the free lists for datagrams
+	 */
+
+	dgram_base = calloc(n_dgrams_tot,
+			    sizeof(struct gnix_datagram));
+	if (dgram_base == NULL) {
+		ret = -FI_ENOMEM;
+		goto err;
+	}
+
+	dg_ptr = dgram_base;
+
+	/*
+	 * first build up the list for connection requests
+	 */
+
+	for (i = 0; i < fabric->n_dgrams; i++, dg_ptr++) {
+		dg_ptr->d_hndl = the_hndl;
+		status = GNI_EpCreate(cm_nic->gni_nic_hndl,
+					NULL,
+					&dg_ptr->gni_ep);
+		if (status != GNI_RC_SUCCESS) {
+			ret = gnixu_to_fi_errno(status);
+			goto err;
+		}
+		gnix_list_node_init(&dg_ptr->list);
+		list_add(&the_hndl->datagram_free_list, &dg_ptr->list);
+		dg_ptr->free_list_head = &the_hndl->datagram_free_list;
+	}
+
+	/*
+	 * now the wild card (WC) dgrams
+	 */
+
+	for (i = 0; i < fabric->n_wc_dgrams; i++, dg_ptr++) {
+		dg_ptr->d_hndl = the_hndl;
+		status = GNI_EpCreate(cm_nic->gni_nic_hndl,
+					NULL,
+					&dg_ptr->gni_ep);
+		if (status != GNI_RC_SUCCESS) {
+			ret = gnixu_to_fi_errno(status);
+			goto err;
+		}
+		gnix_list_node_init(&dg_ptr->list);
+		list_add(&the_hndl->wc_datagram_free_list, &dg_ptr->list);
+		dg_ptr->free_list_head = &the_hndl->wc_datagram_free_list;
+	}
+
+	the_hndl->datagram_base = dgram_base;
+
+	*hndl_ptr = the_hndl;
+
+	return ret;
+err:
+	dg_ptr = dgram_base;
+	if (dg_ptr) {
+
+		for (i = 0; i < n_dgrams_tot; i++, dg_ptr++) {
+			if (dg_ptr->gni_ep != NULL)
+				GNI_EpDestroy(dg_ptr->gni_ep);
+		}
+		free(dgram_base);
+	}
+	if (the_hndl)
+		free(the_hndl);
+	return ret;
+}
+
+int gnix_dgram_hndl_free(struct gnix_dgram_hndl *the_hndl)
+{
+	int i;
+	int n_dgrams;
+	int ret = FI_SUCCESS;
+	struct gnix_datagram *p, *next, *dg_ptr;
+	gni_return_t status;
+
+	if (the_hndl->datagram_base == NULL)
+		return -FI_EINVAL;
+
+	/*
+	 * cancel any active datagrams - GNI_RC_NO_MATCH is okay.
+	 */
+
+	list_for_each_safe(&the_hndl->datagram_active_list, p, next, list) {
+		dg_ptr = p;
+		status = GNI_EpPostDataCancel(dg_ptr->gni_ep);
+		if ((status != GNI_RC_SUCCESS) &&
+					(status != GNI_RC_NO_MATCH)) {
+			ret = gnixu_to_fi_errno(status);
+			goto err;
+		}
+		gnix_list_del_init(&dg_ptr->list);
+	}
+
+	list_for_each_safe(&the_hndl->wc_datagram_active_list,
+				p, next, list) {
+		dg_ptr = p;
+		status = GNI_EpPostDataCancel(dg_ptr->gni_ep);
+		if ((status != GNI_RC_SUCCESS) &&
+					(status != GNI_RC_NO_MATCH)) {
+			ret = gnixu_to_fi_errno(status);
+			goto err;
+		}
+		gnix_list_del_init(&dg_ptr->list);
+	}
+
+	/*
+	 * destroy all the endpoints
+	 */
+
+	n_dgrams = the_hndl->n_dgrams + the_hndl->n_wc_dgrams;
+	dg_ptr = the_hndl->datagram_base;
+
+	for (i = 0; i < n_dgrams; i++, dg_ptr++) {
+		if (dg_ptr->gni_ep != NULL)
+			GNI_EpDestroy(dg_ptr->gni_ep);
+	}
+
+err:
+	free(the_hndl->datagram_base);
+	free(the_hndl);
+
+	return ret;
+}

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -72,6 +72,12 @@ uint32_t gnix_cdm_modes =
 	GNI_CDM_MODE_FMA_SMALL_WINDOW | GNI_CDM_MODE_FORK_PARTCOPY |
 	GNI_CDM_MODE_ERR_NO_KILL);
 
+/* default number of directed datagrams per domain */
+static int gnix_def_gni_n_dgrams = 128;
+/* default number of wildcard datagrams per domain */
+static int gnix_def_gni_n_wc_dgrams = 4;
+static uint64_t gnix_def_gni_datagram_timeouts = -1;
+
 const struct fi_fabric_attr gnix_fabric_attr = {
 	.fabric = NULL,
 	.name = NULL,
@@ -131,6 +137,13 @@ static int gnix_fabric_open(struct fi_fabric_attr *attr,
 	if (!fab) {
 		return -FI_ENOMEM;
 	}
+
+	/*
+	 * set defaults related to use of GNI datagrams
+	 */
+	fab->n_dgrams = gnix_def_gni_n_dgrams;
+	fab->n_wc_dgrams = gnix_def_gni_n_wc_dgrams;
+	fab->datagram_timeout = gnix_def_gni_datagram_timeouts;
 
 	fab->fab_fid.fid.fclass = FI_CLASS_FABRIC;
 	fab->fab_fid.fid.context = context;


### PR DESCRIPTION
This commit adds support for an interface to the GNI datagram
(GNI_EpPostDataWId, etc). that can be used for exchanging the
initial SMSG data  needed to establish a GNI SMSG connection between two
GNI endpoints.  These connections will be used internally
in the GNI provider even in the case of FI_EP_RDM.

The datagram support is designed to be as self contained
and generic as possible.  When a process needs to send
information about a GNI smsg mailbox it takes the following
steps:

1) allocate a datagram with the gnix_dgram_alloc function.
   Since there are only a limited number of gni dgrams available
   (to avoid clogging up the kgni "session" state engine), the
   provider has to be prepared to handle a dgram not being available.
2) With an allocated datagram, fill in the dgram_in_buf buffer in
   the dgram with the info it wishes to exchange with the remote peer
3) Invoke the gnix_dgram_connect_post.  This results in the dgram
   being injected into the kgni "session" state engine, and ultimately
   delivery to the target node.  The intended receive process at the target
   must either post a matching gnix_dgram_connect_post or else have posted
   wildcard datagrams using the gnix_dgram_unbnd_post.
4) The process needs to poll on the EQ associated with the fabric object
   that was used to create the domain/ep's which require this internal
   GNI SMSG connection setup.  The data from the remote peer can be extracted
   from the dgram_out_buf in the datagram.

Note the EQ related code to implement 4 needs to be written.

The current plan is to have a pthread running in the gnix_dgram_prog_thread_fn.
One pthread per domain created.  The threads block in GNI_PostdataProbeWaitById.
When awoken with a completed datagram transaction, they'll inform the application
thread of the completion of the datagram exchange vi an EQ entry.

This commit also includes some refactoring of the code for allocating the
connection management nic (cm nic).

@bturrubiates 
@sungeunchoi 

Signed-off-by: Howard Pritchard howardp@lanl.gov
