### PR TITLE
Generic slist-based free list structure (with criterion tests)

### DIFF
--- a/prov/gni/Makefile.am
+++ b/prov/gni/Makefile.am
@@ -27,6 +27,7 @@ _gni_files = \
 	prov/gni/src/gnix_cm_nic.c \
 	prov/gni/src/gnix_nic.c \
 	prov/gni/src/gnix_util.c \
+	prov/gni/src/gnix_freelist.c \
 	prov/gni/src/gnix_bitmap.c \
 	prov/gni/src/gnix_hashtable.c \
 	prov/gni/fasthash/fasthash.c \
@@ -42,6 +43,7 @@ gnitest_SOURCES = \
 	prov/gni/test/bitmap.c \
 	prov/gni/test/queue.c \
 	prov/gni/test/eq.c \
+	prov/gni/test/freelist.c \
 	prov/gni/test/hashtable.c \
 	prov/gni/test/allocator.c
 

--- a/prov/gni/include/gnix_freelist.h
+++ b/prov/gni/include/gnix_freelist.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _GNIX_FREELIST_H_
+#define _GNIX_FREELIST_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <fi_list.h>
+
+/* Number of elements to seed the freelist with */
+#define GNIX_SFL_INIT_SIZE 100
+/* Initial refill size */
+#define GNIX_SFL_INIT_REFILL_SIZE 10
+/* Refill growth factor */
+#define GNIX_SFL_GROWTH_FACTOR 2
+
+/** Free list based on singly linked slist
+ *
+ * @var freelist           The free list itself
+ * @var chunks             Memory chunks (must be saved for freeing)
+ * @var refill_size        Number of elements for the next refill
+ * @var growth_factor      Factor for increasing refill size
+ * @var max_refill_size;   Max refill size
+ * @var elem_size          Size of element (in bytes)
+ * @var offset             Offset of slist_entry field (in bytes)
+ */
+struct gnix_s_freelist {
+	struct slist freelist;
+	struct slist chunks;
+	int refill_size;
+	int growth_factor;
+	int max_refill_size;
+	int elem_size;
+	int offset;
+};
+
+/** Initializes a gnix_s_freelist
+ *
+ * @param elem_size         Size of element
+ * @param offset            Offset of slist_entry field
+ * @param init_size         Initial freelist size
+ * @param refill_size       Number of elements for next refill
+ * @param growth_factor     Factor for increasing refill size
+ * @param max_refill_size   Max refill size
+ * @param fl                gnix_s_freelist
+ * @return                  FI_SUCCESS on success, -FI_ENOMEM on failure
+ */
+int _gnix_sfl_init(int elem_size, int offset, int init_size,
+		   int refill_size, int growth_factor,
+		   int max_refill_size, struct gnix_s_freelist *fl);
+
+/** Clean up a gnix_s_freelist, including deleting memory chunks
+ *
+ * @param fl    Freelist
+ */
+void _gnix_sfl_destroy(struct gnix_s_freelist *fl);
+
+/** Return an item from the freelist
+ *
+ * @param e     item
+ * @param fl    gnix_s_freelist
+ * @return      FI_SUCCESS on success, -FI_ENOMEM or -FI_EAGAIN on failure
+ */
+int _gnix_sfe_alloc(struct slist_entry **e, struct gnix_s_freelist *fl);
+
+/** Return an item to the free list
+ *
+ * @param e     item
+ * @param fl    gnix_s_freelist
+ */
+void _gnix_sfe_free(struct slist_entry *e, struct gnix_s_freelist *fl);
+
+/** Is freelist empty (primarily used for testing
+ *
+ * @param fl    gnix_s_freelist
+ * @return      True if list is currently empty, false otherwise
+ */
+static inline int _gnix_sfl_empty(struct gnix_s_freelist *fl)
+{
+	return slist_empty(&fl->freelist);
+}
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* _GNIX_FREELIST_H_ */

--- a/prov/gni/src/gnix_freelist.c
+++ b/prov/gni/src/gnix_freelist.c
@@ -48,8 +48,9 @@
  * - Refill size increases by growth_factor each time growth is needed
  *   (limited by max_refill_size)
  * - Refills are allocated as chunks, which are managed by chunks slist
- * - Allocate an extral elemtn at the beginning of each chunk for the
+ * - Allocate an extra element at the beginning of each chunk for the
  *   chunk slist
+ * - Individual elements are *not* zeroed before being returned
  *
  * Your structure doesn't really need to have an slist_entry pointer,
  * it just has to be at least as big as an slist_entry.
@@ -159,9 +160,6 @@ int _gnix_sfe_alloc(struct slist_entry **e, struct gnix_s_freelist *fl)
 			goto err;
 		}
 	}
-
-	/* zero the actual element */
-	memset(((unsigned char *) se)-fl->offset, 0, fl->elem_size);
 
 	*e = se;
 	return ret;

--- a/prov/gni/src/gnix_freelist.c
+++ b/prov/gni/src/gnix_freelist.c
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2015 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * Endpoint common code
+ */
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include "gnix_freelist.h"
+#include "gnix_util.h"
+
+/*
+ * NOTES:
+ * - NOT THREAD-SAFE (do they need to be?)
+ * - Does not shrink
+ * - Cannot be used for data structures with alignment requirements
+ * - Refill size increases by growth_factor each time growth is needed
+ *   (limited by max_refill_size)
+ * - Refills are allocated as chunks, which are managed by chunks slist
+ * - Allocate an extral elemtn at the beginning of each chunk for the
+ *   chunk slist
+ *
+ * Your structure doesn't really need to have an slist_entry pointer,
+ * it just has to be at least as big as an slist_entry.
+ */
+
+static int __gnix_sfl_refill(struct gnix_s_freelist *fl, int n)
+{	int i, ret = FI_SUCCESS;
+	unsigned char *elems;
+
+	assert(fl);
+	assert(n > 0);
+	/*
+	 * We allocate an extra element for use as the pointer to the
+	 * memory chunk maintained in the chunks field for later
+	 * freeing.  Use an entire element, in case size was padded
+	 * for alignment
+	 */
+	elems = malloc((n+1)*fl->elem_size);
+	if (elems == NULL) {
+		ret = -FI_ENOMEM;
+		goto err;
+	}
+
+	/* Save away the pointer to the chunk */
+	slist_insert_tail((struct slist_entry *) elems, &fl->chunks);
+
+	/* Start with slist_entry of first element */
+	elems += fl->elem_size + fl->offset;
+
+	for (i = 0; i < n; i++) {
+		slist_insert_tail((struct slist_entry *) elems, &fl->freelist);
+		elems += fl->elem_size;
+	}
+err:
+	return ret;
+}
+
+int _gnix_sfl_init(int elem_size, int offset, int init_size,
+		   int refill_size, int growth_factor,
+		   int max_refill_size, struct gnix_s_freelist *fl)
+{
+	assert(elem_size > 0);
+	assert(offset > 0);
+	assert(init_size >= 0);
+	assert(refill_size >= 0);
+	assert(growth_factor >= 0);
+	assert(max_refil_size >= 0);
+
+	int fill_size = init_size != 0 ? init_size : GNIX_SFL_INIT_SIZE;
+
+	fl->refill_size = (refill_size != 0 ?
+			   refill_size :
+			   GNIX_SFL_INIT_REFILL_SIZE);
+	fl->growth_factor = (growth_factor != 0 ?
+			     growth_factor :
+			     GNIX_SFL_GROWTH_FACTOR);
+	fl->max_refill_size = (max_refill_size != 0 ?
+			       max_refill_size :
+			       fill_size);
+	fl->elem_size = elem_size;
+	fl->offset = offset;
+
+	assert(slist_empty(&fl->freelist)); /* maybe should be a warning? */
+	slist_init(&fl->freelist);
+	assert(slist_empty(&fl->chunks)); /* maybe should be a warning? */
+	slist_init(&fl->chunks);
+
+	return __gnix_sfl_refill(fl, fill_size);
+}
+
+void _gnix_sfl_destroy(struct gnix_s_freelist *fl)
+{
+	assert(fl);
+
+	struct slist_entry *chunk;
+
+	for (chunk = slist_remove_head(&fl->chunks);
+	     chunk != NULL;
+	     chunk = slist_remove_head(&fl->chunks)) {
+		free(chunk);
+	}
+}
+
+int _gnix_sfe_alloc(struct slist_entry **e, struct gnix_s_freelist *fl)
+{
+	int ret = FI_SUCCESS;
+
+	assert(fl);
+
+	struct slist_entry *se = slist_remove_head(&fl->freelist);
+
+	if (!se) {
+		ret = __gnix_sfl_refill(fl, fl->refill_size);
+		if (ret != FI_SUCCESS)
+			goto err;
+		if (fl->refill_size < fl->max_refill_size) {
+			int ns = fl->refill_size *= fl->growth_factor;
+
+			fl->refill_size = (ns >= fl->max_refill_size ?
+					   fl->max_refill_size :
+					   ns);
+		}
+		se = slist_remove_head(&fl->freelist);
+		if (!se) {
+			/* Can't happen unless multithreaded */
+			ret = -FI_EAGAIN;
+			goto err;
+		}
+	}
+
+	/* zero the actual element */
+	memset(((unsigned char *) se)-fl->offset, 0, fl->elem_size);
+
+	*e = se;
+	return ret;
+
+err:
+	return ret;
+}
+
+void _gnix_sfe_free(struct slist_entry *e, struct gnix_s_freelist *fl)
+{
+	assert(e);
+	assert(fl);
+
+	/* */
+	slist_insert_tail(e, &fl->freelist);
+}
+

--- a/prov/gni/test/freelist.c
+++ b/prov/gni/test/freelist.c
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2015 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <sys/time.h>
+
+#include "gnix_freelist.h"
+
+#ifdef assert
+#undef assert
+#endif
+
+#include <criterion/criterion.h>
+
+static void setup(void)
+{
+	srand(time(NULL));
+}
+
+static void teardown(void)
+{
+}
+
+static void generate_perm(int *perm, int len)
+{
+	int i;
+	/* good 'nuff */
+	for (i = 0; i < len; i++) {
+		int t = perm[i];
+		int j = rand() % len;
+
+		perm[i] = perm[j];
+		perm[j] = t;
+	}
+}
+
+TestSuite(gnix_freelist, .init = setup, .fini = teardown);
+
+Test(gnix_freelist, freelist_init_destroy)
+{
+	const int n = 13;
+	struct gnix_s_freelist fls[n];
+	int i, ret;
+
+	for (i = 0; i < n; i++) {
+		ret = _gnix_sfl_init(sizeof(struct slist_entry), 0,
+				     2*n, n, n, 3*n, &fls[i]);
+		assert_eq(ret, FI_SUCCESS, "Failed to initialize freelist");
+	}
+
+	for (i = n-1; i >= 0; i--)
+		_gnix_sfl_destroy(&fls[i]);
+}
+
+Test(gnix_freelist, freelist_refill_test)
+{
+	struct gnix_s_freelist fl;
+	int i, ret;
+	const int num_elems = 71;
+	struct slist_entry *elems[num_elems];
+	const int refill_size = 47;
+	struct slist_entry *refill_elems[refill_size];
+
+	ret = _gnix_sfl_init(sizeof(struct slist_entry), 0,
+			     num_elems, refill_size, 0, 0, &fl);
+	assert_eq(ret, FI_SUCCESS, "Failed to initialize freelist");
+
+	for (i = 0; i < num_elems; i++) {
+		ret = _gnix_sfe_alloc(&elems[i], &fl);
+		assert_eq(ret, FI_SUCCESS, "Failed to obtain slist_entry");
+	}
+	assert(_gnix_sfl_empty(&fl), "Freelist not empty");
+
+	for (i = 0; i < refill_size; i++) {
+		ret = _gnix_sfe_alloc(&refill_elems[i], &fl);
+		assert_eq(ret, FI_SUCCESS, "Failed to obtain slist_entry");
+		if (i != refill_size-1) {
+			/* Not the last one, so must not be empty */
+			assert(!_gnix_sfl_empty(&fl), "Freelist empty");
+		}
+	}
+	assert(_gnix_sfl_empty(&fl), "Freelist not empty");
+
+	for (i = num_elems-1; i >= 0 ; i--)
+		_gnix_sfe_free(elems[i], &fl);
+
+	for (i = refill_size-1; i >= 0 ; i--)
+		_gnix_sfe_free(refill_elems[i], &fl);
+
+	_gnix_sfl_destroy(&fl);
+}
+
+struct slist_ts {
+	char dummy[7];
+	struct slist_entry e;
+	int n;
+};
+
+Test(gnix_freelist, freelist_random_alloc_free)
+{
+	struct gnix_s_freelist fl;
+	int i, ret;
+	const int n = 719;
+	int perm[n];
+	struct slist_entry *se;
+	struct slist_ts *ts[n];
+
+	for (i = 0; i < n; i++)
+		perm[i] = i;
+
+	generate_perm(perm, n);
+
+	ret = _gnix_sfl_init(sizeof(struct slist_ts),
+			     offsetof(struct slist_ts, e),
+			     0, 0, 0, 0, &fl);
+	assert_eq(ret, FI_SUCCESS, "Failed to initialize freelist");
+
+	for (i = 0; i < n; i++) {
+		ret = _gnix_sfe_alloc(&se, &fl);
+		assert_eq(ret, FI_SUCCESS,
+			  "Failed to obtain valid slist_entry");
+		ts[i] = container_of(se, struct slist_ts, e);
+		ts[i]->n = perm[i];
+	}
+
+	for (i = 0; i < n; i++) {
+		int j = perm[i];
+
+		assert(ts[j]->n == perm[j], "Incorrect value");
+		_gnix_sfe_free(&ts[j]->e, &fl);
+		ts[j] = NULL;
+	}
+
+	_gnix_sfl_destroy(&fl);
+}
+


### PR DESCRIPTION
Clients should wrap these functions for a cleaner interface.

Note that the generic version is a little less appealing than a
type-specific version in a number of (obvious) ways:
- Chunks can't be zeroed with calloc()
- Structures can't be initialized as they are getting added to the list
- If a particular alignment is required of the individual elements,
  the element size must be padded by the client

There are probably others.

Closes #164 

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com
