### PR TITLE
Add job/corespec configuration functions.

### DIFF
--- a/prov/gni/Makefile.am
+++ b/prov/gni/Makefile.am
@@ -29,7 +29,9 @@ _gni_files = \
 
 if HAVE_CRITERION
 bin_PROGRAMS = gnitest
-gnitest_SOURCES = prov/gni/test/cq.c
+gnitest_SOURCES = \
+	prov/gni/test/cq.c \
+	prov/gni/test/utils.c
 
 gnitest_LDFLAGS = -static
 gnitest_CPPFLAGS = $(AM_CPPFLAGS)

--- a/prov/gni/include/gnix_util.h
+++ b/prov/gni/include/gnix_util.h
@@ -65,5 +65,10 @@ extern struct fi_provider gnix_prov;
 int gnixu_get_rdma_credentials(void *addr, uint8_t *ptag, uint32_t *cookie);
 int gnixu_to_fi_errno(int err);
 
+int _gnix_task_is_not_app(void);
+int _gnix_job_enable_unassigned_cpus(void);
+int _gnix_job_disable_unassigned_cpus(void);
+int _gnix_job_enable_affinity_apply(void);
+int _gnix_job_disable_affinity_apply(void);
 
 #endif

--- a/prov/gni/test/utils.c
+++ b/prov/gni/test/utils.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2015 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <getopt.h>
+#include <poll.h>
+#include <time.h>
+#include <string.h>
+#include <linux/limits.h>
+#include <sys/syscall.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <rdma/fabric.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_errno.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_cm.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <inttypes.h>
+
+#include <criterion/criterion.h>
+#include "gnix_util.h"
+
+Test(utils, proc)
+{
+	int rc;
+
+	rc = _gnix_task_is_not_app();
+	expect(rc == 0);
+
+	/* *_unassigned_cpus flags don't work on tiger */
+	rc = _gnix_job_enable_unassigned_cpus();
+	expect(rc != 0);
+
+	rc = _gnix_job_disable_unassigned_cpus();
+	expect(rc != 0);
+
+	rc = _gnix_job_enable_affinity_apply();
+	expect(rc == 0);
+
+	rc = _gnix_job_disable_affinity_apply();
+	expect(rc == 0);
+
+}
+


### PR DESCRIPTION
Fixes ofi-cray/libfabric-cray#74.

Signed-off-by: Zach Tiffany ztiffany@cray.com

@sungeunchoi @hppritcha @bturrubiates 

I chose the _gnix naming convention for now.
