### PR TITLE
Fix memory leak from duplicate prov_name entry.

### DIFF
--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -325,7 +325,6 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 	gnix_info->dest_addr = dest_addr;
 	gnix_info->fabric_attr->name = strdup(gnix_fab_name);
 	/* let's consider gni copyrighted :) */
-	gnix_info->fabric_attr->prov_name = strdup(gnix_fab_name);
 
 	gnix_info->tx_attr->caps = gnix_info->caps;
 	gnix_info->tx_attr->mode = gnix_info->mode;


### PR DESCRIPTION
prov_name is already set by fi_getinfo. See: 
https://github.com/ofiwg/libfabric/blob/master/src/fabric.c#L487

Signed-off-by: Ben Turrubiates bturrubiates@lanl.gov
