### PR TITLE
Refactored E* error codes to FI_E* error codes

### DIFF
--- a/prov/gni/include/gnix_bitmap.h
+++ b/prov/gni/include/gnix_bitmap.h
@@ -10,8 +10,9 @@
 
 #include <stdint.h>
 #include <pthread.h>
-#include <errno.h>
-#include "fi.h"
+#include <fi.h>
+#include <rdma/fi_errno.h>
+
 
 #define GNIX_BITMAP_BUCKET_BITS 6
 #define GNIX_BITMAP_BUCKET_LENGTH (1ULL << GNIX_BITMAP_BUCKET_BITS)
@@ -198,8 +199,10 @@ static inline int test_and_clear_bit(gnix_bitmap_t *bitmap, uint32_t index)
  * @param   bitmap  a gnix_bitmap pointer to the bitmap struct
  * @param   nbits   number of bits to request space for
  * @return  0       on success
- * @return  -EINVAL if bitmap is already initialized, or 0 is given as nbits
- * @return  -ENOMEM if there isn't sufficient memory available to create bitmap
+ * @return  -FI_EINVAL if bitmap is already initialized, or 0 is given
+ *          as nbits
+ * @return  -FI_ENOMEM if there isn't sufficient memory available to
+ *          create bitmap
  */
 int alloc_bitmap(gnix_bitmap_t *bitmap, uint32_t nbits);
 
@@ -215,8 +218,8 @@ int alloc_bitmap(gnix_bitmap_t *bitmap, uint32_t nbits);
  * @param   bitmap  a gnix_bitmap pointer to the bitmap struct
  * @param   nbits   number of bits to resize the bitmap to
  * @return  0       on success
- * @return  -EINVAL if the bitmap hasn't been allocated yet or nbits == 0
- * @return  -ENOMEM if there wasn't sufficient memory to expand the bitmap.
+ * @return  -FI_EINVAL if the bitmap hasn't been allocated yet or nbits == 0
+ * @return  -FI_ENOMEM if there wasn't sufficient memory to expand the bitmap.
  */
 int realloc_bitmap(gnix_bitmap_t *bitmap, uint32_t nbits);
 
@@ -225,7 +228,7 @@ int realloc_bitmap(gnix_bitmap_t *bitmap, uint32_t nbits);
  *
  * @param   bitmap  a gnix_bitmap pointer to the bitmap struct
  * @return  0       on success
- * @return  -EINVAL if the internal resources are uninitialized or already free
+ * @return  -FI_EINVAL if the internal resources are uninitialized or already free
  */
 int free_bitmap(gnix_bitmap_t *bitmap);
 
@@ -243,7 +246,7 @@ void fill_bitmap(gnix_bitmap_t *bitmap, uint64_t value);
  * @param   bitmap	a gnix_bitmap pointer to the bitmap struct
  * @return  index	on success, returns an index s.t.
  *                    0 <= index < bitmap->length
- * @return  -EAGAIN on failure to find a zero bit
+ * @return  -FI_EAGAIN on failure to find a zero bit
  */
 int find_first_zero_bit(gnix_bitmap_t *bitmap);
 
@@ -253,7 +256,7 @@ int find_first_zero_bit(gnix_bitmap_t *bitmap);
  * @param   bitmap  a gnix_bitmap pointer to the bitmap struct
  * @return  index   on success, returns a index s.t.
  *                    0 <= index < bitmap->length
- * @return  -EAGAIN on failure to find a set bit
+ * @return  -FI_EAGAIN on failure to find a set bit
  */
 int find_first_set_bit(gnix_bitmap_t *bitmap);
 
@@ -276,7 +279,7 @@ static inline int bitmap_full(gnix_bitmap_t *bitmap)
  */
 static inline int bitmap_empty(gnix_bitmap_t *bitmap)
 {
-	return find_first_set_bit(bitmap) == -EAGAIN;
+	return find_first_set_bit(bitmap) == -FI_EAGAIN;
 }
 
 #endif /* BITMAP_H_ */

--- a/prov/gni/include/gnix_hashtable.h
+++ b/prov/gni/include/gnix_hashtable.h
@@ -36,7 +36,7 @@
 #include <stdint.h>
 #include <pthread.h>
 
-#include "fi.h"
+#include <fi.h>
 #include "prov/gni/ccan/list.h"
 
 typedef uint64_t gnix_ht_key_t;
@@ -150,8 +150,8 @@ typedef struct gnix_hashtable {
  *
  * @param ht      pointer to the hash table structure
  * @param attr    pointer to the hash table attributes to initialize with
- * @return        0 on success, -EINVAL on initialization error, or -ENOMEM
- *                if allocation of the bucket array fails
+ * @return        0 on success, -FI_EINVAL on initialization error, or
+ *                -FI_ENOMEM if allocation of the bucket array fails
  */
 int gnix_ht_init(gnix_hashtable_t *ht, gnix_hashtable_attr_t *attr);
 
@@ -159,8 +159,8 @@ int gnix_ht_init(gnix_hashtable_t *ht, gnix_hashtable_attr_t *attr);
  * Destroys the hash table
  *
  * @param ht      pointer to the hash table structure
- * @return        0 on success, -EINVAL upon passing an uninitialized or dead
- *                structure
+ * @return        0 on success, -FI_EINVAL upon passing an uninitialized
+ *                or dead structure
  */
 int gnix_ht_destroy(gnix_hashtable_t *ht);
 
@@ -170,9 +170,9 @@ int gnix_ht_destroy(gnix_hashtable_t *ht);
  * @param ht      pointer to the hash table structure
  * @param key     key used to hash the entry
  * @param entry   entry to be stored
- * @return        0 on success, -ENOSPC when another entry with the same key
- *                exists in the hashtable, or -EINVAL when called on a dead or
- *                uninitialized hash table
+ * @return        0 on success, -FI_ENOSPC when another entry with the same key
+ *                exists in the hashtable, or -FI_EINVAL when called on a
+ *                dead or uninitialized hash table
  */
 int gnix_ht_insert(gnix_hashtable_t *ht, gnix_ht_key_t key, void *entry);
 
@@ -181,9 +181,9 @@ int gnix_ht_insert(gnix_hashtable_t *ht, gnix_ht_key_t key, void *entry);
  *
  * @param ht      pointer to the hash table structure
  * @param key     key used to hash the entry
- * @return        0 on success, -ENOENT when the key doesn't exist in the hash
- *                table, or -EINVAL when called on a dead or uninitialized hash
- *                table
+ * @return        0 on success, -FI_ENOENT when the key doesn't exist in
+ *                the hash table, or -FI_EINVAL when called on a dead or
+ *                uninitialized hash table
  */
 int gnix_ht_remove(gnix_hashtable_t *ht, gnix_ht_key_t key);
 

--- a/prov/gni/src/gnix_bitmap.c
+++ b/prov/gni/src/gnix_bitmap.c
@@ -6,7 +6,8 @@
  */
 
 #include <stdlib.h>
-#include <errno.h>
+#include <rdma/fi_errno.h>
+
 #include "gnix_bitmap.h"
 
 int find_first_zero_bit(gnix_bitmap_t *bitmap)
@@ -29,7 +30,7 @@ int find_first_zero_bit(gnix_bitmap_t *bitmap)
 		}
 	}
 
-	return -EAGAIN;
+	return -FI_EAGAIN;
 }
 
 int find_first_set_bit(gnix_bitmap_t *bitmap)
@@ -51,7 +52,7 @@ int find_first_set_bit(gnix_bitmap_t *bitmap)
 		}
 	}
 
-	return -EAGAIN;
+	return -FI_EAGAIN;
 }
 
 void fill_bitmap(gnix_bitmap_t *bitmap, uint64_t value)
@@ -69,15 +70,15 @@ int alloc_bitmap(gnix_bitmap_t *bitmap, uint32_t nbits)
 	int i;
 
 	if (bitmap->state == GNIX_BITMAP_STATE_READY)
-		return -EINVAL;
+		return -FI_EINVAL;
 
 	if (bitmap->length != 0 || nbits == 0)
-		return -EINVAL;
+		return -FI_EINVAL;
 
 	bitmap->arr = calloc(GNIX_BITMAP_BLOCKS(nbits),
 			sizeof(gnix_bitmap_block_t));
 	if (!bitmap->arr)
-		return -ENOMEM;
+		return -FI_ENOMEM;
 
 	bitmap->length = nbits;
 
@@ -96,17 +97,17 @@ int realloc_bitmap(gnix_bitmap_t *bitmap, uint32_t nbits)
 	int i;
 
 	if (bitmap->state != GNIX_BITMAP_STATE_READY)
-		return -EINVAL;
+		return -FI_EINVAL;
 
 	if (nbits == 0 || bitmap->arr == NULL)
-		return -EINVAL;
+		return -FI_EINVAL;
 
 	new_allocation = realloc(bitmap->arr,
 			(blocks_to_allocate *
 					sizeof(gnix_bitmap_block_t)));
 
 	if (!new_allocation)
-		return -ENOMEM;
+		return -FI_ENOMEM;
 
 	bitmap->arr = new_allocation;
 
@@ -128,7 +129,7 @@ int realloc_bitmap(gnix_bitmap_t *bitmap, uint32_t nbits)
 int free_bitmap(gnix_bitmap_t *bitmap)
 {
 	if (bitmap->state != GNIX_BITMAP_STATE_READY)
-		return -EINVAL;
+		return -FI_EINVAL;
 
 	bitmap->length = 0;
 	if (bitmap->arr) {

--- a/prov/gni/test/bitmap.c
+++ b/prov/gni/test/bitmap.c
@@ -41,7 +41,7 @@
 #include <stdint.h>
 #include <sys/time.h>
 
-#include <errno.h>
+#include <rdma/fi_errno.h>
 #include <gnix_bitmap.h>
 
 #ifdef assert
@@ -172,7 +172,7 @@ Test(gnix_bitmap, initialize_0)
 	int ret;
 
 	ret = alloc_bitmap(test_bitmap, 0);
-	assert(ret == -EINVAL);
+	assert(ret == -FI_EINVAL);
 
 	call_free_bitmap = 0;
 }
@@ -184,7 +184,7 @@ Test(gnix_bitmap, already_initialized)
 	__test_initialize_bitmap(test_bitmap, 128);
 
 	ret = alloc_bitmap(test_bitmap, 128);
-	assert(ret == -EINVAL);
+	assert(ret == -FI_EINVAL);
 
 	call_free_bitmap = 0;
 }
@@ -201,7 +201,7 @@ Test(gnix_bitmap, destroy_bitmap_uninitialized)
 	int ret;
 
 	ret = free_bitmap(test_bitmap);
-	assert(ret == -EINVAL);
+	assert(ret == -FI_EINVAL);
 	expect(test_bitmap->arr == NULL);
 	expect(test_bitmap->length == 0);
 	expect(test_bitmap->state == GNIX_BITMAP_STATE_UNINITIALIZED);
@@ -216,7 +216,7 @@ Test(gnix_bitmap, destroy_bitmap_already_freed)
 	__test_free_bitmap_clean(test_bitmap);
 
 	ret = free_bitmap(test_bitmap);
-	assert(ret == -EINVAL);
+	assert(ret == -FI_EINVAL);
 	expect(test_bitmap->arr == NULL);
 	expect(test_bitmap->length == 0);
 	expect(test_bitmap->state == GNIX_BITMAP_STATE_FREE);
@@ -367,7 +367,7 @@ Test(gnix_bitmap, ffs_clean_bitmap)
 {
 	__test_initialize_bitmap_clean(test_bitmap, 64);
 
-	assert(find_first_set_bit(test_bitmap) == -EAGAIN);
+	assert(find_first_set_bit(test_bitmap) == -FI_EAGAIN);
 }
 
 Test(gnix_bitmap, ffs_first_bit_set)
@@ -406,7 +406,7 @@ Test(gnix_bitmap, ffz_full_bitmap)
 		assert(test_bit(test_bitmap, i));
 	}
 
-	assert(find_first_zero_bit(test_bitmap) == -EAGAIN);
+	assert(find_first_zero_bit(test_bitmap) == -FI_EAGAIN);
 }
 
 Test(gnix_bitmap, ffz_first_half_set)

--- a/prov/gni/test/hashtable.c
+++ b/prov/gni/test/hashtable.c
@@ -35,7 +35,7 @@
 #include <stdio.h>
 #include <stdint.h>
 
-#include <errno.h>
+#include <rdma/fi_errno.h>
 #include <gnix_hashtable.h>
 #include <gnix_bitmap.h>
 
@@ -187,7 +187,7 @@ Test(gnix_hashtable_basic, err_initialize_twice)
 	__gnix_hashtable_initialize();
 
 	ret = gnix_ht_init(test_ht, NULL);
-	assert(ret == -EINVAL);
+	assert(ret == -FI_EINVAL);
 	__gnix_hashtable_test_initialized();
 }
 
@@ -201,7 +201,7 @@ Test(gnix_hashtable_basic, err_invalid_initial_size_0)
 	attr.ht_initial_size = 0;
 
 	ret = gnix_ht_init(test_ht, &attr);
-	assert(ret == -EINVAL);
+	assert(ret == -FI_EINVAL);
 	__gnix_hashtable_test_uninitialized();
 }
 
@@ -215,7 +215,7 @@ Test(gnix_hashtable_basic, err_invalid_initial_size_gt_max)
 	attr.ht_initial_size = attr.ht_maximum_size * 2;
 
 	ret = gnix_ht_init(test_ht, &attr);
-	assert(ret == -EINVAL);
+	assert(ret == -FI_EINVAL);
 	__gnix_hashtable_test_uninitialized();
 }
 
@@ -229,7 +229,7 @@ Test(gnix_hashtable_basic, err_invalid_max_size)
 	attr.ht_maximum_size = 0;
 
 	ret = gnix_ht_init(test_ht, &attr);
-	assert(ret == -EINVAL);
+	assert(ret == -FI_EINVAL);
 	__gnix_hashtable_test_uninitialized();
 }
 
@@ -243,7 +243,7 @@ Test(gnix_hashtable_basic, err_invalid_increase_step_all)
 	attr.ht_increase_step = 0;
 
 	ret = gnix_ht_init(test_ht, &attr);
-	assert(ret == -EINVAL);
+	assert(ret == -FI_EINVAL);
 	__gnix_hashtable_test_uninitialized();
 }
 
@@ -258,7 +258,7 @@ Test(gnix_hashtable_basic, err_invalid_increase_step_mult)
 	attr.ht_increase_type = GNIX_HT_INCREASE_MULT;
 
 	ret = gnix_ht_init(test_ht, &attr);
-	assert(ret == -EINVAL);
+	assert(ret == -FI_EINVAL);
 	__gnix_hashtable_test_uninitialized();
 }
 
@@ -272,7 +272,7 @@ Test(gnix_hashtable_basic, err_invalid_increase_type)
 	attr.ht_increase_type = -1;
 
 	ret = gnix_ht_init(test_ht, &attr);
-	assert(ret == -EINVAL);
+	assert(ret == -FI_EINVAL);
 	__gnix_hashtable_test_uninitialized();
 }
 
@@ -286,7 +286,7 @@ Test(gnix_hashtable_basic, err_invalid_collision)
 	attr.ht_collision_thresh = 0;
 
 	ret = gnix_ht_init(test_ht, &attr);
-	assert(ret == -EINVAL);
+	assert(ret == -FI_EINVAL);
 	__gnix_hashtable_test_uninitialized();
 }
 
@@ -295,7 +295,7 @@ Test(gnix_hashtable_basic, err_destroy_uninitialized)
 	int ret;
 
 	ret = gnix_ht_destroy(test_ht);
-	assert(ret == -EINVAL);
+	assert(ret == -FI_EINVAL);
 
 	__gnix_hashtable_test_uninitialized();
 }
@@ -316,7 +316,7 @@ Test(gnix_hashtable_basic, destroy_twice)
 	__gnix_hashtable_destroy();
 
 	ret = gnix_ht_destroy(test_ht);
-	assert(ret == -EINVAL);
+	assert(ret == -FI_EINVAL);
 	__gnix_hashtable_test_destroyed_clean();
 }
 
@@ -340,7 +340,7 @@ Test(gnix_hashtable_advanced, insert_duplicate)
 	assert(atomic_get(&test_ht->ht_elements) == 1);
 
 	ret = gnix_ht_insert(test_ht, simple_element->key, simple_element);
-	assert(ret == -ENOSPC);
+	assert(ret == -FI_ENOSPC);
 
 	assert(atomic_get(&test_ht->ht_elements) == 1);
 }


### PR DESCRIPTION
This commit changes the return codes from the bitmap and hash table
files to use FI_E\* error codes. This change is intended to bring the
source in line with the rest of the provider code.

Signed-off-by: James Swaro jswaro@cray.com

```
modified:   prov/gni/include/gnix_bitmap.h
modified:   prov/gni/include/gnix_hashtable.h
modified:   prov/gni/src/gnix_bitmap.c
modified:   prov/gni/src/gnix_hashtable.c
modified:   prov/gni/test/bitmap.c
modified:   prov/gni/test/hashtable.c
```

closes #134 
