### PR TITLE
prov/gni: switch travis yaml to use hppritcha repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     sudo apt-get update;
     sudo apt-get install gcc-4.9;
     export CC="gcc-4.9";
-  - git clone https://github.com/bturrubiates/ugni-build.git;
+  - git clone https://github.com/hppritcha/ugni-build.git;
     pushd ugni-build;
     tar -xf ugni.build.tgz;
     pushd ugni-build;


### PR DESCRIPTION
Switch from using bturrubiates to hppritcha
for ugni/alps/everything tarball.

@sungeunchoi 
not asking to review, just for your info.

Fixes #151

Signed-off-by: Howard Pritchard howardp@lanl.gov
