### PR TITLE
Initial implementation of the hashtable to be used in the gnix provider

### DIFF
--- a/prov/gni/Makefile.am
+++ b/prov/gni/Makefile.am
@@ -27,7 +27,9 @@ _gni_files = \
 	prov/gni/src/gnix_cm_nic.c \
 	prov/gni/src/gnix_nic.c \
 	prov/gni/src/gnix_util.c \
-	prov/gni/src/gnix_bitmap.c
+	prov/gni/src/gnix_bitmap.c \
+	prov/gni/src/gnix_hashtable.c \
+	prov/gni/fasthash/fasthash.c
 
 if HAVE_CRITERION
 bin_PROGRAMS = gnitest
@@ -38,7 +40,8 @@ gnitest_SOURCES = \
 	prov/gni/test/datagram.c \
 	prov/gni/test/bitmap.c \
 	prov/gni/test/queue.c \
-	prov/gni/test/eq.c
+	prov/gni/test/eq.c \
+	prov/gni/test/hashtable.c
 
 gnitest_LDFLAGS = -static
 gnitest_CPPFLAGS = $(AM_CPPFLAGS)

--- a/prov/gni/fasthash/README
+++ b/prov/gni/fasthash/README
@@ -1,0 +1,5 @@
+fasthash.h and fasthash.c are the source code of FastHash.
+
+hashgen contains the framework source code used to derive FastHash. It
+also contains a dependency library which is located in the dep/
+directory. 

--- a/prov/gni/fasthash/fasthash.c
+++ b/prov/gni/fasthash/fasthash.c
@@ -1,0 +1,75 @@
+/* The MIT License
+
+   Copyright (C) 2012 Zilong Tan (eric.zltan@gmail.com)
+
+   Permission is hereby granted, free of charge, to any person
+   obtaining a copy of this software and associated documentation
+   files (the "Software"), to deal in the Software without
+   restriction, including without limitation the rights to use, copy,
+   modify, merge, publish, distribute, sublicense, and/or sell copies
+   of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+#include "fasthash.h"
+
+// Compression function for Merkle-Damgard construction.
+// This function is generated using the framework provided.
+#define mix(h) ({					\
+			(h) ^= (h) >> 23;		\
+			(h) *= 0x2127599bf4325c37ULL;	\
+			(h) ^= (h) >> 47; })
+
+uint64_t fasthash64(const void *buf, size_t len, uint64_t seed)
+{
+	const uint64_t    m = 0x880355f21e6d1965ULL;
+	const uint64_t *pos = (const uint64_t *)buf;
+	const uint64_t *end = pos + (len / 8);
+	const unsigned char *pos2;
+	uint64_t h = seed ^ (len * m);
+	uint64_t v;
+
+	while (pos != end) {
+		v  = *pos++;
+		h ^= mix(v);
+		h *= m;
+	}
+
+	pos2 = (const unsigned char*)pos;
+	v = 0;
+
+	switch (len & 7) {
+	case 7: v ^= (uint64_t)pos2[6] << 48;
+	case 6: v ^= (uint64_t)pos2[5] << 40;
+	case 5: v ^= (uint64_t)pos2[4] << 32;
+	case 4: v ^= (uint64_t)pos2[3] << 24;
+	case 3: v ^= (uint64_t)pos2[2] << 16;
+	case 2: v ^= (uint64_t)pos2[1] << 8;
+	case 1: v ^= (uint64_t)pos2[0];
+		h ^= mix(v);
+		h *= m;
+	}
+
+	return mix(h);
+} 
+
+uint32_t fasthash32(const void *buf, size_t len, uint32_t seed)
+{
+	// the following trick converts the 64-bit hashcode to Fermat
+	// residue, which shall retain information from both the higher
+	// and lower parts of hashcode.
+        uint64_t h = fasthash64(buf, len, seed);
+	return h - (h >> 32);
+}

--- a/prov/gni/fasthash/fasthash.h
+++ b/prov/gni/fasthash/fasthash.h
@@ -1,0 +1,56 @@
+/* The MIT License
+
+   Copyright (C) 2012 Zilong Tan (eric.zltan@gmail.com)
+
+   Permission is hereby granted, free of charge, to any person
+   obtaining a copy of this software and associated documentation
+   files (the "Software"), to deal in the Software without
+   restriction, including without limitation the rights to use, copy,
+   modify, merge, publish, distribute, sublicense, and/or sell copies
+   of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+#ifndef _FASTHASH_H
+#define _FASTHASH_H
+
+#include <stdint.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * fasthash32 - 32-bit implementation of fasthash
+ * @buf:  data buffer
+ * @len:  data size
+ * @seed: the seed
+ */
+	uint32_t fasthash32(const void *buf, size_t len, uint32_t seed);
+
+/**
+ * fasthash64 - 64-bit implementation of fasthash
+ * @buf:  data buffer
+ * @len:  data size
+ * @seed: the seed
+ */
+	uint64_t fasthash64(const void *buf, size_t len, uint64_t seed);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/prov/gni/include/gnix_hashtable.h
+++ b/prov/gni/include/gnix_hashtable.h
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2015 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef GNIX_HASHTABLE_H_
+#define GNIX_HASHTABLE_H_
+
+#include <stdint.h>
+#include <pthread.h>
+
+#include "fi.h"
+#include "prov/gni/ccan/list.h"
+
+typedef uint64_t gnix_ht_key_t;
+
+typedef enum gnix_ht_state {
+	GNIX_HT_STATE_UNINITIALIZED = 0,
+	GNIX_HT_STATE_READY,
+	GNIX_HT_STATE_DEAD,
+} gnix_ht_state_e;
+
+typedef struct gnix_ht_entry {
+	struct list_node entry;
+	gnix_ht_key_t key;
+	void *value;
+} gnix_ht_entry_t;
+
+typedef struct gnix_ht_list_head {
+	pthread_rwlock_t lh_lock;
+	struct list_head bucket_list;
+} gnix_ht_list_head_t;
+
+enum gnix_ht_increase {
+	GNIX_HT_INCREASE_ADD = 0,
+	GNIX_HT_INCREASE_MULT
+};
+
+/**
+ * Set of attributes that can be passed to the gnix_ht_init.
+ *
+ * @var ht_initial_size      initial number of buckets allocated
+ * @var ht_maximum_size      maximum number of buckets to allocate on resize
+ * @var ht_increase_step     additive or multiplicative factor to increase by.
+ *                           If additive, the new_size = (old_size + increase)
+ *                           If multiplicative, the new size = (old_size *
+ *                           increase)
+ * @var ht_increase_type     based on the gnix_ht_increase enum, this
+ *                           influences whether the increase of the bucket
+ *                           count is additive or multiplicative
+ * @var ht_collision_thresh  threshold for resizing based on insertion
+ *                           collisions. The threshold is based on the
+ *                           average number of collisions per insertion,
+ *                           multiplied by 100. If you want an average bucket
+ *                           depth of 4, you would want to see 3-4 collisions
+ *                           on average, so the appropriate threshold would be
+ *                           ~400.
+ * @var ht_hash_seed		 seed value that affects how items are hashed
+ *                           internally. Using the same seed value and the same
+ *                           insertion pattern will allow for repeatable
+ *                           results.
+ */
+typedef struct gnix_hashtable_attr {
+	int ht_initial_size;
+	int ht_maximum_size;
+	int ht_increase_step;
+	int ht_increase_type;
+	int ht_collision_thresh;
+	uint64_t ht_hash_seed;
+} gnix_hashtable_attr_t;
+
+/**
+ * Hashtable structure
+ *
+ * @var ht_lock        reader/writer lock for protecting internal structures
+ *                     during a resize
+ * @var ht_state       internal state mechanism for detecting valid state
+ *                     transitions
+ * @var ht_attr        attributes for the hash map to follow after init
+ * @var ht_elements    number of items in the hash map
+ * @var ht_collisions  number of insertion collisions since the last resize
+ * @var ht_ops         number of insertions since the last resize
+ * @var ht_size        number of hash buckets
+ * @var ht_tbl         array of hash buckets
+ */
+typedef struct gnix_hashtable {
+	pthread_rwlock_t ht_lock;
+	gnix_ht_state_e ht_state;
+	gnix_hashtable_attr_t ht_attr;
+	atomic_t ht_elements;
+	atomic_t ht_collisions;
+	atomic_t ht_ops;
+	int ht_size;
+	gnix_ht_list_head_t *ht_tbl;
+} gnix_hashtable_t;
+
+/**
+ * Initializes the hash table with provided attributes, if any
+ *
+ * @param ht      pointer to the hash table structure
+ * @param attr    pointer to the hash table attributes to initialize with
+ * @return        0 on success, -EINVAL on initialization error, or -ENOMEM
+ *                if allocation of the bucket array fails
+ */
+int gnix_ht_init(gnix_hashtable_t *ht, gnix_hashtable_attr_t *attr);
+
+/**
+ * Destroys the hash table
+ *
+ * @param ht      pointer to the hash table structure
+ * @return        0 on success, -EINVAL upon passing an uninitialized or dead
+ *                structure
+ */
+int gnix_ht_destroy(gnix_hashtable_t *ht);
+
+/**
+ * Inserts an entry into the map with the provided key
+ *
+ * @param ht      pointer to the hash table structure
+ * @param key     key used to hash the entry
+ * @param entry   entry to be stored
+ * @return        0 on success, -ENOSPC when another entry with the same key
+ *                exists in the hashtable, or -EINVAL when called on a dead or
+ *                uninitialized hash table
+ */
+int gnix_ht_insert(gnix_hashtable_t *ht, gnix_ht_key_t key, void *entry);
+
+/**
+ * Removes an entry from the map with the provided key
+ *
+ * @param ht      pointer to the hash table structure
+ * @param key     key used to hash the entry
+ * @return        0 on success, -ENOENT when the key doesn't exist in the hash
+ *                table, or -EINVAL when called on a dead or uninitialized hash
+ *                table
+ */
+int gnix_ht_remove(gnix_hashtable_t *ht, gnix_ht_key_t key);
+
+/**
+ * Looks up an entry in the hash table using key
+ *
+ * @param ht      pointer to the hash table structure
+ * @param key     key used to hash the entry
+ * @return        NULL if the key did not exist in the hash table, or the
+ *                entry if the key exists in the hash table
+ */
+void *gnix_ht_lookup(gnix_hashtable_t *ht, gnix_ht_key_t key);
+
+/**
+ * Tests to see if the hash table is empty
+ *
+ * @param ht      pointer to the hash table structure
+ * @return        true if the hash table is empty, false if not
+ */
+int gnix_ht_empty(gnix_hashtable_t *ht);
+
+#endif /* GNIX_HASHTABLE_H_ */

--- a/prov/gni/src/gnix_hashtable.c
+++ b/prov/gni/src/gnix_hashtable.c
@@ -1,0 +1,492 @@
+/*
+ * Copyright (c) 2015 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <errno.h>
+#include <stdio.h>
+
+#include <gnix_hashtable.h>
+#include <prov/gni/fasthash/fasthash.h>
+
+#define __GNIX_HT_INITIAL_SIZE 128
+#define __GNIX_HT_MAXIMUM_SIZE 1024
+#define __GNIX_HT_INCREASE_STEP 2
+
+#define __GNIX_HT_COLLISION_THRESH 400 /* average of 4 elements per bucket */
+
+/* This is temporary until I can convince someone that this belongs in the
+ *   fi.h header file.
+ */
+#if HAVE_ATOMICS
+static inline int atomic_add(atomic_t *atomic, int val)
+{
+	ATOMIC_IS_INITIALIZED(atomic);
+	return atomic_fetch_add_explicit(&atomic->val,
+			val, memory_order_acq_rel) + 1;
+}
+
+static inline int atomic_sub(atomic_t *atomic, int val)
+{
+	ATOMIC_IS_INITIALIZED(atomic);
+	return atomic_fetch_sub_explicit(&atomic->val,
+			val, memory_order_acq_rel) - 1;
+}
+#else
+static inline int atomic_add(atomic_t *atomic, int val)
+{
+	int v;
+
+	ATOMIC_IS_INITIALIZED(atomic);
+	fastlock_acquire(&atomic->lock);
+	atomic->val += val;
+	v = atomic->val;
+	fastlock_release(&atomic->lock);
+	return v;
+}
+
+static inline int atomic_sub(atomic_t *atomic, int val)
+{
+	int v;
+
+	ATOMIC_IS_INITIALIZED(atomic);
+	fastlock_acquire(&atomic->lock);
+	atomic->val += val;
+	v = atomic->val;
+	fastlock_release(&atomic->lock);
+	return v;
+}
+#endif
+
+const gnix_hashtable_attr_t default_attr = {
+		.ht_initial_size     = __GNIX_HT_INITIAL_SIZE,
+		.ht_maximum_size     = __GNIX_HT_MAXIMUM_SIZE,
+		.ht_increase_step    = __GNIX_HT_INCREASE_STEP,
+		.ht_increase_type    = GNIX_HT_INCREASE_MULT,
+		.ht_collision_thresh = __GNIX_HT_COLLISION_THRESH,
+		.ht_hash_seed        = 0
+};
+
+static int __gnix_ht_check_attr_sanity(gnix_hashtable_attr_t *attr)
+{
+	if (attr->ht_initial_size == 0 ||
+			attr->ht_initial_size > attr->ht_maximum_size)
+		return -EINVAL;
+
+	if (attr->ht_maximum_size == 0)
+		return -EINVAL;
+
+	if (attr->ht_increase_step == 0)
+		return -EINVAL;
+
+	if (!(attr->ht_increase_type == GNIX_HT_INCREASE_ADD ||
+			attr->ht_increase_type == GNIX_HT_INCREASE_MULT))
+		return -EINVAL;
+
+	if (attr->ht_increase_step == 1 &&
+			attr->ht_increase_type == GNIX_HT_INCREASE_MULT)
+		return -EINVAL;
+
+	if (attr->ht_collision_thresh == 0)
+		return -EINVAL;
+
+	return 0;
+}
+
+static inline void __gnix_ht_delete_entry(gnix_ht_entry_t *ht_entry)
+{
+	list_del(&ht_entry->entry);
+
+	ht_entry->value = NULL;
+	ht_entry->key = 0;
+	free(ht_entry);
+}
+
+static inline void __gnix_ht_init_list_head(gnix_ht_list_head_t *lh)
+{
+	list_head_init(&lh->bucket_list);
+	pthread_rwlock_init(&lh->lh_lock, NULL);
+}
+
+static inline gnix_ht_key_t gnix_hash_func(
+		gnix_hashtable_t *ht,
+		gnix_ht_key_t key)
+{
+	return fasthash64(&key, sizeof(gnix_ht_key_t),
+			ht->ht_attr.ht_hash_seed) % ht->ht_size;
+}
+
+static inline gnix_ht_entry_t *__gnix_ht_lookup_key(
+		gnix_ht_list_head_t *lh,
+		gnix_ht_key_t key,
+		uint64_t *collision_count)
+{
+	gnix_ht_entry_t *ht_entry;
+
+
+	if (list_empty(&lh->bucket_list))
+		return NULL;
+
+	list_for_each(&lh->bucket_list, ht_entry, entry) {
+		if (ht_entry->key == key)
+			return ht_entry;
+
+		if (collision_count)
+			*collision_count += 1;
+	}
+
+	return NULL;
+}
+
+static inline void *gnix_ht_lookup_key(
+		gnix_ht_list_head_t *lh,
+		gnix_ht_key_t key)
+{
+	gnix_ht_entry_t *ht_entry = NULL;
+
+	pthread_rwlock_rdlock(&lh->lh_lock);
+	ht_entry = __gnix_ht_lookup_key(lh, key, NULL);
+	pthread_rwlock_unlock(&lh->lh_lock);
+
+	if (!ht_entry)
+		return NULL;
+
+	return ht_entry->value;
+}
+
+static inline void __gnix_ht_destroy_list(
+		gnix_hashtable_t *ht,
+		gnix_ht_list_head_t *lh)
+{
+	gnix_ht_entry_t *ht_entry, *iter;
+	int entries_freed = 0;
+
+	list_for_each_safe(&lh->bucket_list, ht_entry, iter, entry) {
+		__gnix_ht_delete_entry(ht_entry);
+
+		++entries_freed;
+	}
+
+	atomic_sub(&ht->ht_elements, entries_freed);
+}
+
+static inline int __gnix_ht_insert_list(
+		gnix_ht_list_head_t *lh,
+		gnix_ht_entry_t *ht_entry,
+		uint64_t *collisions)
+{
+	gnix_ht_entry_t *found;
+
+	found = __gnix_ht_lookup_key(lh, ht_entry->key, collisions);
+	if (!found) {
+		list_add_tail(&lh->bucket_list, &ht_entry->entry);
+	} else {
+		return -ENOSPC;
+	}
+
+	return 0;
+}
+
+static inline int __gnix_ht_insert_list_locked(
+		gnix_ht_list_head_t *lh,
+		gnix_ht_entry_t *ht_entry,
+		uint64_t *collisions)
+{
+	int ret;
+
+	pthread_rwlock_wrlock(&lh->lh_lock);
+	ret = __gnix_ht_insert_list(lh, ht_entry, collisions);
+	pthread_rwlock_unlock(&lh->lh_lock);
+
+	return ret;
+}
+
+static inline int __gnix_ht_remove_list(
+		gnix_ht_list_head_t *lh,
+		gnix_ht_key_t key)
+{
+	gnix_ht_entry_t *ht_entry;
+
+	pthread_rwlock_wrlock(&lh->lh_lock);
+
+	ht_entry = __gnix_ht_lookup_key(lh, key, NULL);
+	if (!ht_entry) {
+		pthread_rwlock_unlock(&lh->lh_lock);
+		return -ENOENT;
+	}
+	__gnix_ht_delete_entry(ht_entry);
+
+	pthread_rwlock_unlock(&lh->lh_lock);
+
+	return 0;
+}
+
+static inline void __gnix_ht_rehash_list(
+		gnix_hashtable_t *ht,
+		gnix_ht_list_head_t *list)
+{
+	gnix_ht_entry_t *ht_entry, *tmp;
+	gnix_ht_key_t bucket;
+	int ret;
+
+	if (list_empty(&list->bucket_list))
+		return;
+
+	list_for_each_safe(&list->bucket_list, ht_entry, tmp, entry) {
+		bucket = gnix_hash_func(ht, ht_entry->key);
+
+		list_del(&ht_entry->entry);
+
+		ret = __gnix_ht_insert_list(&ht->ht_tbl[bucket],
+				ht_entry, NULL);
+	}
+}
+
+static inline void __gnix_ht_rehash_table(
+		gnix_hashtable_t *ht,
+		gnix_ht_list_head_t *ht_tbl,
+		int old_length)
+{
+	int i;
+
+	for (i = 0; i < old_length; ++i) {
+		__gnix_ht_rehash_list(ht, &ht_tbl[i]);
+	}
+}
+
+static inline void __gnix_ht_resize_hashtable(gnix_hashtable_t *ht)
+{
+	int old_size = ht->ht_size;
+	int new_size;
+	int i;
+	gnix_ht_list_head_t *new_table = NULL, *old_table = NULL;
+
+	/* set up the new bucket list size */
+	if (ht->ht_attr.ht_increase_type == GNIX_HT_INCREASE_ADD)
+		new_size = old_size + ht->ht_attr.ht_increase_step;
+	else
+		new_size = old_size * ht->ht_attr.ht_increase_step;
+
+	new_size = MIN(new_size, ht->ht_attr.ht_maximum_size);
+
+	/* race to resize... let one of them resize the hash table and the rest
+	 * can just release after the first is done.
+	 */
+	pthread_rwlock_wrlock(&ht->ht_lock);
+	if (ht->ht_size != old_size) {
+		pthread_rwlock_unlock(&ht->ht_lock);
+		return;
+	}
+
+	new_table = calloc(new_size, sizeof(gnix_ht_list_head_t));
+	if (!new_table) {
+		pthread_rwlock_unlock(&ht->ht_lock);
+		return;
+	}
+
+	for (i = 0; i < new_size; ++i) {
+		__gnix_ht_init_list_head(&new_table[i]);
+	}
+
+	old_table = ht->ht_tbl;
+	ht->ht_tbl = new_table;
+	ht->ht_size = new_size;
+
+	__gnix_ht_rehash_table(ht, old_table, old_size);
+
+	pthread_rwlock_unlock(&ht->ht_lock);
+}
+
+int gnix_ht_init(gnix_hashtable_t *ht, gnix_hashtable_attr_t *attr)
+{
+	int i;
+	int ret;
+
+	if (ht->ht_state == GNIX_HT_STATE_READY)
+		return -EINVAL;
+
+	if (ht->ht_state != GNIX_HT_STATE_DEAD)
+		pthread_rwlock_init(&ht->ht_lock, NULL);
+
+	pthread_rwlock_wrlock(&ht->ht_lock);
+
+	if (!attr) {
+		memcpy(&ht->ht_attr, &default_attr,
+				sizeof(gnix_hashtable_attr_t));
+	} else {
+		ret = __gnix_ht_check_attr_sanity(attr);
+		if (ret < 0)
+			return ret;
+
+		memcpy(&ht->ht_attr, attr, sizeof(gnix_hashtable_attr_t));
+	}
+
+	ht->ht_size = ht->ht_attr.ht_initial_size;
+	ht->ht_tbl = calloc(ht->ht_size, sizeof(gnix_ht_list_head_t));
+	if (!ht->ht_tbl) {
+		pthread_rwlock_unlock(&ht->ht_lock);
+		ht->ht_size = 0;
+		return -ENOMEM;
+	}
+
+	for (i = 0; i < ht->ht_size; ++i)
+		__gnix_ht_init_list_head(&ht->ht_tbl[i]);
+
+	if (ht->ht_state == GNIX_HT_STATE_UNINITIALIZED) {
+		atomic_initialize(&ht->ht_elements, 0);
+		atomic_initialize(&ht->ht_collisions, 0);
+		atomic_initialize(&ht->ht_ops, 0);
+	} else {
+		atomic_set(&ht->ht_elements, 0);
+		atomic_set(&ht->ht_collisions, 0);
+		atomic_set(&ht->ht_ops, 0);
+	}
+
+	ht->ht_state = GNIX_HT_STATE_READY;
+
+	pthread_rwlock_unlock(&ht->ht_lock);
+	return 0;
+}
+
+int gnix_ht_destroy(gnix_hashtable_t *ht)
+{
+	int i;
+
+	if (ht->ht_state != GNIX_HT_STATE_READY)
+		return -EINVAL;
+
+	pthread_rwlock_wrlock(&ht->ht_lock);
+
+	for (i = 0; i < ht->ht_size; ++i) {
+		__gnix_ht_destroy_list(ht, &ht->ht_tbl[i]);
+	}
+
+	free(ht->ht_tbl);
+	ht->ht_tbl = NULL;
+
+	ht->ht_size = 0;
+	atomic_set(&ht->ht_collisions, 0);
+	atomic_set(&ht->ht_ops, 0);
+	atomic_set(&ht->ht_elements, 0);
+	ht->ht_state = GNIX_HT_STATE_DEAD;
+
+	pthread_rwlock_unlock(&ht->ht_lock);
+
+	return 0;
+}
+
+int gnix_ht_insert(gnix_hashtable_t *ht, gnix_ht_key_t key, void *entry)
+{
+	int bucket;
+	int ret;
+	int collisions, ops;
+	uint64_t hits = 0;
+
+	gnix_ht_entry_t *list_entry;
+
+	if (ht->ht_state != GNIX_HT_STATE_READY)
+		return -EINVAL;
+
+	list_entry = calloc(1, sizeof(gnix_ht_entry_t));
+	if (!list_entry)
+		return -ENOMEM;
+
+	list_entry->value = entry;
+	list_entry->key = key;
+
+	pthread_rwlock_rdlock(&ht->ht_lock);
+	bucket = gnix_hash_func(ht, key);
+	ret = __gnix_ht_insert_list_locked(&ht->ht_tbl[bucket],
+			list_entry, &hits);
+	pthread_rwlock_unlock(&ht->ht_lock);
+
+	if (ht->ht_size < ht->ht_attr.ht_maximum_size) {
+		collisions = atomic_add(&ht->ht_collisions, hits);
+		ops = atomic_inc(&ht->ht_ops);
+		if (ops > 10 &&
+				((collisions * 100) / ops)
+				> ht->ht_attr.ht_collision_thresh) {
+
+			atomic_set(&ht->ht_collisions, 0);
+			atomic_set(&ht->ht_ops, 0);
+
+			__gnix_ht_resize_hashtable(ht);
+		}
+	}
+
+	if (ret == 0)
+		atomic_inc(&ht->ht_elements);
+
+	return ret;
+}
+
+int gnix_ht_remove(gnix_hashtable_t *ht, gnix_ht_key_t key)
+{
+	int bucket;
+	int ret;
+
+	if (ht->ht_state != GNIX_HT_STATE_READY)
+		return -EINVAL;
+
+	pthread_rwlock_rdlock(&ht->ht_lock);
+
+	bucket = gnix_hash_func(ht, key);
+	ret = __gnix_ht_remove_list(&ht->ht_tbl[bucket], key);
+
+	pthread_rwlock_unlock(&ht->ht_lock);
+
+	if (ret == 0)
+		atomic_dec(&ht->ht_elements);
+
+	return ret;
+}
+
+void *gnix_ht_lookup(gnix_hashtable_t *ht, gnix_ht_key_t key)
+{
+	int bucket;
+	void *ret;
+
+	if (ht->ht_state != GNIX_HT_STATE_READY)
+		return NULL;
+
+	pthread_rwlock_rdlock(&ht->ht_lock);
+	bucket = gnix_hash_func(ht, key);
+
+	ret = gnix_ht_lookup_key(&ht->ht_tbl[bucket], key);
+	pthread_rwlock_unlock(&ht->ht_lock);
+
+	return ret;
+}
+
+int gnix_ht_empty(gnix_hashtable_t *ht)
+{
+	return atomic_get(&ht->ht_elements) == 0;
+}

--- a/prov/gni/src/gnix_hashtable.c
+++ b/prov/gni/src/gnix_hashtable.c
@@ -322,6 +322,8 @@ static inline void __gnix_ht_resize_hashtable(gnix_hashtable_t *ht)
 
 	__gnix_ht_rehash_table(ht, old_table, old_size);
 
+	free(old_table);
+
 	pthread_rwlock_unlock(&ht->ht_lock);
 }
 
@@ -444,6 +446,8 @@ int gnix_ht_insert(gnix_hashtable_t *ht, gnix_ht_key_t key, void *entry)
 
 	if (ret == 0)
 		atomic_inc(&ht->ht_elements);
+	else
+		free(list_entry);
 
 	return ret;
 }

--- a/prov/gni/test/hashtable.c
+++ b/prov/gni/test/hashtable.c
@@ -1,0 +1,574 @@
+/*
+ * Copyright (c) 2015 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdint.h>
+
+#include <errno.h>
+#include <gnix_hashtable.h>
+#include <gnix_bitmap.h>
+
+#ifdef assert
+#undef assert
+#endif
+
+#include <criterion/criterion.h>
+
+#define __GNIX_MAGIC_VALUE 0xDEADBEEF
+
+extern const gnix_hashtable_attr_t default_attr;
+
+typedef struct gnix_test_element {
+	uint64_t val;
+	uint64_t key;
+	uint64_t magic;
+} gnix_test_element_t;
+
+#define GNIX_TEST_ELEMENT_INIT(_val, _key) \
+	{ .val = (_val), .key = (_key), .magic = (__GNIX_MAGIC_VALUE) }
+
+gnix_test_element_t elements[4] = {
+	GNIX_TEST_ELEMENT_INIT(1, 100),
+	GNIX_TEST_ELEMENT_INIT(2, 200),
+	GNIX_TEST_ELEMENT_INIT(10, 300),
+	GNIX_TEST_ELEMENT_INIT(777, 500000)
+};
+
+gnix_test_element_t *simple_element = &elements[0];
+gnix_hashtable_t *test_ht = NULL;
+
+void __gnix_hashtable_test_uninitialized(void)
+{
+	assert(test_ht->ht_state == GNIX_HT_STATE_UNINITIALIZED);
+	assert(test_ht->ht_size == 0);
+	assert(test_ht->ht_tbl == NULL);
+}
+
+void __gnix_hashtable_test_setup_bare(void)
+{
+	assert(test_ht == NULL);
+	test_ht = (gnix_hashtable_t *) calloc(1, sizeof(gnix_hashtable_t));
+	assert(test_ht != NULL);
+
+	__gnix_hashtable_test_uninitialized();
+}
+
+
+void __gnix_hashtable_test_teardown_bare(void)
+{
+	assert(test_ht != NULL);
+	free(test_ht);
+	test_ht = NULL;
+}
+
+void __gnix_hashtable_test_initialized(void)
+{
+	assert(test_ht->ht_state == GNIX_HT_STATE_READY);
+	assert(atomic_get(&test_ht->ht_elements) == 0);
+	assert(test_ht->ht_size == test_ht->ht_attr.ht_initial_size);
+	assert(test_ht->ht_tbl != NULL);
+}
+
+void __gnix_hashtable_test_destroyed_clean(void)
+{
+	assert(test_ht->ht_state == GNIX_HT_STATE_DEAD);
+	assert(atomic_get(&test_ht->ht_elements) == 0);
+	assert(test_ht->ht_size == 0);
+	assert(test_ht->ht_tbl == NULL);
+}
+
+void __gnix_hashtable_destroy(void)
+{
+	int ret = gnix_ht_destroy(test_ht);
+	assert(ret == 0);
+	__gnix_hashtable_test_destroyed_clean();
+}
+
+void __gnix_hashtable_initialize(void)
+{
+	int ret;
+
+	ret = gnix_ht_init(test_ht, NULL);
+	assert(ret == 0);
+
+	__gnix_hashtable_test_initialized();
+}
+
+void __gnix_hashtable_test_setup(void)
+{
+	__gnix_hashtable_test_setup_bare();
+
+	__gnix_hashtable_test_uninitialized();
+
+	__gnix_hashtable_initialize();
+}
+
+void __gnix_hashtable_test_teardown(void)
+{
+	__gnix_hashtable_destroy();
+
+	__gnix_hashtable_test_teardown_bare();
+}
+
+/*
+ * Basic functionality tests for the gnix_hashtable_t object
+ */
+
+TestSuite(gnix_hashtable_basic,
+		.init = __gnix_hashtable_test_setup_bare,
+		.fini = __gnix_hashtable_test_teardown_bare);
+
+TestSuite(gnix_hashtable_advanced,
+		.init = __gnix_hashtable_test_setup,
+		.fini = __gnix_hashtable_test_teardown);
+
+
+Test(gnix_hashtable_basic, uninitialized)
+{
+	__gnix_hashtable_test_uninitialized();
+}
+
+
+Test(gnix_hashtable_basic, initialize_ht)
+{
+	__gnix_hashtable_initialize();
+}
+
+Test(gnix_hashtable_basic, err_initialize_twice)
+{
+	int ret;
+
+	__gnix_hashtable_initialize();
+
+	ret = gnix_ht_init(test_ht, NULL);
+	assert(ret == -EINVAL);
+	__gnix_hashtable_test_initialized();
+}
+
+Test(gnix_hashtable_basic, err_invalid_initial_size_0)
+{
+	int ret;
+	gnix_hashtable_attr_t attr;
+
+	memcpy(&attr, &default_attr, sizeof(gnix_hashtable_attr_t));
+
+	attr.ht_initial_size = 0;
+
+	ret = gnix_ht_init(test_ht, &attr);
+	assert(ret == -EINVAL);
+	__gnix_hashtable_test_uninitialized();
+}
+
+Test(gnix_hashtable_basic, err_invalid_initial_size_gt_max)
+{
+	int ret;
+	gnix_hashtable_attr_t attr;
+
+	memcpy(&attr, &default_attr, sizeof(gnix_hashtable_attr_t));
+
+	attr.ht_initial_size = attr.ht_maximum_size * 2;
+
+	ret = gnix_ht_init(test_ht, &attr);
+	assert(ret == -EINVAL);
+	__gnix_hashtable_test_uninitialized();
+}
+
+Test(gnix_hashtable_basic, err_invalid_max_size)
+{
+	int ret;
+	gnix_hashtable_attr_t attr;
+
+	memcpy(&attr, &default_attr, sizeof(gnix_hashtable_attr_t));
+
+	attr.ht_maximum_size = 0;
+
+	ret = gnix_ht_init(test_ht, &attr);
+	assert(ret == -EINVAL);
+	__gnix_hashtable_test_uninitialized();
+}
+
+Test(gnix_hashtable_basic, err_invalid_increase_step_all)
+{
+	int ret;
+	gnix_hashtable_attr_t attr;
+
+	memcpy(&attr, &default_attr, sizeof(gnix_hashtable_attr_t));
+
+	attr.ht_increase_step = 0;
+
+	ret = gnix_ht_init(test_ht, &attr);
+	assert(ret == -EINVAL);
+	__gnix_hashtable_test_uninitialized();
+}
+
+Test(gnix_hashtable_basic, err_invalid_increase_step_mult)
+{
+	int ret;
+	gnix_hashtable_attr_t attr;
+
+	memcpy(&attr, &default_attr, sizeof(gnix_hashtable_attr_t));
+
+	attr.ht_increase_step = 1;
+	attr.ht_increase_type = GNIX_HT_INCREASE_MULT;
+
+	ret = gnix_ht_init(test_ht, &attr);
+	assert(ret == -EINVAL);
+	__gnix_hashtable_test_uninitialized();
+}
+
+Test(gnix_hashtable_basic, err_invalid_increase_type)
+{
+	int ret;
+	gnix_hashtable_attr_t attr;
+
+	memcpy(&attr, &default_attr, sizeof(gnix_hashtable_attr_t));
+
+	attr.ht_increase_type = -1;
+
+	ret = gnix_ht_init(test_ht, &attr);
+	assert(ret == -EINVAL);
+	__gnix_hashtable_test_uninitialized();
+}
+
+Test(gnix_hashtable_basic, err_invalid_collision)
+{
+	int ret;
+	gnix_hashtable_attr_t attr;
+
+	memcpy(&attr, &default_attr, sizeof(gnix_hashtable_attr_t));
+
+	attr.ht_collision_thresh = 0;
+
+	ret = gnix_ht_init(test_ht, &attr);
+	assert(ret == -EINVAL);
+	__gnix_hashtable_test_uninitialized();
+}
+
+Test(gnix_hashtable_basic, err_destroy_uninitialized)
+{
+	int ret;
+
+	ret = gnix_ht_destroy(test_ht);
+	assert(ret == -EINVAL);
+
+	__gnix_hashtable_test_uninitialized();
+}
+
+Test(gnix_hashtable_basic, destroy)
+{
+	__gnix_hashtable_initialize();
+
+	__gnix_hashtable_destroy();
+}
+
+Test(gnix_hashtable_basic, destroy_twice)
+{
+	int ret;
+
+	__gnix_hashtable_initialize();
+
+	__gnix_hashtable_destroy();
+
+	ret = gnix_ht_destroy(test_ht);
+	assert(ret == -EINVAL);
+	__gnix_hashtable_test_destroyed_clean();
+}
+
+Test(gnix_hashtable_advanced, insert_1)
+{
+	int ret;
+
+	ret = gnix_ht_insert(test_ht, simple_element->key, simple_element);
+	assert(ret == 0);
+
+	assert(atomic_get(&test_ht->ht_elements) == 1);
+}
+
+Test(gnix_hashtable_advanced, insert_duplicate)
+{
+	int ret;
+
+	ret = gnix_ht_insert(test_ht, simple_element->key, simple_element);
+	assert(ret == 0);
+
+	assert(atomic_get(&test_ht->ht_elements) == 1);
+
+	ret = gnix_ht_insert(test_ht, simple_element->key, simple_element);
+	assert(ret == -ENOSPC);
+
+	assert(atomic_get(&test_ht->ht_elements) == 1);
+}
+
+Test(gnix_hashtable_advanced, insert_1_remove_1)
+{
+	int ret;
+
+	srand(time(NULL));
+
+	ret = gnix_ht_insert(test_ht, simple_element->key, simple_element);
+	assert(ret == 0);
+
+	assert(atomic_get(&test_ht->ht_elements) == 1);
+
+	ret = gnix_ht_remove(test_ht, simple_element->key);
+	assert(ret == 0);
+
+	assert(atomic_get(&test_ht->ht_elements) == 0);
+}
+
+
+Test(gnix_hashtable_advanced, insert_1024)
+{
+	int ret, i;
+
+	gnix_test_element_t test_elements[1024];
+
+	srand(time(NULL));
+
+	for (i = 0; i < 1024; ++i) {
+		test_elements[i].key = rand();
+		test_elements[i].val = rand() % (1024 * 1024);
+		test_elements[i].magic = __GNIX_MAGIC_VALUE;
+	}
+
+	for (i = 0; i < 1024; ++i) {
+		ret = gnix_ht_insert(test_ht,
+				test_elements[i].key, &test_elements[i]);
+		assert(ret == 0);
+		assert(atomic_get(&test_ht->ht_elements) == (i + 1));
+	}
+
+	assert(atomic_get(&test_ht->ht_elements) == 1024);
+}
+
+
+Test(gnix_hashtable_advanced, insert_1024_remove_1024)
+{
+	int ret, i;
+
+	gnix_test_element_t test_elements[1024];
+	gnix_test_element_t *item;
+
+	srand(time(NULL));
+
+	for (i = 0; i < 1024; ++i) {
+		item = &test_elements[i];
+		item->key = i;
+		item->val = rand() % (1024 * 1024);
+		item->magic = __GNIX_MAGIC_VALUE;
+	}
+
+	for (i = 0; i < 1024; ++i) {
+		item = &test_elements[i];
+		ret = gnix_ht_insert(test_ht,
+				item->key, item);
+		assert(ret == 0);
+		assert(atomic_get(&test_ht->ht_elements) == (i + 1));
+	}
+
+	for (i = 1023; i >= 0; --i) {
+		item = &test_elements[i];
+		assert(i == item->key);
+
+		ret = gnix_ht_remove(test_ht,
+				item->key);
+		assert(ret == 0);
+		assert(atomic_get(&test_ht->ht_elements) == i);
+	}
+
+	assert(atomic_get(&test_ht->ht_elements) == 0);
+}
+
+
+Test(gnix_hashtable_advanced, insert_1_lookup_pass)
+{
+	int ret;
+	gnix_test_element_t *found = NULL;
+
+	ret = gnix_ht_insert(test_ht,
+			simple_element->key, simple_element);
+	assert(ret == 0);
+
+	assert(atomic_get(&test_ht->ht_elements) == 1);
+
+	found = gnix_ht_lookup(test_ht, simple_element->key);
+	assert(found == simple_element);
+	assert(found->magic == __GNIX_MAGIC_VALUE);
+}
+
+Test(gnix_hashtable_advanced, insert_1_lookup_fail)
+{
+	int ret;
+	gnix_test_element_t *found = NULL;
+
+	ret = gnix_ht_insert(test_ht,
+			simple_element->key, simple_element);
+	assert(ret == 0);
+
+	assert(atomic_get(&test_ht->ht_elements) == 1);
+
+	found = gnix_ht_lookup(test_ht, simple_element->key - 1);
+	assert(found != simple_element);
+	assert(found == NULL);
+}
+
+Test(gnix_hashtable_advanced, insert_1024_lookup_all)
+{
+	int ret, i;
+	gnix_test_element_t test_elements[1024];
+	gnix_test_element_t *item;
+	gnix_test_element_t *found = NULL;
+
+	srand(time(NULL));
+
+	for (i = 0; i < 1024; ++i) {
+		item = &test_elements[i];
+
+		item->key = i;
+		item->val = rand() % (1024 * 1024);
+		item->magic = __GNIX_MAGIC_VALUE;
+	}
+
+	for (i = 0; i < 1024; ++i) {
+		item = &test_elements[i];
+
+		ret = gnix_ht_insert(test_ht,
+				item->key, item);
+		assert(ret == 0);
+		assert(atomic_get(&test_ht->ht_elements) == (i + 1));
+	}
+
+	assert(atomic_get(&test_ht->ht_elements) == 1024);
+
+	for (i = 0; i < 1024; ++i) {
+		found = gnix_ht_lookup(test_ht, test_elements[i].key);
+		assert(found != NULL);
+		assert(found == &test_elements[i]);
+		assert(found->magic == __GNIX_MAGIC_VALUE);
+	}
+}
+
+Test(gnix_hashtable_advanced, insert_1024_lookup_random)
+{
+	int ret, i;
+	gnix_test_element_t test_elements[1024];
+	gnix_test_element_t *found = NULL, *to_find = NULL;
+	gnix_test_element_t *item;
+
+	srand(time(NULL));
+
+	for (i = 0; i < 1024; ++i) {
+		item = &test_elements[i];
+
+		item->key = i;
+		item->val = rand() % (1024 * 1024);
+		item->magic = __GNIX_MAGIC_VALUE;
+	}
+
+	for (i = 0; i < 1024; ++i) {
+		item = &test_elements[i];
+
+		ret = gnix_ht_insert(test_ht,
+				item->key, item);
+		assert(ret == 0);
+		assert(atomic_get(&test_ht->ht_elements) == (i + 1));
+	}
+
+	assert(atomic_get(&test_ht->ht_elements) == 1024);
+
+	for (i = 0; i < 1024; ++i) {
+		to_find = &test_elements[rand() % 1024];
+		found = gnix_ht_lookup(test_ht, to_find->key);
+		assert(found != NULL);
+		assert(found == to_find);
+		assert(found->magic == __GNIX_MAGIC_VALUE);
+	}
+}
+
+Test(gnix_hashtable_advanced, insert_8K_lookup_128K_random)
+{
+	int ret, i, index;
+	gnix_test_element_t *test_elements;
+	gnix_test_element_t *found = NULL, *to_find = NULL;
+	gnix_test_element_t *item;
+	gnix_bitmap_t allocated;
+	int test_size = 8 * 1024;
+	int bitmap_size = 64 * test_size;
+	int lookups = 128 * 1024;
+
+	test_elements = calloc(test_size, sizeof(gnix_test_element_t));
+	assert(test_elements != NULL);
+
+	ret = alloc_bitmap(&allocated, bitmap_size);
+	assert(ret == 0);
+
+	srand(time(NULL));
+
+	for (i = 0; i < test_size; ++i) {
+		do {
+			index = rand() % bitmap_size;
+		} while (test_and_set_bit(&allocated, index));
+
+		item = &test_elements[i];
+
+		item->key = index;
+		item->val = rand() % lookups;
+		item->magic = __GNIX_MAGIC_VALUE;
+	}
+
+	for (i = 0; i < test_size; ++i) {
+		item = &test_elements[i];
+
+		ret = gnix_ht_insert(test_ht,
+				item->key, item);
+		assert(ret == 0);
+		assert(atomic_get(&test_ht->ht_elements) == (i + 1));
+	}
+
+	assert(atomic_get(&test_ht->ht_elements) == test_size);
+
+	for (i = 0; i < lookups; ++i) {
+		to_find = &test_elements[rand() % test_size];
+		found = gnix_ht_lookup(test_ht, to_find->key);
+		assert(found != NULL);
+		assert(found == to_find);
+		assert(found->magic == __GNIX_MAGIC_VALUE);
+	}
+
+	ret = free_bitmap(&allocated);
+	expect(ret == 0);
+
+	free(test_elements);
+}
+

--- a/prov/gni/test/hashtable.c
+++ b/prov/gni/test/hashtable.c
@@ -522,7 +522,7 @@ Test(gnix_hashtable_advanced, insert_8K_lookup_128K_random)
 	gnix_test_element_t *test_elements;
 	gnix_test_element_t *found = NULL, *to_find = NULL;
 	gnix_test_element_t *item;
-	gnix_bitmap_t allocated;
+	gnix_bitmap_t allocated = {0};
 	int test_size = 8 * 1024;
 	int bitmap_size = 64 * test_size;
 	int lookups = 128 * 1024;


### PR DESCRIPTION
The gnix_hashtable_t provides a set of basic functions for interacting with the hashtable as listed below:
-- gnix_ht_init
-- gnix_ht_destroy
-- gnix_ht_insert
-- gnix_ht_remove
-- gnix_ht_lookup
-- gnix_ht_empty

Detailed descriptions of each function are provided in the gnix_hashtable.h
header file.

Included with this commit are the fasthash functions, which will be located
in prov/gni/fasthash with all associated documentation

```
modified:   prov/gni/Makefile.am
new file:   prov/gni/fasthash/README
new file:   prov/gni/fasthash/fasthash.c
new file:   prov/gni/fasthash/fasthash.h
new file:   prov/gni/include/gnix_hashtable.h
new file:   prov/gni/src/gnix_hashtable.c
new file:   prov/gni/test/hashtable.c
```

closes #47 
