### PR TITLE
prov/gni: improvements to cm_nic code

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -297,29 +297,6 @@ struct gnix_fid_av {
 };
 
 /*
- * work queue struct, used for handling delay ops, etc. in a generic wat
- */
-/*
- * gnix cm nic struct - to be used only for GNI_EpPostData, etc.
- */
-
-
-struct gnix_cm_nic {
-	fastlock_t lock;
-	gni_cdm_handle_t gni_cdm_hndl;
-	gni_nic_handle_t gni_nic_hndl;
-	struct gnix_dgram_hndl *dgram_hndl;
-	struct gnix_fid_domain *domain;
-	/* work queue for cm nic */
-	struct list_head cm_nic_wq;
-	uint32_t cdm_id;
-	uint8_t ptag;
-	uint32_t cookie;
-	uint32_t device_id;
-	uint32_t device_addr;
-};
-
-/*
  * defines for connection state for gnix VC
  */
 enum gnix_vc_conn_state {

--- a/prov/gni/src/gnix_cm.c
+++ b/prov/gni/src/gnix_cm.c
@@ -33,6 +33,7 @@
 
 #include "gnix.h"
 #include "gnix_nic.h"
+#include "gnix_cm_nic.h"
 
 /*
  * Retrieve the local endpoint address.

--- a/prov/gni/src/gnix_datagram.c
+++ b/prov/gni/src/gnix_datagram.c
@@ -56,6 +56,7 @@
 #include "gnix.h"
 #include "gnix_datagram.h"
 #include "gnix_util.h"
+#include "gnix_cm_nic.h"
 
 
 /*******************************************************************************

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -442,7 +442,7 @@ static int gnix_ep_close(fid_t fid)
 
 	cm_nic = ep->cm_nic;
 	assert(cm_nic != NULL);
-	gnix_cm_nic_free(cm_nic);
+	_gnix_cm_nic_free(cm_nic);
 
 	nic = ep->nic;
 	assert(nic != NULL);
@@ -552,7 +552,7 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 	 */
 	if (ep_priv->type == FI_EP_RDM) {
 		ep_priv->vc_hash_hndl = NULL;
-		ret = gnix_cm_nic_alloc(domain_priv,
+		ret = _gnix_cm_nic_alloc(domain_priv,
 					 &ep_priv->cm_nic);
 		if (ret != FI_SUCCESS)
 			goto err;

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -204,7 +204,7 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 			goto err_w_lock;
 		}
 
-		ret = gnix_get_new_cdm_id(domain, &fake_cdm_id);
+		ret = _gnix_get_new_cdm_id(domain, &fake_cdm_id);
 		if (ret != FI_SUCCESS)
 			goto err_w_lock;
 


### PR DESCRIPTION
Cleanup, addition of hook to progress cm nic's state:
- move the definition of gnix_cm_nic in to the gnix_cm_nic header file
- add doxygen style verbiage in gnix_cm_nic.h header file
- add work queue logic to process work queue elements enqueued on
  the cm_nic's work queue
- add locks to be able to progress work queue in a thread safe manner
- switched to the _gnix name convention for these gni provider internal
  functions
- added a manual progress test to test/datagram.c criterion test

Needed for progress on issue #5 

Signed-off-by: Howard Pritchard howardp@lanl.gov
