### PR TITLE
Fix memory leak associated with CQs.

### DIFF
--- a/prov/gni/test/cq.c
+++ b/prov/gni/test/cq.c
@@ -85,8 +85,12 @@ void setup(void)
 
 void teardown(void)
 {
-	fi_close(&dom->fid);
-	fi_close(&fab->fid);
+	int ret = 0;
+
+	ret = fi_close(&dom->fid);
+	assert(!ret, "failure in closing domain.");
+	ret = fi_close(&fab->fid);
+	assert(!ret, "failure in closing fabric.");
 	fi_freeinfo(fi);
 	fi_freeinfo(hints);
 }
@@ -130,8 +134,8 @@ void cq_tagged_setup(void)
 
 void cq_teardown(void)
 {
+	assert(!fi_close(&rcq->fid), "failure in closing cq.");
 	teardown();
-	fi_close(&rcq->fid);
 }
 
 /*******************************************************************************


### PR DESCRIPTION
- CQ reference count was being initialized to 1, but being checked against 0.
  This caused the close function to always return -FI_EBUSY.
- Break free queue functionality info separate function and free all queues and
  free lists associated with each CQ.
- Add useful logging for debugging.
- Fix unit test to check return values of close.

@hppritcha @sungeunchoi 

Signed-off-by: Ben Turrubiates bturrubiates@lanl.gov
