### PR TITLE
Change atomic_init to atomic_initialize as per upstream commit fd427eb09...

### DIFF
--- a/prov/gni/src/gnix_av.c
+++ b/prov/gni/src/gnix_av.c
@@ -522,7 +522,7 @@ int gnix_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	int_av->av_fid.fid.context = context;
 	int_av->av_fid.fid.ops = &gnix_fi_av_ops;
 	int_av->av_fid.ops = &gnix_av_ops;
-	atomic_init(&int_av->ref_cnt, 0);
+	atomic_initialize(&int_av->ref_cnt, 0);
 
 	*av = &int_av->av_fid;
 

--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -467,7 +467,7 @@ int gnix_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 
 	cq_priv->domain = domain_priv;
 	cq_priv->attr = *attr;
-	atomic_init(&cq_priv->ref_cnt, 0);
+	atomic_initialize(&cq_priv->ref_cnt, 0);
 	atomic_inc(&cq_priv->domain->ref_cnt);
 
 	cq_priv->cq_fid.fid.fclass = FI_CLASS_CQ;

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -538,7 +538,7 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 	ep_priv->ep_fid.ops = &gnix_ep_ops;
 	ep_priv->domain = domain_priv;
 	ep_priv->type = info->ep_attr->type;
-	atomic_init(&ep_priv->active_fab_reqs, 0);
+	atomic_initialize(&ep_priv->active_fab_reqs, 0);
 
 	ep_priv->ep_fid.msg = &gnix_ep_msg_ops;
 	ep_priv->ep_fid.rma = &gnix_ep_rma_ops;

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -145,7 +145,7 @@ static int gnix_fabric_open(struct fi_fabric_attr *attr,
 	fab->fab_fid.fid.context = context;
 	fab->fab_fid.fid.ops = &gnix_fab_fi_ops;
 	fab->fab_fid.ops = &gnix_fab_ops;
-	atomic_init(&fab->ref_cnt, 0);
+	atomic_initialize(&fab->ref_cnt, 0);
 	list_head_init(&fab->domain_list);
 
 	*fabric = &fab->fab_fid;
@@ -415,7 +415,7 @@ GNI_INI
 		provider = &gnix_prov;
 	}
 
-	atomic_init(&gnix_id_counter, 0);
+	atomic_initialize(&gnix_id_counter, 0);
 
 	return (provider);
 }

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -307,8 +307,8 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 		 * TODO: set up work queue
 		 */
 
-		atomic_init(&nic->ref_cnt, 1);
-		atomic_init(&nic->outstanding_fab_reqs_nic, 0);
+		atomic_initialize(&nic->ref_cnt, 1);
+		atomic_initialize(&nic->outstanding_fab_reqs_nic, 0);
 
 		list_add_tail(&gnix_nic_list, &nic->gnix_nic_list);
 		++gnix_nics_per_ptag[domain->ptag];


### PR DESCRIPTION
Should fix build issue.  Criterion tests still broken.

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com
@hppritcha @bturrubiates 
