### PR TITLE
Topic/fix build

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -121,7 +121,7 @@ extern "C" {
 	(FI_MSG | FI_RMA | FI_TAGGED | FI_ATOMICS |                            \
 	 FI_DIRECTED_RECV | FI_MULTI_RECV | FI_INJECT | FI_SOURCE | FI_READ |  \
 	 FI_WRITE | FI_SEND | FI_RECV | FI_REMOTE_READ | FI_REMOTE_WRITE |     \
-	 FI_TRANSMIT_COMPLETE | FI_CANCEL | FI_FENCE)
+	 FI_TRANSMIT_COMPLETE | FI_FENCE)
 
 /*
  * see Operations flags in fi_endpoint.3

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -461,13 +461,6 @@ ssize_t gnix_ep_tsenddata(struct fid_ep *ep, const void *buf, size_t len,
 	return -FI_ENOSYS;
 }
 
-ssize_t gnix_ep_tsearch(struct fid_ep *ep, uint64_t *tag, uint64_t ignore,
-			uint64_t flags, fi_addr_t *src_addr, size_t *len,
-			void *context)
-{
-	return -FI_ENOSYS;
-}
-
 struct fi_ops_tagged gnix_ep_tagged_ops = {
 	.size = sizeof(struct fi_ops_tagged),
 	.recv = gnix_ep_trecv,


### PR DESCRIPTION
ofiwg/libfabric#912 introduced some API changes and it broke our build. The main issue was the deprecation of the FI_CANCEL flag. 
