### PR TITLE
Add interfaces to find max nics/rank.

### DIFF
--- a/prov/gni/include/gnix_util.h
+++ b/prov/gni/include/gnix_util.h
@@ -71,4 +71,9 @@ int _gnix_job_disable_unassigned_cpus(void);
 int _gnix_job_enable_affinity_apply(void);
 int _gnix_job_disable_affinity_apply(void);
 
+void _gnix_alps_cleanup(void);
+int _gnix_job_fma_limit(uint32_t dev_id, uint8_t ptag, uint32_t *limit);
+int _gnix_pes_on_node(uint32_t *num_pes);
+int _gnix_nics_per_rank(uint32_t *nics_per_rank);
+
 #endif

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -108,6 +108,8 @@ static int gnix_fabric_close(fid_t fid)
 		return -FI_EBUSY;
 	}
 
+	_gnix_alps_cleanup();
+
 	free(fab);
 	return FI_SUCCESS;
 }

--- a/prov/gni/test/utils.c
+++ b/prov/gni/test/utils.c
@@ -77,3 +77,29 @@ Test(utils, proc)
 
 }
 
+Test(utils, alps)
+{
+	int rc;
+	uint8_t ptag;
+	uint32_t cookie, fmas, npes, npr;
+	void *addr = NULL;
+
+	_gnix_alps_cleanup();
+
+	rc = gnixu_get_rdma_credentials(addr, &ptag, &cookie);
+	expect(!rc);
+
+	rc = _gnix_job_fma_limit(0, ptag, &fmas);
+	expect(!rc);
+
+	rc = _gnix_pes_on_node(&npes);
+	expect(!rc);
+
+	rc = _gnix_nics_per_rank(&npr);
+	expect(!rc);
+
+	expect((fmas / npes) == npr);
+
+	_gnix_alps_cleanup();
+}
+


### PR DESCRIPTION
Fixes ofi-cray/libfabric-cray#49.

Signed-off-by: Zach Tiffany ztiffany@cray.com

@hppritcha @bturrubiates @sungeunchoi 

This mod pulls a lot more info out of alps and stores it in global variables.  The alps initialization is done when the first domain is created and freed when a fabric is closed.
