### PR TITLE
Moved initialization into global init function run at load

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -432,6 +432,8 @@ struct gnix_work_req {
 extern const char gnix_fab_name[];
 extern const char gnix_dom_name[];
 extern uint32_t gnix_cdm_modes;
+extern atomic_t gnix_id_counter;
+
 
 /*
  * linked list helpers

--- a/prov/gni/include/gnix_cm_nic.h
+++ b/prov/gni/include/gnix_cm_nic.h
@@ -36,7 +36,6 @@
 
 #include "gnix.h"
 
-extern atomic_t gnix_id_counter;
 /*
  * prototypes for GNI CM NIC methods
  */

--- a/prov/gni/src/gnix_cm_nic.c
+++ b/prov/gni/src/gnix_cm_nic.c
@@ -42,9 +42,6 @@
 #include "gnix_datagram.h"
 #include "gnix_cm_nic.h"
 
-
-atomic_t gnix_id_counter;
-
 /*
  * generate a cdm_id, use the 16 LSB of base_id from domain
  * with 16 MSBs being obtained from atomic increment of

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -415,7 +415,5 @@ GNI_INI
 		provider = &gnix_prov;
 	}
 
-	atomic_initialize(&gnix_id_counter, 0);
-
 	return (provider);
 }

--- a/prov/gni/src/gnix_init.c
+++ b/prov/gni/src/gnix_init.c
@@ -38,6 +38,13 @@
 #include "fi.h"
 #include "prov.h"
 
+/**
+ * @note  To make sure that static linking will work, there must be at
+ *        least one symbol in the file that requires gnix_init.o to have
+ *        to be linked in when building the executable. This insures the
+ *        ctor will run even with static linking.
+ */
+
 atomic_t gnix_id_counter;
 
 /**

--- a/prov/gni/src/gnix_init.c
+++ b/prov/gni/src/gnix_init.c
@@ -37,3 +37,14 @@
 #include "gnix.h"
 #include "fi.h"
 #include "prov.h"
+
+atomic_t gnix_id_counter;
+
+/**
+ * Initialization function for performing global setup
+ */
+__attribute__((constructor))
+void gnix_init(void)
+{
+	atomic_initialize(&gnix_id_counter, 0);
+}


### PR DESCRIPTION
This commit moves the initialization of gnix_id_counter to a function that is called on library load, rather than fabric init. This will ensure that the atomic is only initialized once and provide a location for other such code in the future. 

closes #58 
