### PR TITLE
Close wait objects associated with CQ/EQ. Closes #129.

### DIFF
--- a/prov/gni/include/gnix_wait.h
+++ b/prov/gni/include/gnix_wait.h
@@ -76,6 +76,7 @@ struct gnix_fid_wait {
  */
 int gnix_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 		   struct fid_wait **waitset);
+int gnix_wait_close(struct fid *wait);
 
 /*
  * Exposed internal functions.

--- a/prov/gni/src/gnix_wait.c
+++ b/prov/gni/src/gnix_wait.c
@@ -248,7 +248,7 @@ static int gnix_wait_wait(struct fid_wait *wait, int timeout)
 	return -FI_ENOSYS;
 }
 
-static int gnix_wait_close(struct fid *wait)
+int gnix_wait_close(struct fid *wait)
 {
 	struct gnix_fid_wait *wait_priv;
 


### PR DESCRIPTION
This should close #129. I think this approach is fine, the only case we don't want to be closing anything is when it's a wait set. 

Also, the cq and eq are still pretty symmetric, and eventually that can be fixed. For now it's not important though.

Thoughts?

@hppritcha @sungeunchoi @ztiffany @jswaro 

Signed-off-by: Ben Turrubiates bturrubiates@lanl.gov
