### PR TITLE
Fixed ffs and ffz functions for bitmaps of non-qword length multiples

### DIFF
--- a/prov/gni/src/gnix_bitmap.c
+++ b/prov/gni/src/gnix_bitmap.c
@@ -26,7 +26,10 @@ int find_first_zero_bit(gnix_bitmap_t *bitmap)
 			   established there is an unset bit */
 			pos += ffsll(value) - 1;
 
-			return pos;
+			if (pos < bitmap->length)
+				return pos;
+			else
+				return -FI_EAGAIN;
 		}
 	}
 
@@ -48,8 +51,10 @@ int find_first_set_bit(gnix_bitmap_t *bitmap)
 			   established there is a set bit */
 			pos += ffsll(value) - 1;
 
-			return pos;
-		}
+			if (pos < bitmap->length)
+				return pos;
+			else
+				return -FI_EAGAIN;		}
 	}
 
 	return -FI_EAGAIN;

--- a/prov/gni/test/bitmap.c
+++ b/prov/gni/test/bitmap.c
@@ -527,3 +527,31 @@ Test(gnix_bitmap, performance_set_test_random)
 	expect(secs < 1);
 }
 
+Test(gnix_bitmap, fill_bitmap_60_ffz_eagain)
+{
+	int i;
+
+	__test_initialize_bitmap_clean(test_bitmap, 60);
+
+	for (i = 0; i < 60; ++i)
+		set_bit(test_bitmap, i);
+
+	assert(find_first_zero_bit(test_bitmap) == -FI_EAGAIN);
+}
+
+Test(gnix_bitmap, fill_bitmap_60_ffs_eagain)
+{
+	int i;
+
+	__test_initialize_bitmap_clean(test_bitmap, 60);
+
+	/* this will succeed because set_bit doesn't account for bounds of the
+	 *   bitmap as the user should be responsible for handling the bitmap
+	 *   properly.
+	 */
+	for (i = 60; i < 64; ++i)
+		set_bit(test_bitmap, i);
+
+	assert(find_first_set_bit(test_bitmap) == -FI_EAGAIN);
+}
+


### PR DESCRIPTION
If the bitmap has a length that is not a qword length multiple,
find_first_set_bit and find_first_zero_bit may return an index which
is greater than or equal to the length of the bitmap. This return value
is erroneous from the perspective of user, who should expect the following:

```
0 <= value < bitmap->length
```

This commit fixes this behavior for the two mentioned functions and adds
two new tests to check for this behavior.

Signed-off-by: James Swaro jswaro@cray.com

```
modified:   prov/gni/src/gnix_bitmap.c
modified:   prov/gni/test/bitmap.c
```

closes #142 
