### PR TITLE
Remove use of tsearch, as per upstream commit c339608e

### DIFF
--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -479,7 +479,6 @@ struct fi_ops_tagged gnix_ep_tagged_ops = {
 	.senddata = fi_no_tagged_senddata,
 	.senddata = gnix_ep_tsenddata,
 	.injectdata = fi_no_tagged_injectdata,
-	.search = gnix_ep_tsearch,
 };
 
 static int gnix_ep_close(fid_t fid)


### PR DESCRIPTION
@bturrubiates @hppritcha @ztiffany 
