### PR TITLE
Add non-locking implementation of hash table

### DIFF
--- a/prov/gni/src/gnix_hashtable.c
+++ b/prov/gni/src/gnix_hashtable.c
@@ -418,9 +418,6 @@ static int __gnix_ht_lf_resize(
 	if (!new_tbl)
 		return -ENOMEM;
 
-	for (i = 0; i < new_size; ++i)
-		__gnix_ht_init_lf_list_head(&new_tbl[i]);
-
 	old_tbl = ht->ht_lf_tbl;
 	ht->ht_lf_tbl = new_tbl;
 	ht->ht_size = new_size;

--- a/prov/gni/test/hashtable.c
+++ b/prov/gni/test/hashtable.c
@@ -72,7 +72,7 @@ void __gnix_hashtable_test_uninitialized(void)
 {
 	assert(test_ht->ht_state == GNIX_HT_STATE_UNINITIALIZED);
 	assert(test_ht->ht_size == 0);
-	assert(test_ht->ht_tbl == NULL);
+	assert(test_ht->ht_lf_tbl == NULL);
 }
 
 void __gnix_hashtable_test_setup_bare(void)
@@ -97,7 +97,7 @@ void __gnix_hashtable_test_initialized(void)
 	assert(test_ht->ht_state == GNIX_HT_STATE_READY);
 	assert(atomic_get(&test_ht->ht_elements) == 0);
 	assert(test_ht->ht_size == test_ht->ht_attr.ht_initial_size);
-	assert(test_ht->ht_tbl != NULL);
+	assert(test_ht->ht_lf_tbl != NULL);
 }
 
 void __gnix_hashtable_test_destroyed_clean(void)
@@ -105,7 +105,7 @@ void __gnix_hashtable_test_destroyed_clean(void)
 	assert(test_ht->ht_state == GNIX_HT_STATE_DEAD);
 	assert(atomic_get(&test_ht->ht_elements) == 0);
 	assert(test_ht->ht_size == 0);
-	assert(test_ht->ht_tbl == NULL);
+	assert(test_ht->ht_lf_tbl == NULL);
 }
 
 void __gnix_hashtable_destroy(void)
@@ -163,6 +163,21 @@ Test(gnix_hashtable_basic, uninitialized)
 Test(gnix_hashtable_basic, initialize_ht)
 {
 	__gnix_hashtable_initialize();
+}
+
+Test(gnix_hashtable_basic, initialize_locked_ht)
+{
+	int ret;
+	gnix_hashtable_attr_t attr;
+
+	memcpy(&attr, &default_attr, sizeof(gnix_hashtable_attr_t));
+
+	attr.ht_internal_locking = 1;
+
+	ret = gnix_ht_init(test_ht, &attr);
+	assert(ret == 0);
+
+	__gnix_hashtable_test_initialized();
 }
 
 Test(gnix_hashtable_basic, err_initialize_twice)


### PR DESCRIPTION
This commit adds a non-threadsafe implementation of the hash table.
To get a non-threadsafe hashtable, the ht_internal_locking variable
must be set to 0 in the gnix_hashtable_attr_t structure passed to
init. By default, ht_internal_locking is set to 0 if no attributes
are passed to init, which requires the external API to take into
account the following:

```
With a non-threadsafe hashtable (attr->ht_internal_locking == 0):
-- gnix_ht_init, gnix_ht_destroy, gnix_ht_insert, and gnix_ht_remove
   must be called under an exclusive lock. Each function modifies the
   internal structures in a non-atomic fashion. These functions call be 
   called without lock so long as all other functions cannot be called.
-- gnix_ht_lookup can be called under a shared lock, or no lock at
   all so long as the other functions cannot be called while a lookup
   is in progress
```

When the threadsafe hashtable is in use, memory use of the structure
is increased linearly by the number of buckets in use. Each threadsafe
contains an embedded lock that increases the size of the bucket head
by the size of a pthread_rwlock_t. The non-threadsafe hashtable does
not have the embedded lock.

No changes need to be made to existing code that uses the hash table
as the API has not changed.

```
modified:   prov/gni/include/gnix_hashtable.h
modified:   prov/gni/src/gnix_hashtable.c
modified:   prov/gni/test/hashtable.c
```
