### PR TITLE
Add hint to specify use of GNI fabric in CQ unit test.

### DIFF
--- a/prov/gni/test/cq.c
+++ b/prov/gni/test/cq.c
@@ -69,6 +69,8 @@ void setup(void)
 	hints->domain_attr->cq_data_size = 4;
 	hints->mode = ~0;
 
+	hints->fabric_attr->name = strdup("gni");
+
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	assert(!ret, "fi_getinfo");
 


### PR DESCRIPTION
Fixes #82

Signed-off-by: Ben Turrubiates bturrubiates@lanl.gov
