### PR TITLE
Initial bitmap implementation

### DIFF
--- a/prov/gni/Makefile.am
+++ b/prov/gni/Makefile.am
@@ -25,7 +25,8 @@ _gni_files = \
 	prov/gni/src/gnix_datagram.c \
 	prov/gni/src/gnix_cm_nic.c \
 	prov/gni/src/gnix_nic.c \
-	prov/gni/src/gnix_util.c
+	prov/gni/src/gnix_util.c \
+	prov/gni/src/gnix_bitmap.c
 
 if HAVE_CRITERION
 bin_PROGRAMS = gnitest
@@ -33,7 +34,8 @@ gnitest_SOURCES = \
 	prov/gni/test/cq.c \
 	prov/gni/test/utils.c \
 	prov/gni/test/wait.c \
-	prov/gni/test/datagram.c
+	prov/gni/test/datagram.c \
+	prov/gni/test/bitmap.c
 
 gnitest_LDFLAGS = -static
 gnitest_CPPFLAGS = $(AM_CPPFLAGS)

--- a/prov/gni/include/gnix_bitmap.h
+++ b/prov/gni/include/gnix_bitmap.h
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2015 Cray Inc. All rights reserved.
+ *
+ *  Created on: Apr 16, 2015
+ *      Author: jswaro
+ */
+
+#ifndef BITMAP_H_
+#define BITMAP_H_
+
+#include <stdint.h>
+#include <pthread.h>
+#include <errno.h>
+#include "fi.h"
+
+#define GNIX_BITMAP_BUCKET_BITS 6
+#define GNIX_BITMAP_BUCKET_LENGTH (1ULL << GNIX_BITMAP_BUCKET_BITS)
+#define GNIX_BUCKET_INDEX(index) ((index) >> GNIX_BITMAP_BUCKET_BITS)
+#define GNIX_BIT_INDEX(index) ((index) % GNIX_BITMAP_BUCKET_LENGTH)
+#define GNIX_BIT_VALUE(index) (1ULL << GNIX_BIT_INDEX(index))
+
+#define __PARTIAL_BLOCKS(nbits) (((nbits) % GNIX_BITMAP_BUCKET_LENGTH) ? 1 : 0)
+#define __FULL_BLOCKS(nbits) ((nbits) >> GNIX_BITMAP_BUCKET_BITS)
+#define GNIX_BITMAP_BLOCKS(nbits) \
+	(__FULL_BLOCKS(nbits) + __PARTIAL_BLOCKS(nbits))
+
+typedef uint64_t gnix_bitmap_value_t;
+
+#if HAVE_ATOMICS
+#include <stdatomic.h>
+
+typedef atomic_uint_fast64_t gnix_bitmap_block_t;
+#else
+typedef struct atomic_uint64_t {
+	fastlock_t lock;
+	gnix_bitmap_value_t val;
+} gnix_bitmap_block_t;
+#endif
+
+typedef enum gnix_bitmap_state {
+	GNIX_BITMAP_STATE_UNINITIALIZED = 0,
+	GNIX_BITMAP_STATE_READY,
+	GNIX_BITMAP_STATE_FREE,
+} gnix_bitmap_state_e;
+
+typedef struct gnix_bitmap {
+	gnix_bitmap_state_e state;
+	uint32_t length;
+	gnix_bitmap_block_t *arr;
+} gnix_bitmap_t;
+
+#if HAVE_ATOMICS
+
+#define __gnix_init_block(block) atomic_init(block, 0)
+#define __gnix_set_block(bitmap, index, value) \
+	atomic_store(&(bitmap)->arr[(index)], (value))
+#define __gnix_load_block(bitmap, index) atomic_load(&(bitmap->arr[(index)]))
+#define __gnix_set_bit(bitmap, bit) \
+	atomic_fetch_or(&(bitmap)->arr[GNIX_BUCKET_INDEX(bit)], \
+			GNIX_BIT_VALUE(bit))
+#define __gnix_clear_bit(bitmap, bit) \
+	atomic_fetch_and(&(bitmap)->arr[GNIX_BUCKET_INDEX(bit)], \
+			~GNIX_BIT_VALUE(bit))
+#define __gnix_test_bit(bitmap, bit) \
+	((atomic_load(&(bitmap)->arr[GNIX_BUCKET_INDEX(bit)]) \
+			& GNIX_BIT_VALUE(bit)) != 0)
+#else
+
+static inline void __gnix_init_block(gnix_bitmap_block_t *block)
+{
+	fastlock_init(&block->lock);
+	block->val = 0llu;
+}
+
+static inline void __gnix_set_block(gnix_bitmap_t *bitmap, int index,
+		uint64_t value)
+{
+	gnix_bitmap_block_t *block = &bitmap->arr[index];
+
+	fastlock_acquire(&block->lock);
+	block->val = value;
+	fastlock_release(&block->lock);
+}
+
+static inline uint64_t __gnix_load_block(gnix_bitmap_t *bitmap, int index)
+{
+	gnix_bitmap_block_t *block = &bitmap->arr[index];
+	uint64_t ret;
+
+	fastlock_acquire(&block->lock);
+	ret = block->val;
+	fastlock_release(&block->lock);
+
+	return ret;
+}
+
+static inline uint64_t __gnix_set_bit(gnix_bitmap_t *bitmap, int bit)
+{
+	gnix_bitmap_block_t *block = &bitmap->arr[GNIX_BUCKET_INDEX(bit)];
+	uint64_t ret;
+
+	fastlock_acquire(&block->lock);
+	ret = block->val;
+	block->val |= GNIX_BIT_VALUE(bit);
+	fastlock_release(&block->lock);
+
+	return ret;
+}
+
+static inline uint64_t __gnix_clear_bit(gnix_bitmap_t *bitmap, int bit)
+{
+	gnix_bitmap_block_t *block = &bitmap->arr[GNIX_BUCKET_INDEX(bit)];
+	uint64_t ret;
+
+	fastlock_acquire(&block->lock);
+	ret = block->val;
+	block->val &= ~GNIX_BIT_VALUE(bit);
+	fastlock_release(&block->lock);
+
+	return ret;
+}
+
+static inline int __gnix_test_bit(gnix_bitmap_t *bitmap, int bit)
+{
+	gnix_bitmap_block_t *block = &bitmap->arr[GNIX_BUCKET_INDEX(bit)];
+	int ret;
+
+	fastlock_acquire(&block->lock);
+	ret = (block->val & GNIX_BIT_VALUE(bit)) != 0;
+	fastlock_release(&block->lock);
+
+	return ret;
+}
+#endif
+
+/**
+ * Tests to see if a bit has been set in the bit.
+ *
+ * @param   bitmap  a gnix_bitmap pointer to the bitmap struct
+ * @param   index   index of the bit in the map to test
+ * @return  0 if the bit is not set, 1 if the bit is set
+ */
+static inline int test_bit(gnix_bitmap_t *bitmap, uint32_t index)
+{
+	return __gnix_test_bit(bitmap, index);
+}
+
+/**
+ * Sets a bit in the bitmap
+ *
+ * @param   bitmap  a gnix_bitmap pointer to the bitmap struct
+ * @param   index   index of the bit in the map to set
+ */
+static inline void set_bit(gnix_bitmap_t *bitmap, uint32_t index)
+{
+	__gnix_set_bit(bitmap, index);
+}
+
+/**
+ * Clears a bit in the bitmap
+ *
+ * @param   bitmap  a gnix_bitmap pointer to the bitmap struct
+ * @param   index   index of the bit in the map to clear
+ */
+static inline void clear_bit(gnix_bitmap_t *bitmap, uint32_t index)
+{
+	__gnix_clear_bit(bitmap, index);
+}
+
+/**
+ * Tests to see if a bit is set, then sets the bit in the bitmap
+ *
+ * @param   bitmap  a gnix_bitmap pointer to the bitmap struct
+ * @param   index   index of the bit in the map to test and set
+ * @return  0 if the bit was not set, 1 if the bit was already set
+ */
+static inline int test_and_set_bit(gnix_bitmap_t *bitmap, uint32_t index)
+{
+	return (__gnix_set_bit(bitmap, index) & GNIX_BIT_VALUE(index)) != 0;
+}
+
+/**
+ * Tests to see if a bit is set, the clears the bit in the bitmap
+ *
+ * @param   bitmap  a gnix_bitmap pointer to the bitmap struct
+ * @param   index   index of the bit in the map to test and set
+ * @return  0 if the bit was not set, 1 if the bit was already set
+ */
+static inline int test_and_clear_bit(gnix_bitmap_t *bitmap, uint32_t index)
+{
+	return (__gnix_clear_bit(bitmap, index) & GNIX_BIT_VALUE(index)) != 0;
+}
+
+/**
+ * Takes a gnix_bitmap and allocates the internal structures and performs
+ *   generic setup based on the number of bits requested
+ *
+ * @param   bitmap  a gnix_bitmap pointer to the bitmap struct
+ * @param   nbits   number of bits to request space for
+ * @return  0       on success
+ * @return  -EINVAL if bitmap is already initialized, or 0 is given as nbits
+ * @return  -ENOMEM if there isn't sufficient memory available to create bitmap
+ */
+int alloc_bitmap(gnix_bitmap_t *bitmap, uint32_t nbits);
+
+/**
+ * Takes a gnix_bitmap and reallocates the internal structures to the requested
+ *   size given in bits
+ *
+ * @note    On return of a ENOMEM error code, the bitmap will not be
+ *          resized and will still be a valid and operable bitmap.
+ *          The ENOMEM error only serves to indication that resources
+ *          are	limited.
+ *
+ * @param   bitmap  a gnix_bitmap pointer to the bitmap struct
+ * @param   nbits   number of bits to resize the bitmap to
+ * @return  0       on success
+ * @return  -EINVAL if the bitmap hasn't been allocated yet or nbits == 0
+ * @return  -ENOMEM if there wasn't sufficient memory to expand the bitmap.
+ */
+int realloc_bitmap(gnix_bitmap_t *bitmap, uint32_t nbits);
+
+/**
+ * Frees the internal structures of gnix_bitmap
+ *
+ * @param   bitmap  a gnix_bitmap pointer to the bitmap struct
+ * @return  0       on success
+ * @return  -EINVAL if the internal resources are uninitialized or already free
+ */
+int free_bitmap(gnix_bitmap_t *bitmap);
+
+/**
+ * Sets every bit in the bitmap with (value != 0)
+ *
+ * @param   bitmap  a gnix_bitmap pointer to the bitmap struct
+ * @param   value   an integer value to be compared with 0 to set bits to
+ */
+void fill_bitmap(gnix_bitmap_t *bitmap, uint64_t value);
+
+/**
+ * Finds the bit index of the first zero bit in the bitmap
+ *
+ * @param   bitmap	a gnix_bitmap pointer to the bitmap struct
+ * @return  index	on success, returns an index s.t.
+ *                    0 <= index < bitmap->length
+ * @return  -EAGAIN on failure to find a zero bit
+ */
+int find_first_zero_bit(gnix_bitmap_t *bitmap);
+
+/**
+ * Finds the bit index of the first set bit in the bitmap
+ *
+ * @param   bitmap  a gnix_bitmap pointer to the bitmap struct
+ * @return  index   on success, returns a index s.t.
+ *                    0 <= index < bitmap->length
+ * @return  -EAGAIN on failure to find a set bit
+ */
+int find_first_set_bit(gnix_bitmap_t *bitmap);
+
+/**
+ * Tests to verify that the bitmap is full
+ *
+ * @param   bitmap  a gnix_bitmap pointer to the bitmap struct
+ * @return  0 if the bitmap has cleared bits, 1 if the bitmap is fully set
+ */
+static inline int bitmap_full(gnix_bitmap_t *bitmap)
+{
+	return find_first_zero_bit(bitmap) == -EAGAIN;
+}
+
+/**
+ * Tests to verify that the bitmap is empty
+ *
+ * @param   bitmap  a gnix_bitmap pointer to the bitmap struct
+ * @return  0 if the bitmap has set bits, 1 if the bitmap is fully cleared
+ */
+static inline int bitmap_empty(gnix_bitmap_t *bitmap)
+{
+	return find_first_set_bit(bitmap) == -EAGAIN;
+}
+
+#endif /* BITMAP_H_ */

--- a/prov/gni/src/gnix_bitmap.c
+++ b/prov/gni/src/gnix_bitmap.c
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2015 Cray Inc. All rights reserved.
+ *
+ *  Created on: Apr 16, 2015
+ *      Author: jswaro
+ */
+
+#include <stdlib.h>
+#include <errno.h>
+#include "gnix_bitmap.h"
+
+int find_first_zero_bit(gnix_bitmap_t *bitmap)
+{
+	int i, pos;
+	gnix_bitmap_value_t value;
+
+	for (i = 0, pos = 0;
+			i < GNIX_BITMAP_BLOCKS(bitmap->length);
+			++i, pos += GNIX_BITMAP_BUCKET_LENGTH) {
+		/* invert the bits to check for first zero bit */
+		value = ~(__gnix_load_block(bitmap, i));
+
+		if (value != 0) {
+			/* no need to check for errors because we have
+			   established there is an unset bit */
+			pos += ffsll(value) - 1;
+
+			return pos;
+		}
+	}
+
+	return -EAGAIN;
+}
+
+int find_first_set_bit(gnix_bitmap_t *bitmap)
+{
+	int i, pos;
+	gnix_bitmap_value_t value;
+
+	for (i = 0, pos = 0;
+			i < GNIX_BITMAP_BLOCKS(bitmap->length);
+			++i, pos += GNIX_BITMAP_BUCKET_LENGTH) {
+		value = __gnix_load_block(bitmap, i);
+
+		if (value != 0) {
+			/* no need to check for errors because we have
+			   established there is a set bit */
+			pos += ffsll(value) - 1;
+
+			return pos;
+		}
+	}
+
+	return -EAGAIN;
+}
+
+void fill_bitmap(gnix_bitmap_t *bitmap, uint64_t value)
+{
+	int i;
+	gnix_bitmap_value_t fill_value = (value != 0) ? ~0 : 0;
+
+	for (i = 0; i < GNIX_BITMAP_BLOCKS(bitmap->length); ++i) {
+		__gnix_set_block(bitmap, i, fill_value);
+	}
+}
+
+int alloc_bitmap(gnix_bitmap_t *bitmap, uint32_t nbits)
+{
+	int i;
+
+	if (bitmap->state == GNIX_BITMAP_STATE_READY)
+		return -EINVAL;
+
+	if (bitmap->length != 0 || nbits == 0)
+		return -EINVAL;
+
+	bitmap->arr = calloc(GNIX_BITMAP_BLOCKS(nbits),
+			sizeof(gnix_bitmap_block_t));
+	if (!bitmap->arr)
+		return -ENOMEM;
+
+	bitmap->length = nbits;
+
+	for (i = 0; i < GNIX_BITMAP_BLOCKS(bitmap->length); ++i)
+		__gnix_init_block(&bitmap->arr[i]);
+
+	bitmap->state = GNIX_BITMAP_STATE_READY;
+
+	return 0;
+}
+
+int realloc_bitmap(gnix_bitmap_t *bitmap, uint32_t nbits)
+{
+	gnix_bitmap_block_t *new_allocation;
+	int blocks_to_allocate = GNIX_BITMAP_BLOCKS(nbits);
+	int i;
+
+	if (bitmap->state != GNIX_BITMAP_STATE_READY)
+		return -EINVAL;
+
+	if (nbits == 0 || bitmap->arr == NULL)
+		return -EINVAL;
+
+	new_allocation = realloc(bitmap->arr,
+			(blocks_to_allocate *
+					sizeof(gnix_bitmap_block_t)));
+
+	if (!new_allocation)
+		return -ENOMEM;
+
+	bitmap->arr = new_allocation;
+
+	/* Did we increase the size of the bitmap?
+	 * If so, initialize new blocks */
+	if (blocks_to_allocate > GNIX_BITMAP_BLOCKS(bitmap->length)) {
+		for (i = GNIX_BITMAP_BLOCKS(bitmap->length);
+				i < blocks_to_allocate;
+				++i) {
+			__gnix_init_block(&bitmap->arr[i]);
+		}
+	}
+
+	bitmap->length = nbits;
+
+	return 0;
+}
+
+int free_bitmap(gnix_bitmap_t *bitmap)
+{
+	if (bitmap->state != GNIX_BITMAP_STATE_READY)
+		return -EINVAL;
+
+	bitmap->length = 0;
+	if (bitmap->arr) {
+		free(bitmap->arr);
+		bitmap->arr = NULL;
+	}
+
+	bitmap->state = GNIX_BITMAP_STATE_FREE;
+
+	return 0;
+}
+

--- a/prov/gni/test/bitmap.c
+++ b/prov/gni/test/bitmap.c
@@ -1,0 +1,499 @@
+/*
+ * Copyright (c) 2015 Cray Inc. All rights reserved.
+ *
+ *  Created on: Apr 23, 2015
+ *      Author: jswaro
+ */
+
+#include <stdlib.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdint.h>
+
+#include <errno.h>
+#include <gnix_bitmap.h>
+
+#ifdef assert
+#undef assert
+#endif
+
+#include <criterion/criterion.h>
+
+gnix_bitmap_t *test_bitmap = NULL;
+int call_free_bitmap = 0;
+
+void calculate_time_difference(struct timeval *start, struct timeval *end,
+		int *secs_out, int *usec_out)
+{
+	*secs_out = end->tv_sec - start->tv_sec;
+	if (end->tv_usec < start->tv_usec) {
+		*secs_out = *secs_out - 1;
+		*usec_out = (1000000 + end->tv_usec) - start->tv_usec;
+	} else {
+		*usec_out = end->tv_usec - start->tv_usec;
+	}
+}
+
+void __gnix_bitmap_test_setup(void)
+{
+	assert(test_bitmap == NULL);
+	test_bitmap = (gnix_bitmap_t *) calloc(1, sizeof(test_bitmap));
+	memset(test_bitmap, 0, sizeof(gnix_bitmap_t));
+	assert(test_bitmap != NULL);
+
+	call_free_bitmap = 1;
+}
+
+void __gnix_bitmap_test_teardown(void)
+{
+	if (call_free_bitmap) {
+		free_bitmap(test_bitmap);
+	} else if (test_bitmap && test_bitmap->arr) {
+		free(test_bitmap->arr);
+	}
+
+	assert(test_bitmap != NULL);
+	free(test_bitmap);
+	test_bitmap = NULL;
+}
+
+
+static void __test_clean_bitmap_state(gnix_bitmap_t *bitmap,
+		int _length, gnix_bitmap_state_e _state)
+{
+	assert(bitmap->arr != NULL);
+	assert(bitmap->length == _length);
+	assert(bitmap->state == _state);
+}
+
+static void __test_initialize_bitmap(gnix_bitmap_t *bitmap, int bits)
+{
+	int ret = alloc_bitmap(bitmap, bits);
+
+	assert(ret == 0);
+	__test_clean_bitmap_state(bitmap, bits, GNIX_BITMAP_STATE_READY);
+}
+
+static void __test_initialize_bitmap_clean(gnix_bitmap_t *bitmap, int bits)
+{
+	__test_initialize_bitmap(bitmap, bits);
+	assert(bitmap_empty(bitmap));
+}
+
+static void __test_realloc_bitmap(gnix_bitmap_t *bitmap, int bits)
+{
+	int ret = realloc_bitmap(bitmap, bits);
+
+	assert(ret == 0);
+	__test_clean_bitmap_state(bitmap, bits,	GNIX_BITMAP_STATE_READY);
+}
+
+static void __test_realloc_bitmap_clean(gnix_bitmap_t *bitmap, int initial,
+		int next)
+{
+	__test_initialize_bitmap(bitmap, initial);
+	__test_realloc_bitmap(bitmap, next);
+	assert(bitmap_empty(bitmap));
+}
+
+static void __test_free_bitmap_clean(gnix_bitmap_t *bitmap)
+{
+	int ret = free_bitmap(bitmap);
+
+	assert(ret == 0);
+	assert(bitmap->arr == NULL);
+	assert(bitmap->length == 0);
+	assert(bitmap->state == GNIX_BITMAP_STATE_FREE);
+}
+
+/*
+ * Basic functionality tests for the gnix_bitmap_t object
+ */
+
+TestSuite(gnix_bitmap,
+		.init = __gnix_bitmap_test_setup,
+		.fini = __gnix_bitmap_test_teardown);
+
+Test(gnix_bitmap, uninitialized)
+{
+	assert(test_bitmap->arr == NULL);
+	assert(test_bitmap->length == 0);
+	assert(test_bitmap->state == GNIX_BITMAP_STATE_UNINITIALIZED);
+
+	call_free_bitmap = 0;
+}
+
+Test(gnix_bitmap, initialize_128)
+{
+	__test_initialize_bitmap(test_bitmap, 128);
+
+	call_free_bitmap = 0;
+}
+
+Test(gnix_bitmap, initialize_1)
+{
+	__test_initialize_bitmap(test_bitmap, 1);
+
+	call_free_bitmap = 0;
+}
+
+Test(gnix_bitmap, initialize_0)
+{
+	int ret;
+
+	ret = alloc_bitmap(test_bitmap, 0);
+	assert(ret == -EINVAL);
+
+	call_free_bitmap = 0;
+}
+
+Test(gnix_bitmap, already_initialized)
+{
+	int ret;
+
+	__test_initialize_bitmap(test_bitmap, 128);
+
+	ret = alloc_bitmap(test_bitmap, 128);
+	assert(ret == -EINVAL);
+
+	call_free_bitmap = 0;
+}
+
+Test(gnix_bitmap, destroy_bitmap)
+{
+	__test_initialize_bitmap(test_bitmap, 128);
+
+	__test_free_bitmap_clean(test_bitmap);
+}
+
+Test(gnix_bitmap, destroy_bitmap_uninitialized)
+{
+	int ret;
+
+	ret = free_bitmap(test_bitmap);
+	assert(ret == -EINVAL);
+	expect(test_bitmap->arr == NULL);
+	expect(test_bitmap->length == 0);
+	expect(test_bitmap->state == GNIX_BITMAP_STATE_UNINITIALIZED);
+}
+
+Test(gnix_bitmap, destroy_bitmap_already_freed)
+{
+	int ret;
+
+	__test_initialize_bitmap(test_bitmap, 128);
+
+	__test_free_bitmap_clean(test_bitmap);
+
+	ret = free_bitmap(test_bitmap);
+	assert(ret == -EINVAL);
+	expect(test_bitmap->arr == NULL);
+	expect(test_bitmap->length == 0);
+	expect(test_bitmap->state == GNIX_BITMAP_STATE_FREE);
+}
+
+Test(gnix_bitmap, realloc_63)
+{
+	__test_realloc_bitmap_clean(test_bitmap, 128, 63);
+}
+
+Test(gnix_bitmap, realloc_64)
+{
+	__test_realloc_bitmap_clean(test_bitmap, 128, 64);
+}
+
+Test(gnix_bitmap, realloc_65)
+{
+	__test_realloc_bitmap_clean(test_bitmap, 128, 65);
+}
+
+Test(gnix_bitmap, realloc_255)
+{
+	__test_realloc_bitmap_clean(test_bitmap, 128, 255);
+}
+
+Test(gnix_bitmap, realloc_256)
+{
+	__test_realloc_bitmap_clean(test_bitmap, 128, 256);
+}
+
+Test(gnix_bitmap, realloc_257)
+{
+	__test_realloc_bitmap_clean(test_bitmap, 128, 257);
+}
+
+Test(gnix_bitmap, realloc_63_check_bits)
+{
+	__test_realloc_bitmap_clean(test_bitmap, 128, 63);
+}
+
+Test(gnix_bitmap, realloc_64_check_bits)
+{
+	__test_realloc_bitmap_clean(test_bitmap, 128, 64);
+}
+
+Test(gnix_bitmap, realloc_65_check_bits)
+{
+	__test_realloc_bitmap_clean(test_bitmap, 128, 65);
+}
+
+Test(gnix_bitmap, realloc_255_check_bits)
+{
+	__test_realloc_bitmap_clean(test_bitmap, 128, 255);
+}
+
+Test(gnix_bitmap, realloc_256_check_bits)
+{
+	__test_realloc_bitmap_clean(test_bitmap, 128, 256);
+}
+
+Test(gnix_bitmap, realloc_257_check_bits)
+{
+	__test_realloc_bitmap_clean(test_bitmap, 128, 257);
+}
+
+Test(gnix_bitmap, bit_set_test_pass)
+{
+	__test_initialize_bitmap_clean(test_bitmap, 64);
+
+	set_bit(test_bitmap, 1);
+
+	assert(test_bit(test_bitmap, 1));
+}
+
+Test(gnix_bitmap, bit_set_test_fail)
+{
+	__test_initialize_bitmap_clean(test_bitmap, 64);
+
+	set_bit(test_bitmap, 1);
+
+	assert(!test_bit(test_bitmap, 0));
+}
+
+Test(gnix_bitmap, bit_set_clear)
+{
+	__test_initialize_bitmap_clean(test_bitmap, 64);
+
+	set_bit(test_bitmap, 1);
+
+	assert(test_bit(test_bitmap, 1));
+
+	clear_bit(test_bitmap, 1);
+
+	assert(!test_bit(test_bitmap, 1));
+}
+
+Test(gnix_bitmap, bit_clear)
+{
+	__test_initialize_bitmap_clean(test_bitmap, 64);
+
+	clear_bit(test_bitmap, 1);
+
+	assert(!test_bit(test_bitmap, 1));
+}
+
+Test(gnix_bitmap, bit_set)
+{
+	__test_initialize_bitmap_clean(test_bitmap, 64);
+
+	set_bit(test_bitmap, 1);
+}
+
+Test(gnix_bitmap, bit_test_and_set_unset)
+{
+	__test_initialize_bitmap_clean(test_bitmap, 64);
+
+	assert(!test_and_set_bit(test_bitmap, 1));
+}
+
+Test(gnix_bitmap, bit_test_and_set_already_set)
+{
+	__test_initialize_bitmap_clean(test_bitmap, 64);
+
+	set_bit(test_bitmap, 1);
+	assert(test_bit(test_bitmap, 1));
+
+	assert(test_and_set_bit(test_bitmap, 1));
+}
+
+Test(gnix_bitmap, bit_test_and_clear_unset)
+{
+	__test_initialize_bitmap_clean(test_bitmap, 64);
+
+	assert(!test_and_clear_bit(test_bitmap, 1));
+}
+
+Test(gnix_bitmap, bit_test_and_clear_already_set)
+{
+	__test_initialize_bitmap_clean(test_bitmap, 64);
+
+	set_bit(test_bitmap, 1);
+	assert(test_bit(test_bitmap, 1));
+
+	assert(test_and_clear_bit(test_bitmap, 1));
+}
+
+Test(gnix_bitmap, ffs_clean_bitmap)
+{
+	__test_initialize_bitmap_clean(test_bitmap, 64);
+
+	assert(find_first_set_bit(test_bitmap) == -EAGAIN);
+}
+
+Test(gnix_bitmap, ffs_first_bit_set)
+{
+	__test_initialize_bitmap_clean(test_bitmap, 64);
+
+	set_bit(test_bitmap, 0);
+
+	assert(find_first_set_bit(test_bitmap) == 0);
+}
+
+Test(gnix_bitmap, ffs_seventeen_set)
+{
+	__test_initialize_bitmap_clean(test_bitmap, 64);
+
+	set_bit(test_bitmap, 17);
+
+	assert(find_first_set_bit(test_bitmap) == 17);
+}
+
+Test(gnix_bitmap, ffz_clean_bitmap)
+{
+	__test_initialize_bitmap_clean(test_bitmap, 64);
+
+	assert(find_first_zero_bit(test_bitmap) == 0);
+}
+
+Test(gnix_bitmap, ffz_full_bitmap)
+{
+	int i;
+
+	__test_initialize_bitmap_clean(test_bitmap, 64);
+
+	for (i = 0; i < test_bitmap->length; ++i) {
+		set_bit(test_bitmap, i);
+		assert(test_bit(test_bitmap, i));
+	}
+
+	assert(find_first_zero_bit(test_bitmap) == -EAGAIN);
+}
+
+Test(gnix_bitmap, ffz_first_half_set)
+{
+	int i;
+
+	__test_initialize_bitmap_clean(test_bitmap, 64);
+
+	for (i = 0; i < 32 ; ++i) {
+		set_bit(test_bitmap, i);
+		assert(test_bit(test_bitmap, i));
+	}
+
+	expect(test_bitmap->length == 64);
+	expect(i == 32);
+	assert(find_first_zero_bit(test_bitmap) == i);
+}
+
+Test(gnix_bitmap, map_fill_0)
+{
+	int i;
+
+	__test_initialize_bitmap_clean(test_bitmap, 64);
+
+	for (i = 0; i < test_bitmap->length; ++i) {
+		set_bit(test_bitmap, i);
+		assert(test_bit(test_bitmap, i));
+	}
+
+	assert(bitmap_full(test_bitmap));
+
+	fill_bitmap(test_bitmap, 0);
+
+	assert(bitmap_empty(test_bitmap));
+}
+
+Test(gnix_bitmap, map_fill_1)
+{
+	__test_initialize_bitmap_clean(test_bitmap, 64);
+
+	fill_bitmap(test_bitmap, 1);
+
+	assert(bitmap_full(test_bitmap));
+}
+
+Test(gnix_bitmap, bitmap_load)
+{
+	gnix_bitmap_value_t expected = ~0;
+
+	__test_initialize_bitmap_clean(test_bitmap, 64);
+
+	fill_bitmap(test_bitmap, 1);
+
+	assert(expected == __gnix_load_block(test_bitmap, 0));
+}
+
+Test(gnix_bitmap, bitmap_set)
+{
+	gnix_bitmap_value_t expected = ~0;
+
+	__test_initialize_bitmap_clean(test_bitmap, 64);
+
+	__gnix_set_block(test_bitmap, 0, expected);
+
+	assert(__gnix_load_block(test_bitmap, 0) == expected);
+}
+
+
+Test(gnix_bitmap, performance_set_test)
+{
+	int i, j;
+	int secs, usec;
+	struct timeval start, end;
+
+	__test_initialize_bitmap_clean(test_bitmap, 8192);
+
+	gettimeofday(&start, 0);
+	for (i = 0; i < 100000; ++i) {
+		j = i % 8192;
+		set_bit(test_bitmap, j);
+		assert(test_bit(test_bitmap, j));
+		clear_bit(test_bitmap, j);
+		assert(!test_bit(test_bitmap, j));
+	}
+	gettimeofday(&end, 0);
+
+	calculate_time_difference(&start, &end, &secs, &usec);
+
+	assert(bitmap_empty(test_bitmap));
+
+	expect(secs < 1);
+}
+
+Test(gnix_bitmap, performance_set_test_random)
+{
+	int i, j;
+	int secs, usec;
+	struct timeval start, end;
+
+	srand(time(NULL));
+
+	__test_initialize_bitmap_clean(test_bitmap, 8192);
+
+	gettimeofday(&start, 0);
+	for (i = 0; i < 100000; ++i) {
+		j = rand() % 8192;
+		set_bit(test_bitmap, j);
+		assert(test_bit(test_bitmap, j));
+		clear_bit(test_bitmap, j);
+		assert(!test_bit(test_bitmap, j));
+	}
+	gettimeofday(&end, 0);
+
+	calculate_time_difference(&start, &end, &secs, &usec);
+
+	assert(bitmap_empty(test_bitmap));
+
+	expect(secs < 1);
+}
+


### PR DESCRIPTION
This commit introduces a new structure for handling bitmaps in the
gni provider.

The gnix_bitmap_t provides a set of basic functions for interacting
with the bitmap as listed below:
-- alloc_bitmap
-- realloc_bitmap
-- free_bitmap
-- test_bit
-- set_bit
-- clear_bit
-- test_and_set_bit
-- test_and_clear_bit
-- find_first_set_bit
-- find_first_clear_bit
-- bitmap_empty
-- bitmap_full
