### PR TITLE
prov/gni: initial addition of msg/tmsg vectors for eps

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -292,6 +292,7 @@ _gni_files = \
 	prov/gni/src/gnix_mr.c \
 	prov/gni/src/gnix_cm.c \
 	prov/gni/src/gnix_ep_rdm.c \
+	prov/gni/src/gnix_ep_msg.c \
 	prov/gni/src/gnix_nameserver.c \
 	prov/gni/src/gnix_util.c
 

--- a/prov/gni/src/gnix_ep.h
+++ b/prov/gni/src/gnix_ep.h
@@ -59,9 +59,6 @@ typedef ssize_t (*sendmsg_func_t)(struct fid_ep *ep, const struct fi_msg *msg,
 typedef ssize_t (*msg_inject_func_t)(struct fid_ep *ep, const void *buf,
 					size_t len, fi_addr_t dest_addr);
 
-typedef ssize_t (*msg_inject_func_t)(struct fid_ep *ep, const void *buf,
-					size_t len, fi_addr_t dest_addr);
-
 typedef ssize_t (*recv_func_t)(struct fid_ep *ep, const void *buf,
 				size_t len, void *desc,
 				fi_addr_t dest_addr, void *context);

--- a/prov/gni/src/gnix_ep.h
+++ b/prov/gni/src/gnix_ep.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015 Los Alamos National Security, LLC. Allrights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _GNIX_EP_H_
+#define _GNIX_EP_H_
+
+#include "gnix.h"
+
+/*
+ * prototypes for GNI EP internal implementation
+ */
+
+/*
+ * typedefs for function vectors used to steer send/receive/rma/amo requests,
+ * i.e. fi_send, fi_recv, etc. to ep type specific methods
+ */
+
+typedef ssize_t (*send_func_t)(struct fid_ep *ep, const void *buf,
+				size_t len, void *desc,
+				fi_addr_t dest_addr, void *context);
+
+typedef ssize_t (*sendv_func_t)(struct fid_ep *ep, const struct iovec *iov,
+				void **desc, size_t count,
+				fi_addr_t dest_addr, void *context);
+
+typedef ssize_t (*sendmsg_func_t)(struct fid_ep *ep, const struct fi_msg *msg,
+				   uint64_t flags);
+
+typedef ssize_t (*msg_inject_func_t)(struct fid_ep *ep, const void *buf,
+					size_t len, fi_addr_t dest_addr);
+
+typedef ssize_t (*msg_inject_func_t)(struct fid_ep *ep, const void *buf,
+					size_t len, fi_addr_t dest_addr);
+
+typedef ssize_t (*recv_func_t)(struct fid_ep *ep, const void *buf,
+				size_t len, void *desc,
+				fi_addr_t dest_addr, void *context);
+
+typedef ssize_t (*recvv_func_t)(struct fid_ep *ep, const struct iovec *iov,
+				 void **desc, size_t count,
+				 fi_addr_t dest_addr, void *context);
+
+typedef ssize_t (*recvmsg_func_t)(struct fid_ep *ep, const struct fi_msg *msg,
+				  uint64_t flags);
+
+typedef ssize_t (*tsend_func_t)(struct fid_ep *ep, const void *buf,
+				 size_t len, void *desc,
+				 fi_addr_t dest_addr, uint64_t tag,
+				 void *context);
+
+typedef ssize_t (*tsendv_func_t)(struct fid_ep *ep, const struct iovec *iov,
+				  void **desc, size_t count,
+				  fi_addr_t dest_addr, uint64_t tag,
+				  void *context);
+
+typedef ssize_t (*tsendmsg_func_t)(struct fid_ep *ep,
+				    const struct fi_msg_tagged *msg,
+				    uint64_t flags);
+
+typedef ssize_t (*tinject_func_t)(struct fid_ep *ep,
+				   const void *buf,
+				   size_t len,
+				   fi_addr_t dest_addr,
+				   uint64_t flags);
+
+typedef ssize_t (*trecv_func_t)(struct fid_ep *ep,
+				 void *buf,
+				 size_t len,
+				 void *desc,
+				 fi_addr_t src_addr,
+				 uint64_t tag,
+				 uint64_t ignore,
+				 void *context);
+
+typedef ssize_t (*trecvv_func_t)(struct fid_ep *ep,
+				 const struct iovec *iov,
+				 void **desc,
+				 size_t count,
+				 fi_addr_t src_addr,
+				 uint64_t tag,
+				 uint64_t ignore,
+				 void *context);
+
+typedef ssize_t (*trecvmsg_func_t)(struct fid_ep *ep,
+				   const struct fi_msg_tagged *msg,
+				   uint64_t flags);
+
+#endif /* _GNIX_EP_H_ */

--- a/prov/gni/src/gnix_ep_msg.c
+++ b/prov/gni/src/gnix_ep_msg.c
@@ -37,5 +37,5 @@
 #include "gnix.h"
 
 /*
- * gni provider FID_EP_RDM specific methods
+ * gni provider FID_EP_MSG specific methods
  */

--- a/prov/gni/src/gnix_ep_msg.h
+++ b/prov/gni/src/gnix_ep_msg.h
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015 Los Alamos National Security, LLC. Allrights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _GNIX_EP_MSG_H_
+#define _GNIX_EP_MSG_H_
+
+#include "gnix.h"
+
+/*
+ * Entry points for FI_EP_MSG data motion methods.
+ * This file is intended to be included only in gnix_ep.c
+ */
+
+static ssize_t gnix_ep_send_msg(struct fid_ep *ep, const void *buf, size_t len,
+				void *desc, fi_addr_t dest_addr, void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_sendv_msg(struct fid_ep *ep, const struct iovec *iov,
+				 void **desc, size_t count, fi_addr_t dest_addr,
+				 void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_sendmsg_msg(struct fid_ep *ep, const struct fi_msg *msg,
+				   uint64_t flags)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_msg_inject_msg(struct fid_ep *ep, const void *buf,
+				      size_t len, fi_addr_t dest_addr)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_recv_msg(struct fid_ep *ep, const void *buf, size_t len,
+				void *desc, fi_addr_t dest_addr, void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_recvv_msg(struct fid_ep *ep, const struct iovec *iov,
+				 void **desc, size_t count, fi_addr_t dest_addr,
+				 void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_recvmsg_msg(struct fid_ep *ep, const struct fi_msg *msg,
+				   uint64_t flags)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_tsend_msg(struct fid_ep *ep, const void *buf, size_t len,
+				 void *desc, fi_addr_t dest_addr, uint64_t tag,
+				 void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_tsendv_msg(struct fid_ep *ep, const struct iovec *iov,
+				  void **desc, size_t count,
+				  fi_addr_t dest_addr,
+				  uint64_t tag, void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_tsendmsg_msg(struct fid_ep *ep,
+				    const struct fi_msg_tagged *msg,
+				    uint64_t flags)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_tinject_msg(struct fid_ep *ep, const void *buf,
+				   size_t len, fi_addr_t dest_addr,
+				   uint64_t tag)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_trecv_msg(struct fid_ep *ep, void *buf, size_t len,
+			  void *desc, fi_addr_t src_addr, uint64_t tag,
+			  uint64_t ignore, void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_trecvv_msg(struct fid_ep *ep, const struct iovec *iov,
+				  void **desc, size_t count, fi_addr_t src_addr,
+				  uint64_t tag, uint64_t ignore, void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_trecvmsg_msg(struct fid_ep *ep,
+				    const struct fi_msg_tagged *msg,
+				    uint64_t flags)
+{
+	return -FI_ENOSYS;
+}
+
+#endif /* _GNIX_EP_MSG_H_ */

--- a/prov/gni/src/gnix_ep_rdm.h
+++ b/prov/gni/src/gnix_ep_rdm.h
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015 Los Alamos National Security, LLC. Allrights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#ifndef _GNIX_EP_RDM_H_
+#define _GNIX_EP_RDM_H_
+
+#include "gnix.h"
+
+/*
+ * Entry points for FI_EP_RDM data motion methods.
+ * This file is intended to be included only in gnix_ep.c
+ */
+
+static ssize_t gnix_ep_send_rdm(struct fid_ep *ep, const void *buf, size_t len,
+				void *desc, fi_addr_t dest_addr, void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_sendv_rdm(struct fid_ep *ep, const struct iovec *iov,
+				 void **desc, size_t count, fi_addr_t dest_addr,
+				 void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_sendmsg_rdm(struct fid_ep *ep, const struct fi_msg *msg,
+				   uint64_t flags)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_msg_inject_rdm(struct fid_ep *ep, const void *buf,
+				      size_t len, fi_addr_t dest_addr)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_recv_rdm(struct fid_ep *ep, const void *buf, size_t len,
+				void *desc, fi_addr_t dest_addr, void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_recvv_rdm(struct fid_ep *ep, const struct iovec *iov,
+				 void **desc, size_t count, fi_addr_t dest_addr,
+				 void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_recvmsg_rdm(struct fid_ep *ep, const struct fi_msg *msg,
+				   uint64_t flags)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_tsend_rdm(struct fid_ep *ep, const void *buf, size_t len,
+				 void *desc, fi_addr_t dest_addr, uint64_t tag,
+				 void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_tsendv_rdm(struct fid_ep *ep, const struct iovec *iov,
+				  void **desc, size_t count,
+				  fi_addr_t dest_addr, uint64_t tag,
+				  void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_tsendmsg_rdm(struct fid_ep *ep,
+				    const struct fi_msg_tagged *msg,
+				    uint64_t flags)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_tinject_rdm(struct fid_ep *ep, const void *buf,
+				   size_t len, fi_addr_t dest_addr,
+				   uint64_t tag)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_trecv_rdm(struct fid_ep *ep, void *buf, size_t len,
+				 void *desc, fi_addr_t src_addr, uint64_t tag,
+				 uint64_t ignore, void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_trecvv_rdm(struct fid_ep *ep, const struct iovec *iov,
+				  void **desc, size_t count, fi_addr_t src_addr,
+				  uint64_t tag, uint64_t ignore, void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static ssize_t gnix_ep_trecvmsg_rdm(struct fid_ep *ep,
+				    const struct fi_msg_tagged *msg,
+				    uint64_t flags)
+{
+	return -FI_ENOSYS;
+}
+
+#endif /* _GNIX_EP_RDM_H_ */


### PR DESCRIPTION
Provide steering of the generic ep_send, etc. entry points
in the gni provider to the ep type specific method.  Use
tables of function pointers to elminate conditionals.  May
be particularly important for KNL.

@bturrubiates 
@sungeunchoi 
Signed-off-by: Howard Pritchard howardp@lanl.gov
