### PR TITLE
Update gni provider to reflect API changes in 1.0-rc3.

### DIFF
--- a/prov/gni/src/gnix.h
+++ b/prov/gni/src/gnix.h
@@ -119,14 +119,14 @@ extern "C" {
 	(FI_MSG | FI_RMA | FI_TAGGED | FI_ATOMICS |                            \
 	 FI_DIRECTED_RECV | FI_MULTI_RECV | FI_INJECT | FI_SOURCE | FI_READ |  \
 	 FI_WRITE | FI_SEND | FI_RECV | FI_REMOTE_READ | FI_REMOTE_WRITE |     \
-	 FI_REMOTE_COMPLETE | FI_CANCEL | FI_FENCE)
+	 FI_TRANSMIT_COMPLETE | FI_CANCEL | FI_FENCE)
 
 /*
  * see Operations flags in fi_endpoint.3
  */
 #define GNIX_EP_OP_FLAGS                                                       \
 	(FI_MULTI_RECV | FI_COMPLETION |                                       \
-	 FI_REMOTE_COMPLETE | FI_READ | FI_WRITE | FI_SEND | FI_RECV |         \
+	 FI_TRANSMIT_COMPLETE | FI_READ | FI_WRITE | FI_SEND | FI_RECV |       \
 	 FI_REMOTE_READ | FI_REMOTE_WRITE)
 
 /*

--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -129,11 +129,10 @@ static struct fi_ops_cq gnix_cq_ops = {
 	.read = gnix_cq_read,
 	.readfrom = gnix_cq_readfrom,
 	.readerr = gnix_cq_readerr,
-	.write = fi_no_cq_write,
-	.writeerr = fi_no_cq_writeerr,
 	.sread = gnix_cq_sread,
 	.sreadfrom = gnix_cq_sreadfrom,
-	.strerror = gnix_cq_strerror,
+	.signal = fi_no_cq_signal,
+	.strerror = gnix_cq_strerror
 };
 
 int gnix_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -283,8 +283,6 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 	/* TODO: need to work on this */
 	gnix_info->ep_attr->mem_tag_format = 0x0;
 	/* TODO: remember this when implementing sends */
-	gnix_info->ep_attr->msg_order = FI_ORDER_SAS;
-	gnix_info->ep_attr->comp_order = FI_ORDER_NONE;
 	gnix_info->ep_attr->tx_ctx_cnt = 1;
 	gnix_info->ep_attr->rx_ctx_cnt = 1;
 
@@ -317,8 +315,8 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 		gnix_info->tx_attr->op_flags = GNIX_EP_OP_FLAGS;
 	}
 
-	gnix_info->tx_attr->msg_order = gnix_info->ep_attr->msg_order;
-	gnix_info->tx_attr->comp_order = gnix_info->ep_attr->comp_order;
+	gnix_info->tx_attr->msg_order = FI_ORDER_SAS;
+	gnix_info->tx_attr->comp_order = FI_ORDER_NONE;
 	/* TODO: probably something else here */
 	gnix_info->tx_attr->size = UINT64_MAX;
 	gnix_info->tx_attr->iov_limit = 1;
@@ -333,8 +331,8 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 		gnix_info->rx_attr->op_flags = GNIX_EP_OP_FLAGS;
 	}
 
-	gnix_info->rx_attr->msg_order = gnix_info->ep_attr->msg_order;
-	gnix_info->rx_attr->comp_order = gnix_info->ep_attr->comp_order;
+	gnix_info->rx_attr->msg_order = FI_ORDER_SAS;
+	gnix_info->rx_attr->comp_order = FI_ORDER_NONE;
 	/* TODO: probably something else here */
 	gnix_info->rx_attr->size = UINT64_MAX;
 	gnix_info->rx_attr->iov_limit = 1;


### PR DESCRIPTION
- Write and writeerr functions for CQ were removed.
- Add implementation for new signal callback (fi_no_cq_signal).
- Rename FI_REMOTE_COMPLETE to FI_TRANSMIT_COMPLETE
- Remove references to msg_order and comp_order of entries in ep_attr. These
  are also in tx_attr and rx_attr.
- Fix definitions of msg_order and comp_order for tx_attr and rx_attr.

@sungeunchoi @hppritcha 

Signed-off-by: Ben Turrubiates bturrubiates@lanl.gov
