### PR TITLE
prov/gni: implement vc connection setup

### DIFF
--- a/prov/gni/Makefile.am
+++ b/prov/gni/Makefile.am
@@ -26,6 +26,7 @@ _gni_files = \
 	prov/gni/src/gnix_datagram.c \
 	prov/gni/src/gnix_cm_nic.c \
 	prov/gni/src/gnix_nic.c \
+	prov/gni/src/gnix_vc.c \
 	prov/gni/src/gnix_util.c \
 	prov/gni/src/gnix_freelist.c \
 	prov/gni/src/gnix_bitmap.c \
@@ -46,7 +47,8 @@ gnitest_SOURCES = \
 	prov/gni/test/freelist.c \
 	prov/gni/test/hashtable.c \
 	prov/gni/test/allocator.c \
-	prov/gni/test/mr.c
+	prov/gni/test/mr.c \
+	prov/gni/test/vc.c
 
 gnitest_LDFLAGS = -static
 gnitest_CPPFLAGS = $(AM_CPPFLAGS)

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -43,6 +43,8 @@ extern "C" {
 #endif /* HAVE_CONFIG_H */
 
 #include "gnix.h"
+#include "gnix_bitmap.h"
+#include "gnix_mbox_allocator.h"
 #include <assert.h>
 
 /*
@@ -86,12 +88,20 @@ struct gnix_nic {
 	struct list_head tx_desc_free_list;
 	struct gnix_tx_descriptor *tx_desc_base;
 	atomic_t outstanding_fab_reqs_nic;
+	fastlock_t wq_lock;
 	struct list_head nic_wq;
 	uint8_t ptag;
 	uint32_t cookie;
 	uint32_t device_id;
 	uint32_t device_addr;
 	int max_tx_desc_id;
+	fastlock_t vc_id_lock;
+	struct gnix_vc **vc_id_table;
+	int vc_id_table_capacity;
+	int vc_id_table_count;
+	gnix_bitmap_t vc_id_bitmap;
+	uint32_t mem_per_mbox;
+	struct gnix_mbox_alloc_handle *mbox_hndl;
 	atomic_t ref_cnt;
 };
 
@@ -144,6 +154,7 @@ int _gnix_nic_tx_freelist_init(struct gnix_nic *nic, int n_descs);
 int _gnix_nic_free(struct gnix_nic *nic);
 int gnix_nic_alloc(struct gnix_fid_domain *domain,
 			struct gnix_nic **nic_ptr);
+int _gnix_nic_progress(struct gnix_nic *nic);
 
 /*
  * inline functions

--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _GNIX_VC_H_
+#define _GNIX_VC_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#include "gnix.h"
+#include "gnix_nic.h"
+
+/*
+ * mode bits
+ */
+#define GNIX_VC_MODE_IN_WQ		(1U)
+#define GNIX_VC_MODE_IN_HT		(1U << 1)
+#define GNIX_VC_MODE_DG_POSTED		(1U << 2)
+
+/*
+ * defines for connection state for gnix VC
+ */
+enum gnix_vc_conn_state {
+	GNIX_VC_CONN_NONE = 1,
+	GNIX_VC_CONNECTING,
+	GNIX_VC_CONNECTED,
+	GNIX_VC_CONN_TERMINATING,
+	GNIX_VC_CONN_TERMINATED,
+	GNIX_VC_CONN_ERROR
+};
+
+enum gnix_vc_conn_req_type {
+	GNIX_VC_CONN_REQ_CONN = 100,
+	GNIX_VC_CONN_REQ_LISTEN
+};
+
+/**
+ * Virual Connection (VC) struct
+ *
+ * @var send_queue           linked list of pending send requests to be
+ *                           delivered to peer_address
+ * @var entry                used internally for managing linked lists
+ *                           of vc structs that require O(1) insertion/removal
+ * @var peer_addr            address of peer with which this VC is connected
+ * @var ep                   libfabric endpoint with which this VC is
+ *                           associated
+ * @var smsg_mbox            pointer to GNI SMSG mailbox used by this VC
+ *                           to exchange SMSG messages with its peer
+ * @var dgram                pointer to dgram - used in connection setup
+ * @var gni_ep               GNI endpoint for this VC
+ * @var outstanding_fab_reqs Count of outstanding libfabric level requests
+ *                           associated with this endpoint.
+ * @var conn_state           Connection state of this VC
+ * @var vc_id                ID of this vc. Allows for rapid O(1) lookup
+ *                           of the VC when using GNI_CQ_GET_INST_ID to get
+ *                           the inst_id of a GNI CQE.
+ * @var modes                Used internally to track current state of
+ *                           the VC not pertaining to the connection state.
+ */
+struct gnix_vc {
+	struct slist send_queue;
+	struct dlist_entry entry;
+	struct gnix_address peer_addr;
+	struct gnix_fid_ep *ep;
+	void *smsg_mbox;
+	struct gnix_datagram *dgram;
+	gni_ep_handle_t gni_ep;
+	atomic_t outstanding_fab_reqs;
+	enum gnix_vc_conn_state conn_state;
+	int vc_id;
+	int modes;
+};
+
+/*
+ * prototypes
+ */
+
+/**
+ * @brief Allocates a virtual channel(vc) struct
+ *
+ * @param[in]  ep_priv    pointer to previously allocated gnix_fid_ep object
+ * @param[in]  dest_addr  remote peer address for this VC
+ * @param[out] vc         location in which the address of the allocated vc
+ *                        struct is to be returned.
+ * @return FI_SUCCESS on success, -FI_ENOMEM if allocation of vc struct fails,
+ */
+int _gnix_vc_alloc(struct gnix_fid_ep *ep_priv, fi_addr_t dest_addr,
+			struct gnix_vc **vc);
+
+/**
+ * @brief Initiates non-blocking connect of a vc with its peer
+ *
+ * @param[in]  vc   pointer to previously allocated vc struct
+ *
+ * @return FI_SUCCESS on success, -FI_EINVAL if an invalid field in the vc
+ *         struct is encountered, -ENOMEM if insufficient memory to initiate
+ *         connection request.
+ */
+int _gnix_vc_connect(struct gnix_vc *vc);
+
+
+/**
+ * @brief Sets up an accepting vc - one accepting vc can accept a
+ *        single incoming connection request
+ *
+ * @param[in]  vc   pointer to previously allocated vc struct with
+ *                  FI_ADDR_UNSPEC value supplied for the fi_addr_t
+ *                  argument
+ *
+ * @return FI_SUCCESS on success, -FI_EINVAL if an invalid field in the vc
+ *         struct is encountered, -ENOMEM if insufficient memory to initiate
+ *         accept request.
+ */
+int _gnix_vc_accept(struct gnix_vc *vc);
+
+/**
+ * @brief Initiates a non-blocking disconnect of a vc from its peer
+ *
+ * @param[in]  vc   pointer to previously allocated and connected vc struct
+ *
+ * @return FI_SUCCESS on success, -FI_EINVAL if an invalid field in the vc
+ *         struct is encountered, -ENOMEM if insufficient memory to initiate
+ *         connection request.
+ */
+int _gnix_vc_disconnect(struct gnix_vc *vc);
+
+
+/**
+ * @brief Destroys a previously allocated vc and cleans up resources
+ *        associated with the vc
+ *
+ * @param[in]  vc   pointer to previously allocated vc struct
+ *
+ * @return FI_SUCCESS on success, -FI_EINVAL if an invalid field in the vc
+ *         struct is encountered.
+ */
+int _gnix_vc_destroy(struct gnix_vc *vc);
+
+/**
+ * @brief Add a vc to the work queue of its associated nic
+ *
+ * @param[in] vc  pointer to previously allocated vc struct
+ *
+ * @return FI_SUCCESS on success, -ENOMEM if insufficient memory
+ * 	   allocate memory to enqueue work request
+ */
+int _gnix_vc_add_to_wq(struct gnix_vc *vc);
+
+/*
+ * inline functions
+ */
+
+/**
+ * @brief Return connection state of a vc
+ *
+ * @param[in]  vc     pointer to previously allocated vc struct
+ * @return connection state of vc
+ */
+static inline enum gnix_vc_conn_state _gnix_vc_state(struct gnix_vc *vc)
+{
+	assert(vc);
+	return vc->conn_state;
+}
+
+/**
+ * @brief Look up vc by id
+ *
+ * @param[in] nic    pointer to gni nic with which the vc is associated
+ * @param[in] vc_d   id of the vc being looked up
+ *
+ * @return           pointer to vc with the given vc_id
+ */
+static inline struct gnix_vc *_gnix_vc_get_by_id(struct gnix_nic *nic,
+						int vc_id)
+{
+	assert(nic);
+	assert(vc_id <= nic->vc_id_table_count);
+	return nic->vc_id_table[vc_id];
+}
+
+#endif /* _GNIX_VC_H_ */

--- a/prov/gni/src/gnix_av.c
+++ b/prov/gni/src/gnix_av.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Cray Inc. All rights reserved.
- * Copyright (c) 2015 Los Alamos National Security, LLC. Allrights reserved.
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -278,6 +278,8 @@ static int map_lookup(struct gnix_fid_av *int_av, fi_addr_t fi_addr, void *addr,
 	int ret = FI_SUCCESS;
 	size_t copy_size;
 
+	GNIX_TRACE(FI_LOG_AV, "\n");
+
 	copy_size = sizeof(out);
 
 	if (*addrlen < copy_size) {
@@ -353,6 +355,8 @@ static int gnix_av_insert(struct fid_av *av, const void *addr, size_t count,
 	struct gnix_fid_av *int_av = NULL;
 	int ret = FI_SUCCESS;
 
+	GNIX_TRACE(FI_LOG_AV, "\n");
+
 	if (!av) {
 		ret = -FI_EINVAL;
 		goto err;
@@ -387,6 +391,8 @@ static int gnix_av_remove(struct fid_av *av, fi_addr_t *fi_addr, size_t count,
 {
 	struct gnix_fid_av *int_av = NULL;
 	int ret = FI_SUCCESS;
+
+	GNIX_TRACE(FI_LOG_AV, "\n");
 
 	if (!av) {
 		ret = -FI_EINVAL;
@@ -447,6 +453,8 @@ static int gnix_av_close(fid_t fid)
 	struct gnix_fid_av *av = NULL;
 	int ret = FI_SUCCESS;
 
+	GNIX_TRACE(FI_LOG_AV, "\n");
+
 	if (!fid) {
 		ret = -FI_EINVAL;
 		goto err;
@@ -479,6 +487,8 @@ int gnix_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	enum fi_av_type type = FI_AV_TABLE;
 	size_t count = 128;
 	int ret = FI_SUCCESS;
+
+	GNIX_TRACE(FI_LOG_AV, "\n");
 
 	if (!domain) {
 		ret = -FI_EINVAL;

--- a/prov/gni/src/gnix_cm.c
+++ b/prov/gni/src/gnix_cm.c
@@ -32,6 +32,7 @@
  */
 
 #include "gnix.h"
+#include "gnix_util.h"
 #include "gnix_nic.h"
 #include "gnix_cm_nic.h"
 
@@ -53,6 +54,8 @@ static int gnix_getname(fid_t fid, void *addr, size_t *addrlen)
 	struct gnix_fid_ep *ep = NULL;
 	int ret = FI_SUCCESS;
 	size_t copy_size;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
 	copy_size = sizeof(struct gnix_ep_name);
 

--- a/prov/gni/src/gnix_cm_nic.c
+++ b/prov/gni/src/gnix_cm_nic.c
@@ -220,6 +220,7 @@ int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 	cm_nic->control_progress = domain->control_progress;
 	fastlock_init(&cm_nic->lock);
 	fastlock_init(&cm_nic->wq_lock);
+	list_head_init(&cm_nic->cm_nic_wq);
 
 	/*
 	 * prep the cm nic's dgram component

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -1,0 +1,1213 @@
+/*
+ * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * code for managing VC's
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include "gnix.h"
+#include "gnix_vc.h"
+#include "gnix_util.h"
+#include "gnix_datagram.h"
+#include "gnix_cm_nic.h"
+#include "gnix_mbox_allocator.h"
+#include "gnix_hashtable.h"
+
+/*******************************************************************************
+ * Helper functions.
+ ******************************************************************************/
+
+static int __gnix_vc_free_id(struct gnix_vc *vc)
+{
+	struct gnix_fid_ep *ep = NULL;
+	struct gnix_nic *nic;
+
+	ep = vc->ep;
+	if (ep == NULL)
+		return -FI_EINVAL;
+
+	nic = ep->nic;
+	if (nic == NULL)
+		return -FI_EINVAL;
+
+	__gnix_clear_bit(&nic->vc_id_bitmap, vc->vc_id);
+
+	return FI_SUCCESS;
+}
+
+/*
+ * this function is needed to allow for quick lookup of a vc based on
+ * the contents of the GNI CQE coming off of the GNI RX CQ associated
+ * with GNI nic being used by this VC.  Using a bitmap to expedite
+ * scanning vc's in the case of a GNI CQ overrun.
+ */
+
+static int _gnix_vc_get_id(struct gnix_vc *vc)
+{
+	int ret = FI_SUCCESS;
+	struct gnix_fid_ep *ep = NULL;
+	struct gnix_nic *nic;
+	struct gnix_vc **table_base;
+
+	ep = vc->ep;
+	if (ep == NULL)
+		return -FI_EINVAL;
+
+	nic = ep->nic;
+	if (nic == NULL)
+		return -FI_EINVAL;
+
+	/*
+	 * TODO:  really need to search bitmap for clear
+	 * bit before resizing the table
+	 */
+
+	fastlock_acquire(&nic->vc_id_lock);
+	if (nic->vc_id_table_capacity == nic->vc_id_table_count) {
+		table_base = realloc(nic->vc_id_table,
+				     2 * nic->vc_id_table_capacity *
+				     sizeof(struct gnix_vc *));
+		if (table_base == NULL) {
+			ret =  -FI_ENOMEM;
+			goto err;
+		}
+		nic->vc_id_table_capacity *= 2;
+		nic->vc_id_table = table_base;
+	}
+
+	nic->vc_id_table[nic->vc_id_table_count] = vc;
+	vc->vc_id = nic->vc_id_table_count;
+
+	/*
+	 * set bit in the bitmap
+	 */
+
+	__gnix_set_bit(&nic->vc_id_bitmap, nic->vc_id_table_count);
+
+	++(nic->vc_id_table_count);
+err:
+	fastlock_release(&nic->vc_id_lock);
+	return ret;
+}
+
+/*
+ * call back prior to posting of datagram to kgni,
+ * within the critical region surrounding the call
+ * to GNI_EpPostDataWId.
+ *
+ * Returning 1 in the address post, says to post
+ * the datagram to kgni, otherwise not.
+ */
+
+static int  __gnix_vc_pre_post_clbk(struct gnix_datagram *dgram,
+					int *post)
+{
+	int ret = FI_SUCCESS;
+	int can_we_post = 1;
+	struct gnix_vc *vc;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	vc = (struct gnix_vc *)dgram->cache;
+	assert(vc);
+
+	/*
+	 * vc should be in the hash table
+	 */
+
+	assert(vc->modes & GNIX_VC_MODE_IN_HT);
+
+	/*
+	 * the VC may have already completed connecting
+	 * if one of the local WC datagrams got matched
+	 * with the peer we were trying to connect to.
+	 * In this case, don't post the datagram.
+	 */
+	if ((vc->conn_state == GNIX_VC_CONNECTED)
+		|| (vc->conn_state == GNIX_VC_CONNECTING))
+		can_we_post = 0;
+
+	*post = can_we_post;
+	return ret;
+}
+
+/*
+ * call back after posting of datagram to kgni,
+ * within the critical region surrounding call to
+ * GNI_EpPostDataWId.
+ *
+ * The vc is transitioned to GNIX_VC_CONNECTING if
+ * the datagram has been successfully posted to kgni,
+ * or there is already a wildcard match to the
+ * VC's address in kgni's datagram state engine.
+ * Otherwise move the vc to error state and return
+ * error code.
+ */
+static int __gnix_vc_post_post_clbk(struct gnix_datagram *dgram,
+				    gni_return_t status)
+{
+	int ret;
+	struct gnix_vc *vc;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	vc = (struct gnix_vc *)dgram->cache;
+	assert(vc);
+
+	switch (status) {
+	case GNI_RC_SUCCESS:
+		vc->modes |= GNIX_VC_MODE_DG_POSTED;
+	case GNI_RC_ERROR_RESOURCE:
+		vc->conn_state = GNIX_VC_CONNECTING;
+		ret = FI_SUCCESS;
+		break;
+	default:
+		vc->conn_state = GNIX_VC_CONN_ERROR;
+		ret = gnixu_to_fi_errno(status);
+	}
+	return ret;
+}
+
+/*
+ * special call back for wildcard datagrams.  The
+ * call back is invoked after calling GNI_EpPostDataTestById
+ * within the critical region surrounding the call.
+ *
+ * If the post state reported by GNI indicates that
+ * the datagram was matched, insert the vc into
+ * the hash table and transition to GNIX_VC_CONNECTING.
+ *
+ * Note there are several intermediate gni post states
+ * that may be reported as a datagram exchange is taking
+ * place: GNI_POST_COMPLETED, GNI_POST_REMOTE_DATA,
+ * and GNI_POST_PENDING, so this routine may be invoked
+ * multiple times per completing datagram exchange.
+ */
+static int __gnix_vc_post_test_clbk(struct gnix_datagram *dgram,
+				    struct gnix_address peer_addr,
+				    gni_post_state_t post_state)
+{
+	int ret = FI_SUCCESS;
+	gnix_ht_key_t key;
+	struct gnix_vc *vc = NULL;
+	struct gnix_fid_ep *ep = NULL;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	vc = (struct gnix_vc *)dgram->cache;
+	assert(vc);
+
+	ep = vc->ep;
+	assert(ep);
+	assert(ep->vc_ht);
+
+	switch (post_state) {
+	case GNI_POST_COMPLETED:
+	case GNI_POST_REMOTE_DATA:
+	case GNI_POST_PENDING:
+		if (GNIX_ADDR_UNSPEC(vc->peer_addr)) {
+			vc->peer_addr = peer_addr;
+			memcpy(&key, &peer_addr,
+				sizeof(gnix_ht_key_t));
+			ret = gnix_ht_insert(ep->vc_ht, key,
+						vc);
+			if (ret == FI_SUCCESS) {
+				vc->modes |= GNIX_VC_MODE_IN_HT;
+				vc->conn_state =
+					GNIX_VC_CONNECTING;
+			} else if (ret != -FI_ENOSPC)
+				GNIX_WARN(FI_LOG_EP_CTRL,
+				"__gnix_vc_post_test_clbk (0x%x,0x%x) %d\n",
+				peer_addr.device_addr,
+				peer_addr.cdm_id,
+				ret);
+		}
+		break;
+	default:
+		break;
+	}
+	return ret;
+}
+
+/*
+ * My connection request matched either a connection
+ * request from my peer or a wildcard.  This means
+ * I have already inserted the vc in to the hash table
+ * and may potentially have a message backlog.
+ */
+
+static int __gnix_vc_hndl_con_match_con(struct gnix_datagram *dgram,
+					struct gnix_address peer_address)
+{
+	int ret = FI_SUCCESS;
+	struct gnix_vc *vc = NULL;
+	struct gnix_fid_ep *ep;
+	struct gnix_nic *nic;
+	int local_id, peer_id;
+	gni_smsg_attr_t local_smsg_attr;
+	gni_smsg_attr_t peer_smsg_attr;
+	gni_return_t __attribute__((unused)) status;
+	ssize_t __attribute__((unused)) len;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	/*
+	 * get our local vc associated with this datagram
+	 * from the cache
+	 */
+
+	vc = (struct gnix_vc *)dgram->cache;
+	assert(vc);
+
+	/*
+	 * at this point vc should be in connecting state
+	 */
+	assert(vc->conn_state == GNI_VC_CONNECTING);
+
+	ep = vc->ep;
+	assert(ep);
+
+	nic = ep->nic;
+	assert(nic);
+
+	/*
+	 * get our local id (the vc_id of the vc
+	 * that we allocated earlier)
+	 */
+	len = _gnix_dgram_unpack_buf(dgram,
+				     GNIX_DGRAM_IN_BUF,
+				     &local_id,
+				     sizeof(int));
+	assert(len == sizeof(int));
+
+	/*
+	 * get the smsg attributes of the mbox we allocated
+	 * earlier for this conn req.
+	 */
+	len = _gnix_dgram_unpack_buf(dgram,
+				     GNIX_DGRAM_IN_BUF,
+				     &local_smsg_attr,
+				     sizeof(gni_smsg_attr_t));
+	assert(len == sizeof(gni_smsg_attr_t));
+
+	/*
+	 * get the vc id of peer
+	 */
+	len = _gnix_dgram_unpack_buf(dgram, GNIX_DGRAM_OUT_BUF,
+				     &peer_id,
+				     sizeof(int));
+	assert(len == sizeof(int));
+
+	/*
+	 * get the smsg attributes of the mbox our peer allocated
+	 * earlier for this conn req.
+	 */
+	len = _gnix_dgram_unpack_buf(dgram,
+				     GNIX_DGRAM_OUT_BUF,
+				     &peer_smsg_attr,
+				     sizeof(gni_smsg_attr_t));
+
+	assert(len == sizeof(gni_smsg_attr_t));
+
+	/*
+	 *  now build the SMSG connection
+	 */
+	status = GNI_EpCreate(ep->nic->gni_nic_hndl,
+			     ep->nic->tx_cq,
+			     &vc->gni_ep);
+	if (status != GNI_RC_SUCCESS) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "GNI_EpCreate returned %s\n", gni_err_str[status]);
+		ret = gnixu_to_fi_errno(status);
+		goto err;
+	}
+
+	status = GNI_EpBind(vc->gni_ep,
+			    peer_address.device_addr,
+			    peer_address.cdm_id);
+	if (status != GNI_RC_SUCCESS) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "GNI_EpBind returned %s\n", gni_err_str[status]);
+		ret = gnixu_to_fi_errno(status);
+		goto err1;
+	}
+
+	status = GNI_SmsgInit(vc->gni_ep,
+			      &local_smsg_attr,
+			      &peer_smsg_attr);
+	if (status != GNI_RC_SUCCESS) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "GNI_SmsgInit returned %s\n", gni_err_str[status]);
+		ret = gnixu_to_fi_errno(status);
+		goto err1;
+	}
+
+	status = GNI_EpSetEventData(vc->gni_ep,
+				    local_id,
+				    peer_id);
+	if (status != GNI_RC_SUCCESS) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "GNI_EpSetEventData returned %s\n",
+			  gni_err_str[status]);
+		ret = gnixu_to_fi_errno(status);
+		goto err1;
+	}
+
+	/*
+	 * transition the VC to connected
+	 * put in to the nic's work queue for
+	 * further processing
+	 */
+
+	vc->conn_state = GNIX_VC_CONNECTED;
+	ret = _gnix_dgram_free(dgram);
+	if (ret != FI_SUCCESS)
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "gnix_mbox_free returned %d\n", ret);
+	vc->dgram = NULL;
+
+	ret = _gnix_vc_add_to_wq(vc);
+	if (ret == FI_SUCCESS)
+		ret = _gnix_nic_progress(nic);
+
+	return ret;
+err1:
+	GNI_EpDestroy(vc->gni_ep);
+err:
+	vc->conn_state = GNIX_VC_CONN_ERROR;
+	return ret;
+}
+
+/*
+ * One of my wildcards matched an incoming connection
+ * request from peer.  In this case we may have a vc for this
+ * peer in the hash table of vc's for this ep.
+ */
+
+static int __gnix_vc_hndl_wc_match_con(struct gnix_datagram *dgram,
+					struct gnix_address peer_address)
+{
+	int ret = FI_SUCCESS;
+	struct gnix_vc *vc = NULL, *wc_vc = NULL;
+	struct gnix_fid_ep *ep;
+	struct gnix_nic *nic;
+	int local_id, peer_id;
+	gni_smsg_attr_t local_smsg_attr;
+	gni_smsg_attr_t peer_smsg_attr;
+	gni_return_t __attribute__((unused)) status;
+	gnix_ht_key_t key;
+	ssize_t __attribute__((unused)) len;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	wc_vc = (struct gnix_vc *)dgram->cache;
+	assert(wc_vc);
+
+	ep = wc_vc->ep;
+	assert(ep);
+
+	nic = ep->nic;
+	assert(nic);
+
+	/*
+	 * should be in connecting state at this
+	 * point.
+	 */
+	assert(wc_vc->conn_state == GNIX_VC_CONNECTING);
+
+	/*
+	 * remove the vc from the EPs dlist of wc vc's
+	 */
+	dlist_remove(&wc_vc->entry);
+
+	/*
+	 * if the wc vc is not in the hash table
+	 * that means we are hitting the case where
+	 * we were trying to connect with a peer
+	 * who was also connecting to us, and
+	 * so hit the GNI_RC_ERROR_RESOURCE case
+	 * when posting a datagram.  We need to
+	 * move any pending sends on to the wc_vc,
+	 * remove the current vc for this peer from
+	 * the hash table, and insert the wc_vc
+	 */
+	if (!(wc_vc->modes & GNIX_VC_MODE_IN_HT)) {
+		memcpy(&key, &peer_address,
+			sizeof(gnix_ht_key_t));
+		vc = gnix_ht_lookup(ep->vc_ht, key);
+		assert(vc != NULL);
+		ret = gnix_ht_remove(ep->vc_ht, key);
+		assert(ret == FI_SUCCESS);
+		if (!slist_empty(&vc->send_queue))
+			slist_insert_head(vc->send_queue.head,
+					  &wc_vc->send_queue);
+		ret = _gnix_vc_destroy(vc);
+		assert(ret == FI_SUCCESS);
+		vc = wc_vc;
+		ret = gnix_ht_insert(ep->vc_ht, key, vc);
+		assert(ret == FI_SUCCESS);
+	} else
+		vc = wc_vc;
+
+
+	/*
+	 * get our local id (the vc_id of the vc
+	 * that we allocated earlier)
+	 */
+	len = _gnix_dgram_unpack_buf(dgram,
+				     GNIX_DGRAM_IN_BUF,
+				     &local_id,
+				     sizeof(int));
+	assert(len == sizeof(int));
+
+	/*
+	 * get the smsg attributes of the mbox we allocated
+	 * earlier for this conn req.
+	 */
+	len = _gnix_dgram_unpack_buf(dgram,
+				     GNIX_DGRAM_IN_BUF,
+				     &local_smsg_attr,
+				     sizeof(gni_smsg_attr_t));
+	assert(len == sizeof(gni_smsg_attr_t));
+
+	/*
+	 * get the vc id of peer
+	 */
+	len = _gnix_dgram_unpack_buf(dgram, GNIX_DGRAM_OUT_BUF,
+				     &peer_id,
+				     sizeof(int));
+	assert(len == sizeof(int));
+
+	/*
+	 * get the smsg attributes of the mbox our peer allocated
+	 * earlier for this conn req.
+	 */
+	len = _gnix_dgram_unpack_buf(dgram,
+				     GNIX_DGRAM_OUT_BUF,
+				     &peer_smsg_attr,
+				     sizeof(gni_smsg_attr_t));
+	assert(len == sizeof(gni_smsg_attr_t));
+
+	/*
+	 *  now build the SMSG connection
+	 */
+
+	status = GNI_EpCreate(ep->nic->gni_nic_hndl,
+			     ep->nic->tx_cq,
+			     &vc->gni_ep);
+	if (status != GNI_RC_SUCCESS) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "GNI_EpCreate returned %s\n", gni_err_str[status]);
+		ret = gnixu_to_fi_errno(status);
+		goto err;
+	}
+
+	status = GNI_EpBind(vc->gni_ep,
+			    peer_address.device_addr,
+			    peer_address.cdm_id);
+	if (status != GNI_RC_SUCCESS) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "GNI_EpBind returned %s\n", gni_err_str[status]);
+		ret = gnixu_to_fi_errno(status);
+		goto err1;
+	}
+
+	status = GNI_SmsgInit(vc->gni_ep,
+			      &local_smsg_attr,
+			      &peer_smsg_attr);
+	if (status != GNI_RC_SUCCESS) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "GNI_SmsgInit returned %s\n", gni_err_str[status]);
+		ret = gnixu_to_fi_errno(status);
+		goto err1;
+	}
+
+	status = GNI_EpSetEventData(vc->gni_ep,
+				    local_id,
+				    peer_id);
+	if (status != GNI_RC_SUCCESS) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "GNI_EpSetEventData returned %s\n",
+			  gni_err_str[status]);
+		ret = gnixu_to_fi_errno(status);
+		goto err1;
+	}
+
+	/*
+	 * transition the VC to connected
+	 * repost a wildcard, then
+	 * put the vc in to the nic's work queue for
+	 * further processing
+	 */
+
+	vc->conn_state = GNIX_VC_CONNECTED;
+
+
+	ret = _gnix_dgram_free(dgram);
+	if (ret != FI_SUCCESS)
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "gnix_mbox_free returned %d\n",
+			  ret);
+	vc->dgram = NULL;
+
+
+	/*
+	 * repost a wildcard datagram
+	 */
+
+	ret = _gnix_vc_alloc(ep, FI_ADDR_UNSPEC, &wc_vc);
+	if (ret != FI_SUCCESS)
+		goto err1;
+
+	ret = _gnix_vc_accept(wc_vc);
+	if (ret != FI_SUCCESS)
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "gnix_vc_accept returned %d\n",
+			  ret);
+
+	dlist_insert_tail(&wc_vc->entry, &ep->wc_vc_list);
+
+	/*
+	 * put the connected vc in to the work queue of the gnix_nic
+	 */
+
+	ret = _gnix_vc_add_to_wq(vc);
+	if (ret == FI_SUCCESS) {
+		ret = _gnix_nic_progress(nic);
+		goto out;
+	}
+
+	return ret;
+err1:
+	GNI_EpDestroy(vc->gni_ep);
+err:
+out:
+	return ret;
+}
+
+
+static int _gnix_vc_process_datagram_w_error(struct gnix_datagram *dgram,
+					     struct gnix_address peer_address,
+					     gni_post_state_t state)
+{
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+	return -FI_ENOSYS;
+}
+
+static int __gnix_vc_process_datagram(struct gnix_datagram *dgram,
+				     struct gnix_address peer_address,
+				     gni_post_state_t state)
+{
+	int ret = FI_SUCCESS;
+	enum gnix_vc_conn_req_type rtype_in, rtype_out;
+	ssize_t __attribute__((unused)) len;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	/*
+	 * first get the vc conn req type from the in buf
+	 */
+
+	len = _gnix_dgram_unpack_buf(dgram, GNIX_DGRAM_IN_BUF,
+				     &rtype_in,
+				     sizeof(rtype_in));
+	assert(len == sizeof(rtype_in));
+
+	len = _gnix_dgram_unpack_buf(dgram, GNIX_DGRAM_OUT_BUF,
+				     &rtype_out,
+				     sizeof(rtype_out));
+	assert(len == sizeof(rtype_out));
+
+	/*
+	 * next check the post state, if its anything but
+	 * GNI_POST_COMPLETED process using error handling
+	 * function.
+	 */
+
+	if (state != GNI_POST_COMPLETED) {
+		ret = _gnix_vc_process_datagram_w_error(dgram,
+							 peer_address,
+							 state);
+		goto err;
+	}
+
+	/*
+	 * handle different cases for datagram matching:
+	 * my active matched peer's active conn req
+	 * my passive matched peer's active
+	 * my active matched peer's passive
+	 * passive matching passive is an error
+	 */
+
+	switch (rtype_in) {
+	case GNIX_VC_CONN_REQ_CONN:
+	switch (rtype_out) {
+	case GNIX_VC_CONN_REQ_CONN:
+	case GNIX_VC_CONN_REQ_LISTEN:
+
+		ret = __gnix_vc_hndl_con_match_con(dgram,peer_address);
+		break;
+		default:
+		assert(0);
+	}
+	break;
+
+	case GNIX_VC_CONN_REQ_LISTEN:
+		switch (rtype_out) {
+		case GNIX_VC_CONN_REQ_CONN:
+
+		ret = __gnix_vc_hndl_wc_match_con(dgram,peer_address);
+		break;
+		case GNIX_VC_CONN_REQ_LISTEN:
+		default:
+		assert(0);
+		}
+	}
+err:
+	return ret;
+}
+
+static int __gnix_vc_connect_prog_fn(void *data, int *complete_ptr)
+{
+	int ret = FI_SUCCESS;
+	gni_return_t __attribute__((unused)) status;
+	int complete = 0;
+	struct gnix_vc *vc = (struct gnix_vc *)data;
+	struct gnix_mbox *mbox = NULL;
+	gni_smsg_attr_t smsg_mbox_attr;
+	struct gnix_fid_ep *ep = NULL;
+	struct gnix_cm_nic *cm_nic = NULL;
+	struct gnix_datagram *dgram = NULL;
+	enum gnix_vc_conn_req_type rtype = GNIX_VC_CONN_REQ_CONN;
+	ssize_t __attribute__((unused)) len;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	ep = vc->ep;
+	if (ep == NULL)
+		return -FI_EINVAL;
+
+	cm_nic = ep->cm_nic;
+	if (cm_nic == NULL)
+		return -FI_EINVAL;
+
+	/*
+	 * sanity check that the vc is in the hash table
+	 */
+
+	if (!(vc->modes & GNIX_VC_MODE_IN_HT))
+		return -FI_EINVAL;
+
+	/*
+	 * if one of our wild cards is completing or has
+	 * already completed setup of the connection just
+	 * indicate completion and early return
+	 */
+
+	if ((vc->conn_state == GNIX_VC_CONNECTING)
+		|| (vc->conn_state == GNIX_VC_CONNECTED)) {
+		complete = 1;
+		goto exit;
+	}
+
+	/*
+	 * first see if we still need a mailbox
+	 */
+
+	if (vc->smsg_mbox == NULL) {
+		ret = gnix_mbox_alloc(vc->ep->nic->mbox_hndl,
+				 &mbox);
+		if (ret == FI_SUCCESS)
+			vc->smsg_mbox = mbox;
+		else
+			goto exit;
+	}
+
+	mbox = vc->smsg_mbox;
+
+	/*
+	 * okay, got a mailbox, now lets try to
+	 * get a datagram
+	 */
+
+	ret = _gnix_dgram_alloc(cm_nic->dgram_hndl,
+				GNIX_DGRAM_BND,
+				&dgram);
+	if (ret != FI_SUCCESS)
+		goto exit;
+
+	/*
+	 * set the datagram completion callback function
+	 * and target address
+	 */
+
+	dgram->target_addr = vc->peer_addr;
+	dgram->callback_fn = __gnix_vc_process_datagram;
+	dgram->pre_post_clbk_fn = __gnix_vc_pre_post_clbk;
+	dgram->post_post_clbk_fn = __gnix_vc_post_post_clbk;
+	dgram->post_test_clbk_fn = __gnix_vc_post_test_clbk;
+	dgram->cache = vc;
+
+	/*
+	 * fill in the mbox smsg info and pack in to the
+	 * datagram IN payload
+	 */
+
+	smsg_mbox_attr.msg_type = GNI_SMSG_TYPE_MBOX_AUTO_RETRANSMIT;
+	smsg_mbox_attr.msg_buffer = mbox->base;
+	smsg_mbox_attr.buff_size =  vc->ep->nic->mem_per_mbox;
+	smsg_mbox_attr.mem_hndl = *mbox->memory_handle;
+	smsg_mbox_attr.mbox_offset = (uint64_t)mbox->offset;
+	smsg_mbox_attr.mbox_maxcredit = 64; /* TODO: fix this */
+	smsg_mbox_attr.msg_maxsize =  16384;  /* TODO: definite fix */
+
+	/*
+	 * pack the things we need into the datagram in_box:
+	 * - vc conn request type
+	 * - vc_id of the connection
+	 * - the smsg_mbox_attr sturr
+	 */
+
+	len = _gnix_dgram_pack_buf(dgram, GNIX_DGRAM_IN_BUF,
+				   &rtype,
+				   sizeof(enum gnix_vc_conn_req_type));
+	assert(len == sizeof(enum gnix_vc_conn_req_type));
+
+	len = _gnix_dgram_pack_buf(dgram, GNIX_DGRAM_IN_BUF,
+				   &vc->vc_id, sizeof(vc->vc_id));
+	assert(len == sizeof(vc->vc_id));
+
+	len = _gnix_dgram_pack_buf(dgram, GNIX_DGRAM_IN_BUF,
+				   &smsg_mbox_attr,
+				   sizeof(gni_smsg_attr_t));
+	assert(len == sizeof(gni_smsg_attr_t));
+
+	ret = _gnix_dgram_bnd_post(dgram);
+	if (ret != FI_SUCCESS)
+		goto exit;
+
+	/*
+	 * We may not have posted a datagram.  This
+	 * happens if a previously posted wildcard datagram
+	 * already matched with the destination address,
+	 * we free the mbox and datagram since these
+	 * will be supplied from the values of the in
+	 * buffer in the wildcard datagram that matched.
+	 */
+
+	if (!(vc->modes & GNIX_VC_MODE_DG_POSTED) &&
+		(vc->conn_state != GNIX_VC_CONNECTED)) {
+		ret = gnix_mbox_free(vc->smsg_mbox);
+		if (ret != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "gnix_mbox_free returned %d\n",
+				  ret);
+		vc->smsg_mbox = NULL;
+
+		ret = _gnix_dgram_free(dgram);
+		if (ret != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "gnix_dgram_free returned %d\n",
+				  ret);
+	}
+
+	complete = 1;
+
+exit:
+	*complete_ptr = complete;
+	return ret;
+}
+
+/*
+ * connect completer function for work queue element,
+ * sort of a NO-OP for now.
+ */
+static int __gnix_vc_connect_comp_fn(void *data)
+{
+	return FI_SUCCESS;
+}
+
+/*******************************************************************************
+ * Internal API functions
+ ******************************************************************************/
+
+int _gnix_vc_alloc(struct gnix_fid_ep *ep_priv, fi_addr_t dest_addr,
+		   struct gnix_vc **vc)
+
+{
+	int ret = FI_SUCCESS;
+	struct gnix_vc *vc_ptr = NULL;
+#if 0
+	struct gnix_fid_av *av = NULL;
+#endif
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+#if 0
+	/*
+	 * if ep is of type FI_EP_RDM, need to check the map type
+	 */
+
+	if (ep_priv->type == FI_EP_RDM) {
+		if (!ep_priv->av)
+			return -FI_EINVAL;
+		av = ep_priv->av;
+		if (ep_priv->av->type == FI_AV_TABLE)
+			/* TODO: need something here */
+	}
+#endif
+
+	vc_ptr = calloc(1, sizeof(*vc_ptr));
+	if (!vc_ptr)
+		return -FI_ENOMEM;
+
+	vc_ptr->conn_state = GNIX_VC_CONN_NONE;
+	memcpy(&vc_ptr->peer_addr, &dest_addr, sizeof(dest_addr));
+	vc_ptr->ep = ep_priv;
+	atomic_inc(&ep_priv->ref_cnt);
+	slist_init(&vc_ptr->send_queue);
+
+	/*
+	 * we need an id for the vc to allow for quick lookup
+	 * based on GNI_CQ_GET_INST_ID
+	 */
+
+	ret = _gnix_vc_get_id(vc_ptr);
+	if (ret != FI_SUCCESS)
+		goto err;
+
+	*vc = vc_ptr;
+
+	return ret;
+
+err:
+	if (vc_ptr)
+		free(vc_ptr);
+	return ret;
+}
+
+int _gnix_vc_destroy(struct gnix_vc *vc)
+{
+	int ret = FI_SUCCESS;
+	gni_return_t status;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	if (vc->ep == NULL)
+		return -FI_EINVAL;
+
+	/*
+	 * check the state of the VC, may need to
+	 * do something for some cases
+	 */
+
+	if ((vc->conn_state != GNIX_VC_CONN_NONE)
+		&& (vc->conn_state != GNIX_VC_CONN_TERMINATED)) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			      "vc conn state  %d\n",
+			       vc->conn_state);
+		return -FI_EBUSY;
+	}
+
+	/*
+	 * if send_q not empty, return -FI_EBUSY
+	 * Note for FI_EP_MSG type eps, this behavior
+	 * may not be correct for handling fi_shutdown.
+	 */
+
+	if (!slist_empty(&vc->send_queue)) {
+		GNIX_WARN(FI_LOG_EP_CTRL, "vc sendqueue not empty\n");
+		return -FI_EBUSY;
+	}
+
+	if (vc->gni_ep != NULL) {
+		status = GNI_EpDestroy(vc->gni_ep);
+		if (status != GNI_RC_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL, "GNI_EpDestroy returned %s\n",
+				  gni_err_str[status]);
+			ret = gnixu_to_fi_errno(status);
+			return ret;
+		}
+	}
+
+	if (vc->smsg_mbox != NULL) {
+		ret = gnix_mbox_free(vc->smsg_mbox);
+		if (ret != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_EP_CTRL,
+			      "gnix_mbox_free returned %d\n", ret);
+		vc->smsg_mbox = NULL;
+	}
+
+	if (vc->dgram != NULL) {
+		ret = _gnix_dgram_free(vc->dgram);
+		if (ret != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_EP_CTRL,
+			      "gnix_dgram_free returned %d\n", ret);
+		vc->dgram = NULL;
+	}
+
+	ret = __gnix_vc_free_id(vc);
+	if (ret != FI_SUCCESS)
+		GNIX_WARN(FI_LOG_EP_CTRL,
+		      "__gnix_vc_free_id returned %d\n", ret);
+
+	atomic_dec(&vc->ep->ref_cnt);
+
+	free(vc);
+
+	return ret;
+}
+
+int _gnix_vc_connect(struct gnix_vc *vc)
+{
+	int ret = FI_SUCCESS;
+	struct gnix_fid_ep *ep = NULL;
+	struct gnix_cm_nic *cm_nic = NULL;
+	struct gnix_work_req *work_req;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	/*
+	 * can happen that we are already connecting, or
+	 * are connected
+	 */
+
+	if ((vc->conn_state == GNIX_VC_CONNECTING) ||
+		(vc->conn_state == GNIX_VC_CONNECTED))
+		return FI_SUCCESS;
+
+	ep = vc->ep;
+	if (ep == NULL)
+		return -FI_EINVAL;
+
+	cm_nic = ep->cm_nic;
+	if (cm_nic == NULL)
+		return -FI_EINVAL;
+
+	/*
+	 * only endpoints of type FI_EP_RDM use this
+	 * connection method
+	 */
+	if (ep->type != FI_EP_RDM)
+		return -FI_EINVAL;
+
+	/*
+	 * allocate a work request and try to
+	 * run the progress function once.  If it
+	 * doesn't succeed, put it on the cm_nic work queue.
+	 */
+
+	work_req = calloc(1, sizeof(*work_req));
+	if (work_req == NULL)
+		return -FI_ENOMEM;
+
+	work_req->progress_func = __gnix_vc_connect_prog_fn;
+	work_req->data = vc;
+	work_req->completer_func = __gnix_vc_connect_comp_fn;
+	work_req->completer_data = vc;
+
+	/*
+	 * add the work request to the tail of the
+	 * cm_nic's work queue, progress the cm_nic.
+	 */
+
+	fastlock_acquire(&cm_nic->wq_lock);
+	list_add_tail(&cm_nic->cm_nic_wq, &work_req->list);
+	fastlock_release(&cm_nic->wq_lock);
+
+	ret = _gnix_cm_nic_progress(cm_nic);
+
+	return ret;
+}
+
+int _gnix_vc_accept(struct gnix_vc *vc)
+{
+	int ret = FI_SUCCESS;
+	struct gnix_fid_ep *ep = NULL;
+	struct gnix_cm_nic *cm_nic = NULL;
+	struct gnix_nic *nic = NULL;
+	struct gnix_mbox *mbox = NULL;
+	gni_smsg_attr_t smsg_mbox_attr;
+	struct gnix_datagram *dgram = NULL;
+	enum gnix_vc_conn_req_type rtype = GNIX_VC_CONN_REQ_LISTEN;
+	ssize_t __attribute__((unused)) len;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	ep = vc->ep;
+	if (ep == NULL)
+		return -FI_EINVAL;
+
+	cm_nic = ep->cm_nic;
+	if (cm_nic == NULL)
+		return -FI_EINVAL;
+
+	nic = ep->nic;
+	if (nic == NULL)
+		return -FI_EINVAL;
+
+	/*
+	 * only endpoints of type FI_EP_RDM use this
+	 * connection method
+	 */
+	if (ep->type != FI_EP_RDM)
+		return -FI_EINVAL;
+
+	/*
+	 * the peer_address of the endpoint must be GNIX_ADDR_UNSPEC
+	 */
+
+	if (!GNIX_ADDR_UNSPEC(vc->peer_addr))
+		return -FI_EINVAL;
+
+	/*
+	 * try to allocate a mailbox
+	 */
+	ret = gnix_mbox_alloc(nic->mbox_hndl,
+			      &mbox);
+	if (ret == FI_SUCCESS)
+		vc->smsg_mbox = mbox;
+	else {
+		ret = -FI_EAGAIN;
+		goto err;
+	}
+
+	/*
+	 * try to allocate a datagram
+	 */
+
+	ret = _gnix_dgram_alloc(cm_nic->dgram_hndl,
+				GNIX_DGRAM_WC,
+				&dgram);
+	if (ret != FI_SUCCESS)
+		goto err1;
+
+	/*
+	 * set the datagram completion callback function
+	 */
+
+	dgram->callback_fn = __gnix_vc_process_datagram;
+	dgram->post_test_clbk_fn = __gnix_vc_post_test_clbk;
+	vc->dgram = dgram;
+	dgram->cache = vc;
+
+	/*
+	 * fill in the mbox smsg info and pack in to the
+	 * datagram IN payload
+	 */
+
+	smsg_mbox_attr.msg_type = GNI_SMSG_TYPE_MBOX_AUTO_RETRANSMIT;
+	smsg_mbox_attr.msg_buffer = mbox->base;
+	smsg_mbox_attr.buff_size =  nic->mem_per_mbox;
+	smsg_mbox_attr.mem_hndl = *mbox->memory_handle;
+	smsg_mbox_attr.mbox_offset = (uint64_t)mbox->offset;
+	smsg_mbox_attr.mbox_maxcredit = 64; /* TODO: fix this */
+	smsg_mbox_attr.msg_maxsize =  16384;  /* TODO: definite fix */
+
+	/*
+	 * pack the things we need into the datagram in_box:
+	 * - vc conn request type
+	 * - vc_id of the connection
+	 * - the smsg_mbox_attr stuff
+	 */
+
+	len = _gnix_dgram_pack_buf(dgram, GNIX_DGRAM_IN_BUF,
+				   &rtype,
+				   sizeof(enum gnix_vc_conn_req_type));
+	assert(len == sizeof(enum gnix_vc_conn_req_type));
+
+	len = _gnix_dgram_pack_buf(dgram, GNIX_DGRAM_IN_BUF,
+				   &vc->vc_id, sizeof(vc->vc_id));
+	assert(len == sizeof(vc->vc_id));
+
+	len = _gnix_dgram_pack_buf(dgram, GNIX_DGRAM_IN_BUF,
+				   &smsg_mbox_attr,
+				   sizeof(gni_smsg_attr_t));
+	assert(len == sizeof(gni_smsg_attr_t));
+
+	ret = _gnix_dgram_wc_post(dgram);
+	if (ret != FI_SUCCESS)
+		goto err1;
+
+	return ret;
+
+err1:
+	ret = gnix_mbox_free(mbox);
+err:
+	return ret;
+}
+
+/*
+ * TODO: this is very simple right now and will need more
+ * work to propertly disconnect
+ */
+
+int _gnix_vc_disconnect(struct gnix_vc *vc)
+{
+	vc->conn_state = GNIX_VC_CONN_TERMINATED;
+	return FI_SUCCESS;
+}
+
+int _gnix_vc_add_to_wq(struct gnix_vc *vc)
+{
+	struct gnix_nic *nic = vc->ep->nic;
+	struct gnix_work_req *work_req;
+
+	if (!(vc->modes & GNIX_VC_MODE_IN_WQ)) {
+
+		work_req = calloc(1, sizeof(*work_req));
+		if (work_req == NULL)
+			return -FI_ENOMEM;
+
+#if 0
+		work_req->progress_func = __gnix_vc_prog_fn;
+#endif
+		work_req->progress_func = NULL;
+		work_req->data = vc;
+#if 0
+		work_req->completer_func = __gnix_vc_comp_fn;
+#endif
+		work_req->completer_func = NULL;
+		work_req->completer_data = vc;
+
+		fastlock_acquire(&nic->wq_lock);
+		list_add_tail(&nic->nic_wq, &work_req->list);
+		fastlock_release(&nic->wq_lock);
+	}
+
+	return FI_SUCCESS;
+}

--- a/prov/gni/test/datagram.c
+++ b/prov/gni/test/datagram.c
@@ -338,7 +338,6 @@ static int dgram_callback_fn(struct gnix_datagram *the_dgram,
 Test(dg_allocation,  dgram_wc_post_exchg)
 {
 	int ret = 0;
-	gni_return_t status;
 	struct gnix_cm_nic *cm_nic;
 	struct gnix_datagram *dgram_wc, *dgram_bnd;
 
@@ -353,7 +352,7 @@ Test(dg_allocation,  dgram_wc_post_exchg)
 	assert(!ret, "_gnix_dgram_alloc wc");
 
 	dgram_wc->callback_fn = dgram_callback_fn;
-	ret = _gnix_dgram_wc_post(dgram_wc, &status);
+	ret = _gnix_dgram_wc_post(dgram_wc);
 	assert((ret == 0), "_gnix_dgram_alloc wc");
 
 	ret = _gnix_dgram_alloc(cm_nic->dgram_hndl, GNIX_DGRAM_BND,
@@ -367,7 +366,7 @@ Test(dg_allocation,  dgram_wc_post_exchg)
 	local_address.cdm_id = cm_nic->cdm_id;
 
 	dgram_bnd->callback_fn = dgram_callback_fn;
-	ret = _gnix_dgram_bnd_post(dgram_bnd, &status);
+	ret = _gnix_dgram_bnd_post(dgram_bnd);
 	assert(ret == 0);
 
 	/*
@@ -390,7 +389,6 @@ Test(dg_allocation,  dgram_wc_post_exchg)
 Test(dg_allocation,  dgram_wc_post_exchg_manual, .init = dg_setup_prog_manual)
 {
 	int ret = 0;
-	gni_return_t status;
 	struct gnix_cm_nic *cm_nic;
 	struct gnix_datagram *dgram_wc, *dgram_bnd;
 
@@ -407,7 +405,7 @@ Test(dg_allocation,  dgram_wc_post_exchg_manual, .init = dg_setup_prog_manual)
 	assert(!ret, "_gnix_dgram_alloc wc");
 
 	dgram_wc->callback_fn = dgram_callback_fn;
-	ret = _gnix_dgram_wc_post(dgram_wc, &status);
+	ret = _gnix_dgram_wc_post(dgram_wc);
 	assert((ret == 0), "_gnix_dgram_alloc wc");
 
 	ret = _gnix_dgram_alloc(cm_nic->dgram_hndl, GNIX_DGRAM_BND,
@@ -421,7 +419,7 @@ Test(dg_allocation,  dgram_wc_post_exchg_manual, .init = dg_setup_prog_manual)
 	local_address.cdm_id = cm_nic->cdm_id;
 
 	dgram_bnd->callback_fn = dgram_callback_fn;
-	ret = _gnix_dgram_bnd_post(dgram_bnd, &status);
+	ret = _gnix_dgram_bnd_post(dgram_bnd);
 	assert(ret == 0);
 
 	/*

--- a/prov/gni/test/vc.c
+++ b/prov/gni/test/vc.c
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <getopt.h>
+#include <poll.h>
+#include <time.h>
+#include <string.h>
+#include <pthread.h>
+
+#include <rdma/fabric.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_errno.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_cm.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <inttypes.h>
+
+#include "gnix_vc.h"
+#include "gnix_cm_nic.h"
+#include "gnix_hashtable.h"
+
+#ifdef assert
+#undef assert
+#endif
+
+#include <criterion/criterion.h>
+
+static struct fid_fabric *fab;
+static struct fid_domain *dom;
+static struct fid_ep *ep[2];
+static struct fid_av *av;
+static struct fi_info *hints;
+static struct fi_info *fi;
+void *ep_name[2];
+size_t gni_addr[2];
+
+void vc_setup(void)
+{
+	int ret = 0;
+	struct fi_av_attr attr;
+	size_t addrlen = 0;
+
+	hints = fi_allocinfo();
+	assert(hints, "fi_allocinfo");
+
+	hints->domain_attr->cq_data_size = 4;
+	hints->mode = ~0;
+
+	hints->fabric_attr->name = strdup("gni");
+
+	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
+	assert(!ret, "fi_getinfo");
+
+	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	assert(!ret, "fi_fabric");
+
+	ret = fi_domain(fab, fi, &dom, NULL);
+	assert(!ret, "fi_domain");
+
+	attr.type = FI_AV_MAP;
+	attr.count = 16;
+
+	ret = fi_av_open(dom, &attr, &av, NULL);
+	assert(!ret, "fi_av_open");
+
+	ret = fi_endpoint(dom, fi, &ep[0], NULL);
+	assert(!ret, "fi_endpoint");
+
+	ret = fi_getname(&ep[0]->fid, NULL, &addrlen);
+	assert(addrlen > 0);
+
+	ep_name[0] = malloc(addrlen);
+	assert(ep_name[0] != NULL);
+
+	ep_name[1] = malloc(addrlen);
+	assert(ep_name[1] != NULL);
+
+	ret = fi_getname(&ep[0]->fid, ep_name[0], &addrlen);
+	assert(ret == FI_SUCCESS);
+
+	ret = fi_endpoint(dom, fi, &ep[1], NULL);
+	assert(!ret, "fi_endpoint");
+
+	ret = fi_getname(&ep[1]->fid, ep_name[1], &addrlen);
+	assert(ret == FI_SUCCESS);
+
+	ret = fi_av_insert(av, ep_name[0], 1, &gni_addr[0], 0,
+				NULL);
+	assert(ret == 1);
+
+	ret = fi_av_insert(av, ep_name[1], 1, &gni_addr[1], 0,
+				NULL);
+	assert(ret == 1);
+
+	ret = fi_ep_bind(ep[0], &av->fid, 0);
+	assert(!ret, "fi_ep_bind");
+
+	ret = fi_ep_bind(ep[1], &av->fid, 0);
+	assert(!ret, "fi_ep_bind");
+}
+
+void vc_teardown(void)
+{
+	int ret = 0;
+
+	ret = fi_close(&ep[0]->fid);
+	assert(!ret, "failure in closing ep.");
+
+	ret = fi_close(&ep[1]->fid);
+	assert(!ret, "failure in closing ep.");
+
+	ret = fi_close(&av->fid);
+	assert(!ret, "failure in closing av.");
+
+	ret = fi_close(&dom->fid);
+	assert(!ret, "failure in closing domain.");
+
+	ret = fi_close(&fab->fid);
+	assert(!ret, "failure in closing fabric.");
+
+	fi_freeinfo(fi);
+	fi_freeinfo(hints);
+	free(ep_name[0]);
+	free(ep_name[1]);
+}
+
+/*******************************************************************************
+ * Test vc functions.
+ ******************************************************************************/
+
+TestSuite(vc_management, .init = vc_setup, .fini = vc_teardown);
+
+Test(vc_management, vc_alloc_simple)
+{
+	int ret;
+	struct gnix_vc *vc[2];
+	struct gnix_fid_ep *ep_priv;
+
+	ep_priv = container_of(ep[0], struct gnix_fid_ep, ep_fid);
+
+	ret = _gnix_vc_alloc(ep_priv, gni_addr[0], &vc[0]);
+	assert_eq(ret, FI_SUCCESS);
+
+	ret = _gnix_vc_alloc(ep_priv, gni_addr[1], &vc[1]);
+	assert_eq(ret, FI_SUCCESS);
+
+	/*
+	 * vc_id's have to be different since the
+	 * vc's were allocated using the same ep.
+	 */
+	assert_neq(vc[0]->vc_id, vc[1]->vc_id);
+
+	ret = _gnix_vc_destroy(vc[0]);
+	assert_eq(ret, FI_SUCCESS);
+
+	ret = _gnix_vc_destroy(vc[1]);
+	assert_eq(ret, FI_SUCCESS);
+}
+
+Test(vc_management, vc_lookup_by_id)
+{
+	int ret;
+	struct gnix_vc *vc[2], *vc_chk;
+	struct gnix_fid_ep *ep_priv;
+
+	ep_priv = container_of(ep[0], struct gnix_fid_ep, ep_fid);
+
+	ret = _gnix_vc_alloc(ep_priv, gni_addr[0], &vc[0]);
+	assert_eq(ret, FI_SUCCESS);
+
+	ret = _gnix_vc_alloc(ep_priv, gni_addr[1], &vc[1]);
+	assert_eq(ret, FI_SUCCESS);
+
+	vc_chk = _gnix_vc_get_by_id(ep_priv->nic, vc[0]->vc_id);
+	assert_eq(vc_chk, vc[0]);
+
+	vc_chk = _gnix_vc_get_by_id(ep_priv->nic, vc[1]->vc_id);
+	assert_eq(vc_chk, vc[1]);
+
+	ret = _gnix_vc_destroy(vc[0]);
+	assert_eq(ret, FI_SUCCESS);
+
+	ret = _gnix_vc_destroy(vc[1]);
+	assert_eq(ret, FI_SUCCESS);
+
+}
+
+Test(vc_management, vc_accept)
+{
+	int ret;
+	struct gnix_vc *vc[2];
+	struct gnix_fid_ep *ep_priv;
+
+	ep_priv = container_of(ep[0], struct gnix_fid_ep, ep_fid);
+
+	ret = _gnix_vc_alloc(ep_priv, gni_addr[0], &vc[0]);
+	assert_eq(ret, FI_SUCCESS);
+
+	ret = _gnix_vc_alloc(ep_priv, FI_ADDR_UNSPEC, &vc[1]);
+	assert_eq(ret, FI_SUCCESS);
+
+	/*
+	 * this should fail because the vc was allocated with
+	 * an addr other than FI_ADDR_UNSPEC
+	 */
+
+	ret = _gnix_vc_accept(vc[0]);
+	assert_eq(ret, -FI_EINVAL);
+
+	/*
+	 * this should succeed because the vc was allocated with
+	 * FI_ADDR_UNSPEC
+	 */
+
+	ret = _gnix_vc_accept(vc[1]);
+	assert_eq(ret, FI_SUCCESS);
+
+	ret = _gnix_vc_destroy(vc[0]);
+	assert_eq(ret, FI_SUCCESS);
+
+	ret = _gnix_vc_destroy(vc[1]);
+	assert_eq(ret, FI_SUCCESS);
+
+}
+
+Test(vc_management, vc_conn_accept)
+{
+	int ret;
+	struct gnix_vc *vc_conn, *vc_listen;
+	struct gnix_fid_ep *ep_priv[2];
+	struct gnix_cm_nic *cm_nic[2];
+	gnix_ht_key_t key;
+	enum gnix_vc_conn_state state;
+
+	ep_priv[0] = container_of(ep[0], struct gnix_fid_ep, ep_fid);
+	cm_nic[0] = ep_priv[0]->cm_nic;
+
+	ep_priv[1] = container_of(ep[1], struct gnix_fid_ep, ep_fid);
+	cm_nic[1] = ep_priv[1]->cm_nic;
+
+	ret = _gnix_vc_alloc(ep_priv[0], gni_addr[1], &vc_conn);
+	assert_eq(ret, FI_SUCCESS);
+
+	memcpy(&key, &gni_addr[1],
+		sizeof(gnix_ht_key_t));
+
+	ret = gnix_ht_insert(ep_priv[0]->vc_ht, key, vc_conn);
+	assert_eq(ret, FI_SUCCESS);
+	vc_conn->modes |= GNIX_VC_MODE_IN_HT;
+
+	ret = _gnix_vc_alloc(ep_priv[1], FI_ADDR_UNSPEC, &vc_listen);
+	assert_eq(ret, FI_SUCCESS);
+
+	ret = _gnix_vc_accept(vc_listen);
+	assert_eq(ret, FI_SUCCESS);
+
+	/*
+	 * this is the moral equivalent of fi_enable(ep[0]),
+	 * but we don't want to do that in our prologue since
+	 * the fi_enable would consume all of the available wc datagrams.
+	 */
+	dlist_insert_tail(&vc_listen->entry, &ep_priv[1]->wc_vc_list);
+
+	ret = _gnix_vc_connect(vc_conn);
+	assert_eq(ret, FI_SUCCESS);
+
+	/*
+	 * progress the cm_nic
+	 */
+
+	state = GNIX_VC_CONN_NONE;
+	while (state != GNIX_VC_CONNECTED) {
+		ret = _gnix_cm_nic_progress(cm_nic[0]);
+		assert_eq(ret, FI_SUCCESS);
+		pthread_yield();
+		state = _gnix_vc_state(vc_conn);
+	}
+
+	state = GNIX_VC_CONN_NONE;
+	while (state != GNIX_VC_CONNECTED) {
+		ret = _gnix_cm_nic_progress(cm_nic[1]);
+		assert_eq(ret, FI_SUCCESS);
+		pthread_yield();
+		state = _gnix_vc_state(vc_listen);
+	}
+
+	ret = _gnix_vc_disconnect(vc_conn);
+	assert_eq(ret, FI_SUCCESS);
+
+	ret = _gnix_vc_destroy(vc_conn);
+	assert_eq(ret, FI_SUCCESS);
+
+	ret = _gnix_vc_disconnect(vc_listen);
+	assert_eq(ret, FI_SUCCESS);
+
+	ret = _gnix_vc_destroy(vc_listen);
+	assert_eq(ret, FI_SUCCESS);
+}


### PR DESCRIPTION
Consider this a preliminary PR.  I will add a link to flow charts
detailing the transitions of a VC from unconnected to connected
state as soon as possible.  I also need to add criterion tests
for the vc ops.  But I figured it would be good to 
have something available for review now. 

I don't expect Ben to necessarily look at this but at'd him anyway.

---

Implement methods required to enable vc connection
setup for FI_EP_RDM endpoints when needing to
send/receive messages between endpoints.

This commit implements the core vc-related methods
for handling active connection requests, passive
(wildcard) vc setup, processing of datagrams returned
from the gni datagram state engine to move vc's
to the connected state.  The method is non-trivial
owing to various race conditions that could be hit.

Some modifications were required to existing criterion
tests since now the gni provider internally allocates
a mbox allocator.  This necessitated changes in the
allocator test.

This commit also fixes #89.
Fixes #97.

@bturrubiates 
@ztiffany 
@jswaro 
@sungeunchoi 

Signed-off-by: Howard Pritchard howardp@lanl.gov
