### PR TITLE
Fix naming of prototypes in header file. Fix seg fault arising from pass...

### DIFF
--- a/prov/gni/include/gnix_cq.h
+++ b/prov/gni/include/gnix_cq.h
@@ -39,11 +39,11 @@ struct gnix_fid_cq {
 };
 
 
-ssize_t gnix_cq_add_event(struct gnix_fid_cq *cq, void *op_context,
+ssize_t _gnix_cq_add_event(struct gnix_fid_cq *cq, void *op_context,
 			  uint64_t flags, size_t len, void *buf,
 			  uint64_t data, uint64_t tag);
 
-ssize_t gnix_cq_add_error(struct gnix_fid_cq *cq, void *op_context,
+ssize_t _gnix_cq_add_error(struct gnix_fid_cq *cq, void *op_context,
 			  uint64_t flags, size_t len, void *buf,
 			  uint64_t data, uint64_t tag, size_t olen,
 			  int err, int prov_errno, void *err_data);


### PR DESCRIPTION
...ing incorrect pointer to fill functions.

Found the seg fault while trying out the unit testing framework.

Signed-off-by: Ben Turrubiates bturrubiates@lanl.gov
