### PR TITLE
Fix conflict of assert definition by including criterion last and undefi...

### DIFF
--- a/prov/gni/test/cq.c
+++ b/prov/gni/test/cq.c
@@ -48,8 +48,13 @@
 #include <stdlib.h>
 #include <inttypes.h>
 
-#include <criterion/criterion.h>
 #include "gnix_cq.h"
+
+#ifdef assert
+#undef assert
+#endif
+
+#include <criterion/criterion.h>
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;


### PR DESCRIPTION
...ning assert beforehand.

Signed-off-by: Ben Turrubiates bturrubiates@lanl.gov
