### PR TITLE
prov/gni: gnix_cm_nic now bound to eps

### DIFF
--- a/prov/gni/Makefile.am
+++ b/prov/gni/Makefile.am
@@ -24,6 +24,7 @@ _gni_files = \
 	prov/gni/src/gnix_ep_rdm.c \
 	prov/gni/src/gnix_nameserver.c \
 	prov/gni/src/gnix_datagram.c \
+	prov/gni/src/gnix_cm_nic.c \
 	prov/gni/src/gnix_util.c
 
 if HAVE_CRITERION

--- a/prov/gni/include/gnix_cm_nic.h
+++ b/prov/gni/include/gnix_cm_nic.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2015 Cray Inc. All rights reserved.
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -30,40 +31,19 @@
  * SOFTWARE.
  */
 
-#if HAVE_CONFIG_H
-#include <config.h>
-#endif /* HAVE_CONFIG_H */
+#ifndef _GNIX_CM_NIC_H_
+#define _GNIX_CM_NIC_H_
 
-#ifndef _GNIX_UTIL_H_
-#define _GNIX_UTIL_H_
+#include "gnix.h"
 
-#include <stdio.h>
-#include "rdma/fi_log.h"
-
-extern struct fi_provider gnix_prov;
-
-#define GNIX_WARN(subsystem, ...)                                              \
-	FI_WARN(&gnix_prov, subsystem, __VA_ARGS__)
-#define GNIX_TRACE(subsystem, ...)                                             \
-	FI_TRACE(&gnix_prov, subsystem, __VA_ARGS__)
-#define GNIX_INFO(subsystem, ...)                                              \
-	FI_INFO(&gnix_prov, subsystem, __VA_ARGS__)
-#define GNIX_DEBUG(subsystem, ...)                                             \
-	FI_DBG(&gnix_prov, subsystem, __VA_ARGS__)
-
+extern atomic_t gnix_id_counter;
 /*
- * TODO: This currently breaks the logging semantics. Discuss how to handle
- * error output.
+ * prototypes for GNI CM NIC methods
  */
-#define GNIX_ERR(subsystem, ...)                                               \
-	fi_log(&gnix_prov, FI_LOG_WARN, subsystem, __func__, __LINE__,         \
-	       __VA_ARGS__);
 
-/*
- * prototypes
- */
-int gnixu_get_rdma_credentials(void *addr, uint8_t *ptag, uint32_t *cookie);
-int gnixu_to_fi_errno(int err);
+int gnix_cm_nic_free(struct gnix_cm_nic *cm_nic);
+int gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
+			struct gnix_cm_nic **cm_nic);
+int gnix_get_new_cdm_id(struct gnix_fid_domain *domain, uint32_t *id);
 
-
-#endif
+#endif /* _GNIX_CM_NIC_H_ */

--- a/prov/gni/src/gnix_cm.c
+++ b/prov/gni/src/gnix_cm.c
@@ -84,11 +84,17 @@ static int gnix_getname(fid_t fid, void *addr, size_t *addrlen)
 	}
 
 	/*
-	 * Retrieve the cdm_id & device_addr from the gnix_nic structure.
+	 * Retrieve the cdm_id & device_addr from the gnix_cm_nic structure.
 	 */
-	name.gnix_addr.cdm_id = ep->cm_nic->cdm_id;
-	name.gnix_addr.device_addr = ep->cm_nic->device_addr;
-	name.cookie = ep->domain->cookie;
+
+	if (ep->type == FI_EP_RDM) {
+		name.gnix_addr.cdm_id = ep->cm_nic->cdm_id;
+		name.gnix_addr.device_addr = ep->cm_nic->device_addr;
+		name.cookie = ep->domain->cookie;
+	} else {
+		return -FI_ENOSYS;  /*TODO: something different needed for
+				      FI_EP_MSG */
+	}
 
 	memcpy(addr, &name, copy_size);
 

--- a/prov/gni/src/gnix_cm.c
+++ b/prov/gni/src/gnix_cm.c
@@ -86,8 +86,8 @@ static int gnix_getname(fid_t fid, void *addr, size_t *addrlen)
 	/*
 	 * Retrieve the cdm_id & device_addr from the gnix_nic structure.
 	 */
-	name.gnix_addr.cdm_id = ep->nic->cdm_id;
-	name.gnix_addr.device_addr = ep->nic->device_addr;
+	name.gnix_addr.cdm_id = ep->cm_nic->cdm_id;
+	name.gnix_addr.device_addr = ep->cm_nic->device_addr;
 	name.cookie = ep->domain->cookie;
 
 	memcpy(addr, &name, copy_size);

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Los Alamos National Security, LLC. Allrights reserved.
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  * Copyright (c) 2015 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -41,12 +41,11 @@
 #include "gnix.h"
 #include "gnix_util.h"
 
-LIST_HEAD(gnix_cm_nic_list);
-
 uint32_t gnix_def_gni_tx_cq_size = 2048;
 /* rx cq bigger to avoid having to deal with rx overruns so much */
 uint32_t gnix_def_gni_rx_cq_size = 16384;
-/* TODO: should we use physical pages for gni cq rings? This is a question for Zach */
+/* TODO: should we use physical pages for gni cq rings? This is a question for
+ * Zach */
 gni_cq_mode_t gnix_def_gni_cq_modes = GNI_CQ_PHYS_PAGES;
 
 /*******************************************************************************
@@ -56,128 +55,6 @@ gni_cq_mode_t gnix_def_gni_cq_modes = GNI_CQ_PHYS_PAGES;
 static struct fi_ops gnix_domain_fi_ops;
 static struct fi_ops_mr gnix_domain_mr_ops;
 static struct fi_ops_domain gnix_domain_ops;
-
-/*******************************************************************************
- * Helper functions.
- ******************************************************************************/
-static int gnix_cm_nic_free(struct gnix_cm_nic *cm_nic)
-{
-	int ret = FI_SUCCESS, v;
-	gni_return_t status;
-
-	if (cm_nic == NULL)
-		return -FI_EINVAL;
-
-	v = atomic_dec(&cm_nic->ref_cnt);
-	if ((cm_nic->gni_cdm_hndl != NULL) && (v == 0))  {
-		status = GNI_CdmDestroy(cm_nic->gni_cdm_hndl);
-		if (status != GNI_RC_SUCCESS) {
-			GNIX_ERR(FI_LOG_DOMAIN, "oops, cdm destroy failed\n");
-			ret = gnixu_to_fi_errno(status);
-			free(cm_nic);
-		}
-	}
-
-	return ret;
-}
-
-static int gnix_cm_nic_alloc(struct gnix_fid_fabric *fabric, uint8_t ptag,
-				uint32_t cookie, uint32_t cdm_id,
-				struct gnix_cm_nic **cm_nic_ptr)
-{
-	int ret = FI_SUCCESS;
-	struct gnix_cm_nic *cm_nic = NULL, *elem;
-	uint32_t device_addr;
-	gni_return_t status;
-
-	*cm_nic_ptr = NULL;
-
-	/*
-	 * look for the cm_nic for this ptag/cookie in the list
-	 * TODO: thread safety, this iterator is not thread safe
-	 */
-
-	list_for_each(&gnix_cm_nic_list, elem, list) {
-		if ((elem->ptag == ptag) &&
-			(elem->cookie == cookie) &&
-			(elem->cdm_id == cdm_id)) {
-			cm_nic = elem;
-			atomic_inc(&cm_nic->ref_cnt);
-			break;
-		}
-	}
-
-	/*
-	 * no matching cm_nic found in the list, so create one for this
-	 * domain and add to the list.
-	 */
-
-	if (cm_nic == NULL) {
-
-		GNIX_INFO(FI_LOG_DOMAIN, "creating cm_nic for %u/0x%x id %d\n",
-		      ptag, cookie, getpid());
-		cm_nic = (struct gnix_cm_nic *)calloc(1, sizeof(*cm_nic));
-		if (cm_nic == NULL) {
-			ret = -FI_ENOMEM;
-			goto err;
-		}
-
-		status = GNI_CdmCreate(cdm_id, ptag, cookie,
-				       gnix_cdm_modes,
-				       &cm_nic->gni_cdm_hndl);
-		if (status != GNI_RC_SUCCESS) {
-			GNIX_ERR(FI_LOG_DOMAIN, "GNI_CdmCreate returned %s\n",
-				       gni_err_str[status]);
-			ret = gnixu_to_fi_errno(status);
-			goto err;
-		}
-
-		/*
-		 * Okay, now go for the attach
-		 */
-		status = GNI_CdmAttach(cm_nic->gni_cdm_hndl, 0, &device_addr,
-				       &cm_nic->gni_nic_hndl);
-		if (status != GNI_RC_SUCCESS) {
-			GNIX_ERR(FI_LOG_DOMAIN, "GNI_CdmAttach returned %s\n",
-			       gni_err_str[status]);
-			ret = gnixu_to_fi_errno(status);
-			goto err;
-		}
-
-		gnix_list_node_init(&cm_nic->list);
-		cm_nic->cdm_id = cdm_id;
-		cm_nic->ptag = ptag;
-		cm_nic->cookie = cookie;
-		cm_nic->device_addr = device_addr;
-		fastlock_init(&cm_nic->lock);
-
-		/*
-		 * prep the cm nic's dgram component
-		 */
-		ret = gnix_dgram_hndl_alloc(fabric, cm_nic,
-					    &cm_nic->dgram_hndl);
-		if (ret != FI_SUCCESS)
-			goto err;
-
-		atomic_init(&cm_nic->ref_cnt, 1);
-		list_add_tail(&gnix_cm_nic_list, &cm_nic->list);
-	}
-
-	*cm_nic_ptr = cm_nic;
-	return ret;
-
-err:
-	if (cm_nic->dgram_hndl)
-		gnix_dgram_hndl_free(cm_nic->dgram_hndl);
-
-	if (cm_nic->gni_cdm_hndl)
-		GNI_CdmDestroy(cm_nic->gni_cdm_hndl);
-
-	if (cm_nic != NULL)
-		free(cm_nic);
-
-	return ret;
-}
 
 /*******************************************************************************
  * API function implementations.
@@ -206,13 +83,6 @@ static int gnix_domain_close(fid_t fid)
 	}
 
 	GNIX_INFO(FI_LOG_DOMAIN, "gnix_domain_close invoked.\n");
-
-	if (domain->cm_nic) {
-		ret = gnix_cm_nic_free(domain->cm_nic);
-		if (ret != FI_SUCCESS)
-			goto err;
-		domain->cm_nic = NULL;
-	}
 
 	/*
 	 *  remove nics from the domain's nic list,
@@ -287,7 +157,6 @@ int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	int ret = FI_SUCCESS;
 	uint8_t ptag;
 	uint32_t cookie;
-	struct gnix_cm_nic *cm_nic = NULL;
 	struct gnix_fid_fabric *fabric_priv;
 
 	GNIX_INFO(FI_LOG_DOMAIN, "%s\n", __func__);
@@ -335,16 +204,12 @@ int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 
 	list_head_init(&domain->domain_wq);
 
-	ret = gnix_cm_nic_alloc(fabric_priv, ptag, cookie, getpid(), &cm_nic);
-	if (ret != FI_SUCCESS)
-		goto err;
-
 	domain->fabric = fabric_priv;
 	atomic_inc(&fabric_priv->ref_cnt);
 
-	domain->cm_nic = cm_nic;
 	domain->ptag = ptag;
 	domain->cookie = cookie;
+	domain->cdm_id_seed = getpid();  /*TODO: direct syscall better */
 	domain->gni_tx_cq_size = gnix_def_gni_tx_cq_size;
 	domain->gni_rx_cq_size = gnix_def_gni_rx_cq_size;
 	domain->gni_cq_modes = gnix_def_gni_cq_modes;
@@ -360,9 +225,6 @@ int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	return FI_SUCCESS;
 
 err:
-	if (cm_nic)
-		gnix_cm_nic_free(cm_nic);
-
 	if (domain != NULL) {
 		free(domain);
 	}

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Cray Inc. All rights reserved.
- * Copyright (c) 2015 Los Alamos National Security, LLC. Allrights reserved.
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -39,6 +39,7 @@
 #include <assert.h>
 
 #include "gnix.h"
+#include "gnix_cm_nic.h"
 #include "gnix_util.h"
 #include "gnix_ep.h"
 #include "gnix_ep_rdm.h"
@@ -487,6 +488,7 @@ static int gnix_ep_close(fid_t fid)
 	struct gnix_fid_ep *ep;
 	struct gnix_fid_domain *domain;
 	struct gnix_nic *nic;
+	struct gnix_cm_nic *cm_nic;
 
 	ep = container_of(fid, struct gnix_fid_ep, ep_fid.fid);
 	/* TODO: lots more stuff to do here */
@@ -495,6 +497,10 @@ static int gnix_ep_close(fid_t fid)
 	assert(domain != NULL);
 	atomic_dec(&domain->ref_cnt);
 	assert(atomic_get(&domain->ref_cnt) > 0);
+
+	cm_nic = ep->cm_nic;
+	assert(cm_nic != NULL);
+	gnix_cm_nic_free(cm_nic);
 
 	nic = ep->nic;
 	assert(nic != NULL);
@@ -565,7 +571,7 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 {
 	int ret = FI_SUCCESS;
 	struct gnix_fid_domain *domain_priv;
-	struct gnix_fid_ep *ep_priv;
+	struct gnix_fid_ep *ep_priv = NULL;
 	struct gnix_nic *elem, *nic = NULL;
 	gni_return_t status;
 	uint32_t device_addr;
@@ -580,9 +586,8 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 	domain_priv = container_of(domain, struct gnix_fid_domain, domain_fid);
 
 	ep_priv = calloc(1, sizeof *ep_priv);
-	if (!ep) {
+	if (!ep_priv)
 		return -FI_ENOMEM;
-	}
 
 	ep_priv->ep_fid.fid.fclass = FI_CLASS_EP;
 	ep_priv->ep_fid.fid.context = context;
@@ -605,6 +610,10 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 	 */
 	if (ep_priv->type == FI_EP_RDM) {
 		ep_priv->vc_hash_hndl = NULL;
+		ret = gnix_cm_nic_alloc(domain_priv,
+					 &ep_priv->cm_nic);
+		if (ret != FI_SUCCESS)
+			goto err_w_ep;
 	} else {
 		ep_priv->vc = NULL;
 	}
@@ -636,10 +645,9 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 
 	if (gnix_nics_per_ptag[domain_priv->ptag] ==
 					gnix_def_max_nics_per_ptag) {
-		list_for_each(&gnix_nic_list, elem, list) {
+		list_for_each(&gnix_nic_list, elem, gnix_nic_list) {
 			if ((elem->ptag == domain_priv->ptag) &&
-				(elem->cookie == domain_priv->cookie)
-				&& (elem->cdm_id == domain_priv->cdm_id)) {
+				(elem->cookie == domain_priv->cookie)) {
 				nic = elem;
 				break;
 			}
@@ -667,14 +675,10 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 			goto err_w_lock;
 		}
 
-		/*
-		 * cook up a fake cdm_id, use the 16 LSB of my pid
-		 * with 16 MSBs being obtained from atomic increment of
-		 * a local variable.
-		 */
-		atomic_inc(&gnix_id_counter);
-		fake_cdm_id = (domain_priv->cdm_id & 0x0000FFFF) |
-				((uint32_t)atomic_get(&gnix_id_counter) << 16);
+		ret = gnix_get_new_cdm_id(domain_priv, &fake_cdm_id);
+		if (ret != FI_SUCCESS)
+			goto err_w_lock;
+
 		status = GNI_CdmCreate(fake_cdm_id,
 					domain_priv->ptag,
 					domain_priv->cookie,
@@ -762,14 +766,15 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 			goto err_w_inc;
 		}
 
-		nic->cdm_id = ep_priv->domain->cm_nic->cdm_id;
-		nic->device_addr = ep_priv->domain->cm_nic->device_addr;
+		nic->device_addr = device_addr;
+		nic->ptag = domain_priv->ptag;
+		nic->cookie = domain_priv->cookie;
 
 		/*
 		 * TODO: set up work queue
 		 */
 
-		atomic_init(&nic->ref_cnt, 1);
+		atomic_init(&nic->ref_cnt, 0);
 		atomic_init(&nic->outstanding_fab_reqs_nic, 0);
 
 		list_add_tail(&gnix_nic_list, &nic->gnix_nic_list);
@@ -811,5 +816,11 @@ err_w_lock:
 	if (nic != NULL)
 		free(nic);
 	pthread_mutex_unlock(&gnix_nic_list_lock);
+err_w_ep:
+	if (ep_priv != NULL) {
+		if (ep_priv->cm_nic != NULL)
+			gnix_cm_nic_free(ep_priv->cm_nic);
+		free(ep_priv);
+	}
 	return ret;
 }

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -53,12 +53,12 @@
 #include "prov.h"
 
 #include "gnix.h"
+#include "gnix_cm_nic.h"
 #include "gnix_util.h"
 #include "gnix_nameserver.h"
 
 const char gnix_fab_name[] = "gni";
 const char gnix_dom_name[] = "/sys/class/gni/kgni0";
-atomic_t gnix_id_counter;
 
 /* TODO: this will need to be adjustable - probably set in GNI_INI*/
 uint32_t gnix_def_max_nics_per_ptag = 4;

--- a/prov/gni/src/gnix_util.c
+++ b/prov/gni/src/gnix_util.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2014 Intel Corporation, Inc.  All rights reserved.
- * Copyright (c) 2015 Los Alamos National Security, LLC. Allrights reserved.
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  * Copyright (c) 2015 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -164,6 +164,7 @@ err:
 	}
 	return ret;
 }
+
 
 #define NUM_GNI_RC (GNI_RC_ERROR_NOMEM+1)
 static int gnix_rc_table[NUM_GNI_RC] = {


### PR DESCRIPTION
Turns out trying to use gnix_cm_nic's on a per domain
basis isn't going to work very well for establishing
GNI smsg connections between FID_EP_RDM type EP's.
Trying to multiplex datagram messages using the same
nic_addr/cookie/cdm_id wasn't going to be easy.  So
instead, associate a separate gnix_cm_nic with each
ep created from a given domain.

Also, move the cdm_id generation into a single function
in the same file where the gnix_cm_nic code is located.
This cdm_id generation is used both for creating the
cm_nics and the data motion nics.

Fix a problem with the recycling of gnix_nic's too
with this commit.

@bturrubiates 
@sungeunchoi 
@ztiffany 

Signed-off-by: Howard Pritchard howardp@lanl.gov
