### PR TITLE
Add generalized queue data structure. Closes #115.

### DIFF
--- a/prov/gni/Makefile.am
+++ b/prov/gni/Makefile.am
@@ -36,7 +36,8 @@ gnitest_SOURCES = \
 	prov/gni/test/utils.c \
 	prov/gni/test/wait.c \
 	prov/gni/test/datagram.c \
-	prov/gni/test/bitmap.c
+	prov/gni/test/bitmap.c \
+	prov/gni/test/queue.c
 
 gnitest_LDFLAGS = -static
 gnitest_CPPFLAGS = $(AM_CPPFLAGS)

--- a/prov/gni/Makefile.am
+++ b/prov/gni/Makefile.am
@@ -13,6 +13,7 @@ _gni_files = \
 	prov/gni/src/gnix_init.c \
 	prov/gni/src/gnix_fabric.c \
 	prov/gni/src/gnix_dom.c \
+	prov/gni/src/gnix_queue.c \
 	prov/gni/src/gnix_ep.c \
 	prov/gni/src/gnix_cq.c \
 	prov/gni/src/gnix_av.c \

--- a/prov/gni/include/gnix_queue.h
+++ b/prov/gni/include/gnix_queue.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _GNIX_QUEUE_H
+#define _GNIX_QUEUE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <fi_list.h>
+
+typedef struct slist_entry *(*alloc_func)(size_t entry_size);
+typedef void (*free_func)(struct slist_entry *item);
+
+struct gnix_queue {
+	struct slist item_list;
+	struct slist free_list;
+
+	alloc_func alloc_item;
+	free_func free_item;
+
+	size_t entry_size;
+};
+
+int _gnix_queue_create(struct gnix_queue **queue, alloc_func alloc_item,
+		       free_func free_item, size_t entry_size,
+		       size_t entry_count);
+void _gnix_queue_destroy(struct gnix_queue *queue);
+
+struct slist_entry *_gnix_queue_peek(struct gnix_queue *queue);
+
+struct slist_entry *_gnix_queue_get_free(struct gnix_queue *queue);
+struct slist_entry *_gnix_queue_dequeue(struct gnix_queue *queue);
+struct slist_entry *_gnix_queue_dequeue_free(struct gnix_queue *queue);
+
+void _gnix_queue_enqueue(struct gnix_queue *queue, struct slist_entry *item);
+void _gnix_queue_enqueue_free(struct gnix_queue *queue,
+			      struct slist_entry *item);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* #define _GNIX_QUEUE_H */

--- a/prov/gni/src/gnix_queue.c
+++ b/prov/gni/src/gnix_queue.c
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include "gnix_queue.h"
+
+int _gnix_queue_create(struct gnix_queue **queue, alloc_func alloc_item,
+		       free_func free_item, size_t entry_size,
+		       size_t entry_count)
+{
+	struct gnix_queue *q;
+	struct slist_entry *temp;
+	int ret = FI_SUCCESS;
+
+	if (!alloc_item || !free_item) {
+		ret = -FI_EINVAL;
+		goto err;
+	}
+
+	q = calloc(1, sizeof(*q));
+	if (!q) {
+		ret = -FI_ENOMEM;
+		goto err;
+	}
+
+	q->alloc_item = alloc_item;
+	q->free_item = free_item;
+
+	q->entry_size = entry_size;
+
+	slist_init(&q->item_list);
+	slist_init(&q->free_list);
+
+	for (size_t count = 0; count < entry_count; count++) {
+		temp = q->alloc_item(entry_size);
+		if (!temp) {
+			ret = -FI_ENOMEM;
+			goto err1;
+		}
+
+		_gnix_queue_enqueue_free(q, temp);
+	}
+
+	*queue = q;
+
+	return ret;
+
+err1:
+	_gnix_queue_destroy(q);
+	*queue = NULL;
+err:
+	return ret;
+}
+
+void _gnix_queue_destroy(struct gnix_queue *queue)
+{
+	struct slist_entry *temp;
+
+	while ((temp = _gnix_queue_dequeue(queue)))
+		queue->free_item(temp);
+
+	while ((temp = _gnix_queue_dequeue_free(queue)))
+		queue->free_item(temp);
+
+	free(queue);
+}
+
+struct slist_entry *_gnix_queue_peek(struct gnix_queue *queue)
+{
+	return queue->item_list.head;
+}
+
+struct slist_entry *_gnix_queue_get_free(struct gnix_queue *queue)
+{
+	struct slist_entry *ret;
+
+	ret = _gnix_queue_dequeue_free(queue);
+	if (!ret)
+		ret = queue->alloc_item(queue->entry_size);
+
+	return ret;
+}
+
+struct slist_entry *_gnix_queue_dequeue(struct gnix_queue *queue)
+{
+	return slist_remove_head(&queue->item_list);
+}
+
+struct slist_entry *_gnix_queue_dequeue_free(struct gnix_queue *queue)
+{
+	return slist_remove_head(&queue->free_list);
+}
+
+void _gnix_queue_enqueue(struct gnix_queue *queue, struct slist_entry *item)
+{
+	slist_insert_tail(item, &queue->item_list);
+}
+
+void _gnix_queue_enqueue_free(struct gnix_queue *queue,
+			      struct slist_entry *item)
+{
+	slist_insert_tail(item, &queue->free_list);
+}

--- a/prov/gni/test/queue.c
+++ b/prov/gni/test/queue.c
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "gnix_queue.h"
+
+#ifdef assert
+#undef assert
+#endif
+
+#include <criterion/criterion.h>
+
+struct gnix_queue *queue;
+
+struct int_entry {
+	int x;
+	struct slist_entry item;
+};
+
+static struct slist_entry *alloc_int_entry(size_t size)
+{
+	(void) size;
+	struct int_entry *entry = malloc(sizeof(*entry));
+
+	if (!entry)
+		return NULL;
+
+	return &entry->item;
+}
+
+static void free_int_entry(struct slist_entry *list_entry)
+{
+	struct int_entry *entry;
+
+	entry = container_of(list_entry, struct int_entry, item);
+
+	free(entry);
+}
+
+void setup_count_eight(void)
+{
+	int ret;
+
+	ret = _gnix_queue_create(&queue, alloc_int_entry, free_int_entry,
+				 0, 8);
+	assert_eq(ret, FI_SUCCESS, "failed to create queue.");
+}
+
+void setup_count_zero(void)
+{
+	int ret;
+
+	ret = _gnix_queue_create(&queue, alloc_int_entry, free_int_entry,
+				 0, 0);
+	assert_eq(ret, FI_SUCCESS, "failed to create queue.");
+}
+
+void teardown_queue(void)
+{
+	_gnix_queue_destroy(queue);
+}
+
+TestSuite(empty, .init = setup_count_zero, .fini = teardown_queue);
+
+Test(empty, null_read)
+{
+	struct slist_entry *list_entry;
+
+	list_entry = _gnix_queue_dequeue(queue);
+	expect(!list_entry, "non null read on empty queue.");
+
+	list_entry = _gnix_queue_dequeue_free(queue);
+	expect(!list_entry, "non null read on free list of empty queue.");
+
+	list_entry = _gnix_queue_peek(queue);
+	expect(!list_entry, "non null peek on empty queue.");
+}
+
+Test(empty, single_write)
+{
+	struct slist_entry *list_entry;
+	struct int_entry *entry;
+
+	/*
+	 * Write single entry with value 4 to queue.
+	 */
+	list_entry = _gnix_queue_get_free(queue);
+	expect(list_entry, "null entry from queue get free function.");
+
+	entry = container_of(list_entry, struct int_entry, item);
+
+	entry->x = 4;
+
+	_gnix_queue_enqueue(queue, &entry->item);
+
+	/*
+	 * Read back entry with value 4.
+	 */
+	list_entry = _gnix_queue_dequeue(queue);
+	expect(list_entry, "null entry from queue after enqueue.");
+
+	entry = container_of(list_entry, struct int_entry, item);
+
+	expect_eq(4, entry->x, "entry does not contain assigned value.");
+
+	/*
+	 * Add to free list.
+	 */
+	_gnix_queue_enqueue_free(queue, &entry->item);
+
+	/*
+	 * Read from now empty queue.
+	 */
+	list_entry = _gnix_queue_dequeue(queue);
+	expect(!list_entry, "entry read from empty queue is non-null.");
+
+	/*
+	 * Read from free and make sure it's the same.
+	 */
+	list_entry = _gnix_queue_get_free(queue);
+	expect(list_entry, "null entry from free queue after adding to free.");
+
+	entry = container_of(list_entry, struct int_entry, item);
+
+	expect_eq(4, entry->x, "entry does not contain assigned value.");
+
+	/*
+	 * Completely empty list. Shouldn't seg fault on teardown.
+	 */
+	queue->free_item(&entry->item);
+}
+
+TestSuite(eight, .init = setup_count_eight, .fini = teardown_queue);
+
+Test(eight, read_nine)
+{
+	struct slist_entry *list_entry;
+	struct int_entry *entry;
+
+	/*
+	 * Fill the queue. The value of each will be the counter position.
+	 */
+	for (size_t i = 0; i < 8; i++) {
+		list_entry = _gnix_queue_get_free(queue);
+		expect(list_entry, "null entry from queue get free function.");
+
+		entry = container_of(list_entry, struct int_entry, item);
+
+		entry->x = i;
+
+		_gnix_queue_enqueue(queue, &entry->item);
+	}
+
+	/*
+	 * Peek and make sure the top of queue is 0.
+	 */
+	list_entry = _gnix_queue_peek(queue);
+	expect(list_entry, "null entry from peek.");
+
+	entry = container_of(list_entry, struct int_entry, item);
+
+	expect_eq(0, entry->x, "value of peek isn't first added to queue.");
+
+	/*
+	 * Peek again and make sure it's still 0.
+	 */
+	list_entry = _gnix_queue_peek(queue);
+	expect(list_entry, "null entry from peek.");
+
+	entry = container_of(list_entry, struct int_entry, item);
+
+	expect_eq(0, entry->x, "value of peek isn't first added to queue.");
+
+	/*
+	 * Read it back.
+	 */
+	for (size_t i = 0; i < 8; i++) {
+		list_entry = _gnix_queue_dequeue(queue);
+		expect(list_entry, "null entry from queue dequeue.");
+
+		entry = container_of(list_entry, struct int_entry, item);
+
+		expect_eq(i, entry->x, "value not same as assigned.");
+
+		_gnix_queue_enqueue_free(queue, &entry->item);
+	}
+
+	/*
+	 * Read an extra item. Should return null.
+	 */
+	list_entry = _gnix_queue_dequeue(queue);
+	expect(!list_entry, "entry from empty queue not null.");
+}


### PR DESCRIPTION
Attempt to unify the CQ and EQ structures by creating a queue data structure.
The queue contains both an events list and a free list. Upon creation an
allocation and free function can be passed in and these will be used to
allocate objects for the free list and free objects in the destroy function.

Closes #115.

Signed-off-by: Ben Turrubiates bturrubiates@lanl.gov
