### PR TITLE
Refactored bitmap functions to the _gnix_* naming convention

### DIFF
--- a/prov/gni/src/gnix_mbox_allocator.c
+++ b/prov/gni/src/gnix_mbox_allocator.c
@@ -356,7 +356,7 @@ static int __create_slab(struct gnix_mbox_alloc_handle *handle)
 		goto err_mmap;
 	}
 
-	ret = alloc_bitmap(slab->used, __mbox_count(handle));
+	ret = _gnix_alloc_bitmap(slab->used, __mbox_count(handle));
 	if (ret) {
 		GNIX_WARN(FI_LOG_EP_CTRL, "Error allocating bitmap.\n");
 		goto err_alloc_bitmap;
@@ -383,7 +383,7 @@ static int __create_slab(struct gnix_mbox_alloc_handle *handle)
 	return ret;
 
 err_memregister:
-	free_bitmap(slab->used);
+	_gnix_free_bitmap(slab->used);
 	free(slab->used);
 err_alloc_bitmap:
 	munmap(slab->base, total_size);
@@ -420,7 +420,7 @@ static int __destroy_slab(struct gnix_mbox_alloc_handle *handle,
 
 	total_size = handle->page_size * __page_count(handle);
 
-	free_bitmap(slab->used);
+	_gnix_free_bitmap(slab->used);
 	free(slab->used);
 
 	GNI_MemDeregister(handle->nic_handle->gni_nic_hndl,
@@ -478,7 +478,7 @@ static int __check_bitmap(struct gnix_mbox_alloc_handle *handle,
 static int __find_free(struct gnix_mbox_alloc_handle *handle,
 		       struct gnix_slab **slab)
 {
-	return __check_bitmap(handle, slab, find_first_zero_bit);
+	return __check_bitmap(handle, slab, _gnix_find_first_zero_bit);
 }
 
 /**
@@ -494,7 +494,7 @@ static int __find_free(struct gnix_mbox_alloc_handle *handle,
 static int __find_used(struct gnix_mbox_alloc_handle *handle,
 		       struct gnix_slab **slab)
 {
-	return __check_bitmap(handle, slab, find_first_set_bit);
+	return __check_bitmap(handle, slab, _gnix_find_first_set_bit);
 }
 
 /**
@@ -543,7 +543,7 @@ static int __fill_mbox(struct gnix_mbox_alloc_handle *handle,
 		goto err_invalid;
 	}
 
-	ret = test_and_set_bit(slab->used, position);
+	ret = _gnix_test_and_set_bit(slab->used, position);
 	if (ret != 0) {
 		GNIX_WARN(FI_LOG_EP_CTRL,
 			  "Bit already set when creating mbox.\n");
@@ -716,7 +716,7 @@ int gnix_mbox_free(struct gnix_mbox *ptr)
 
 	position = ptr->offset / ptr->slab->allocator->mbox_size;
 
-	ret = test_and_clear_bit(ptr->slab->used, position);
+	ret = _gnix_test_and_clear_bit(ptr->slab->used, position);
 	if (ret != 1) {
 		GNIX_WARN(FI_LOG_EP_CTRL,
 			  "Bit already cleared while freeing mbox.\n");

--- a/prov/gni/test/bitmap.c
+++ b/prov/gni/test/bitmap.c
@@ -53,6 +53,35 @@
 gnix_bitmap_t *test_bitmap = NULL;
 int call_free_bitmap = 0;
 
+#if HAVE_ATOMICS
+
+#define __gnix_set_block(bitmap, index, value) \
+	atomic_store(&(bitmap)->arr[(index)], (value))
+#define __gnix_load_block(bitmap, index) atomic_load(&(bitmap->arr[(index)]))
+#else
+static inline void __gnix_set_block(gnix_bitmap_t *bitmap, int index,
+		uint64_t value)
+{
+	gnix_bitmap_block_t *block = &bitmap->arr[index];
+
+	fastlock_acquire(&block->lock);
+	block->val = value;
+	fastlock_release(&block->lock);
+}
+
+static inline uint64_t __gnix_load_block(gnix_bitmap_t *bitmap, int index)
+{
+	gnix_bitmap_block_t *block = &bitmap->arr[index];
+	uint64_t ret;
+
+	fastlock_acquire(&block->lock);
+	ret = block->val;
+	fastlock_release(&block->lock);
+
+	return ret;
+}
+#endif
+
 void calculate_time_difference(struct timeval *start, struct timeval *end,
 		int *secs_out, int *usec_out)
 {
@@ -77,7 +106,7 @@ void __gnix_bitmap_test_setup(void)
 void __gnix_bitmap_test_teardown(void)
 {
 	if (call_free_bitmap) {
-		free_bitmap(test_bitmap);
+		_gnix_free_bitmap(test_bitmap);
 	} else if (test_bitmap && test_bitmap->arr) {
 		free(test_bitmap->arr);
 	}
@@ -98,7 +127,7 @@ static void __test_clean_bitmap_state(gnix_bitmap_t *bitmap,
 
 static void __test_initialize_bitmap(gnix_bitmap_t *bitmap, int bits)
 {
-	int ret = alloc_bitmap(bitmap, bits);
+	int ret = _gnix_alloc_bitmap(bitmap, bits);
 
 	assert(ret == 0);
 	__test_clean_bitmap_state(bitmap, bits, GNIX_BITMAP_STATE_READY);
@@ -107,12 +136,12 @@ static void __test_initialize_bitmap(gnix_bitmap_t *bitmap, int bits)
 static void __test_initialize_bitmap_clean(gnix_bitmap_t *bitmap, int bits)
 {
 	__test_initialize_bitmap(bitmap, bits);
-	assert(bitmap_empty(bitmap));
+	assert(_gnix_bitmap_empty(bitmap));
 }
 
 static void __test_realloc_bitmap(gnix_bitmap_t *bitmap, int bits)
 {
-	int ret = realloc_bitmap(bitmap, bits);
+	int ret = _gnix_realloc_bitmap(bitmap, bits);
 
 	assert(ret == 0);
 	__test_clean_bitmap_state(bitmap, bits,	GNIX_BITMAP_STATE_READY);
@@ -123,12 +152,12 @@ static void __test_realloc_bitmap_clean(gnix_bitmap_t *bitmap, int initial,
 {
 	__test_initialize_bitmap(bitmap, initial);
 	__test_realloc_bitmap(bitmap, next);
-	assert(bitmap_empty(bitmap));
+	assert(_gnix_bitmap_empty(bitmap));
 }
 
 static void __test_free_bitmap_clean(gnix_bitmap_t *bitmap)
 {
-	int ret = free_bitmap(bitmap);
+	int ret = _gnix_free_bitmap(bitmap);
 
 	assert(ret == 0);
 	assert(bitmap->arr == NULL);
@@ -171,7 +200,7 @@ Test(gnix_bitmap, initialize_0)
 {
 	int ret;
 
-	ret = alloc_bitmap(test_bitmap, 0);
+	ret = _gnix_alloc_bitmap(test_bitmap, 0);
 	assert(ret == -FI_EINVAL);
 
 	call_free_bitmap = 0;
@@ -183,7 +212,7 @@ Test(gnix_bitmap, already_initialized)
 
 	__test_initialize_bitmap(test_bitmap, 128);
 
-	ret = alloc_bitmap(test_bitmap, 128);
+	ret = _gnix_alloc_bitmap(test_bitmap, 128);
 	assert(ret == -FI_EINVAL);
 
 	call_free_bitmap = 0;
@@ -200,7 +229,7 @@ Test(gnix_bitmap, destroy_bitmap_uninitialized)
 {
 	int ret;
 
-	ret = free_bitmap(test_bitmap);
+	ret = _gnix_free_bitmap(test_bitmap);
 	assert(ret == -FI_EINVAL);
 	expect(test_bitmap->arr == NULL);
 	expect(test_bitmap->length == 0);
@@ -215,7 +244,7 @@ Test(gnix_bitmap, destroy_bitmap_already_freed)
 
 	__test_free_bitmap_clean(test_bitmap);
 
-	ret = free_bitmap(test_bitmap);
+	ret = _gnix_free_bitmap(test_bitmap);
 	assert(ret == -FI_EINVAL);
 	expect(test_bitmap->arr == NULL);
 	expect(test_bitmap->length == 0);
@@ -286,113 +315,113 @@ Test(gnix_bitmap, bit_set_test_pass)
 {
 	__test_initialize_bitmap_clean(test_bitmap, 64);
 
-	set_bit(test_bitmap, 1);
+	_gnix_set_bit(test_bitmap, 1);
 
-	assert(test_bit(test_bitmap, 1));
+	assert(_gnix_test_bit(test_bitmap, 1));
 }
 
 Test(gnix_bitmap, bit_set_test_fail)
 {
 	__test_initialize_bitmap_clean(test_bitmap, 64);
 
-	set_bit(test_bitmap, 1);
+	_gnix_set_bit(test_bitmap, 1);
 
-	assert(!test_bit(test_bitmap, 0));
+	assert(!_gnix_test_bit(test_bitmap, 0));
 }
 
 Test(gnix_bitmap, bit_set_clear)
 {
 	__test_initialize_bitmap_clean(test_bitmap, 64);
 
-	set_bit(test_bitmap, 1);
+	_gnix_set_bit(test_bitmap, 1);
 
-	assert(test_bit(test_bitmap, 1));
+	assert(_gnix_test_bit(test_bitmap, 1));
 
-	clear_bit(test_bitmap, 1);
+	_gnix_clear_bit(test_bitmap, 1);
 
-	assert(!test_bit(test_bitmap, 1));
+	assert(!_gnix_test_bit(test_bitmap, 1));
 }
 
 Test(gnix_bitmap, bit_clear)
 {
 	__test_initialize_bitmap_clean(test_bitmap, 64);
 
-	clear_bit(test_bitmap, 1);
+	_gnix_clear_bit(test_bitmap, 1);
 
-	assert(!test_bit(test_bitmap, 1));
+	assert(!_gnix_test_bit(test_bitmap, 1));
 }
 
 Test(gnix_bitmap, bit_set)
 {
 	__test_initialize_bitmap_clean(test_bitmap, 64);
 
-	set_bit(test_bitmap, 1);
+	_gnix_set_bit(test_bitmap, 1);
 }
 
 Test(gnix_bitmap, bit_test_and_set_unset)
 {
 	__test_initialize_bitmap_clean(test_bitmap, 64);
 
-	assert(!test_and_set_bit(test_bitmap, 1));
+	assert(!_gnix_test_and_set_bit(test_bitmap, 1));
 }
 
 Test(gnix_bitmap, bit_test_and_set_already_set)
 {
 	__test_initialize_bitmap_clean(test_bitmap, 64);
 
-	set_bit(test_bitmap, 1);
-	assert(test_bit(test_bitmap, 1));
+	_gnix_set_bit(test_bitmap, 1);
+	assert(_gnix_test_bit(test_bitmap, 1));
 
-	assert(test_and_set_bit(test_bitmap, 1));
+	assert(_gnix_test_and_set_bit(test_bitmap, 1));
 }
 
 Test(gnix_bitmap, bit_test_and_clear_unset)
 {
 	__test_initialize_bitmap_clean(test_bitmap, 64);
 
-	assert(!test_and_clear_bit(test_bitmap, 1));
+	assert(!_gnix_test_and_clear_bit(test_bitmap, 1));
 }
 
 Test(gnix_bitmap, bit_test_and_clear_already_set)
 {
 	__test_initialize_bitmap_clean(test_bitmap, 64);
 
-	set_bit(test_bitmap, 1);
-	assert(test_bit(test_bitmap, 1));
+	_gnix_set_bit(test_bitmap, 1);
+	assert(_gnix_test_bit(test_bitmap, 1));
 
-	assert(test_and_clear_bit(test_bitmap, 1));
+	assert(_gnix_test_and_clear_bit(test_bitmap, 1));
 }
 
 Test(gnix_bitmap, ffs_clean_bitmap)
 {
 	__test_initialize_bitmap_clean(test_bitmap, 64);
 
-	assert(find_first_set_bit(test_bitmap) == -FI_EAGAIN);
+	assert(_gnix_find_first_set_bit(test_bitmap) == -FI_EAGAIN);
 }
 
 Test(gnix_bitmap, ffs_first_bit_set)
 {
 	__test_initialize_bitmap_clean(test_bitmap, 64);
 
-	set_bit(test_bitmap, 0);
+	_gnix_set_bit(test_bitmap, 0);
 
-	assert(find_first_set_bit(test_bitmap) == 0);
+	assert(_gnix_find_first_set_bit(test_bitmap) == 0);
 }
 
 Test(gnix_bitmap, ffs_seventeen_set)
 {
 	__test_initialize_bitmap_clean(test_bitmap, 64);
 
-	set_bit(test_bitmap, 17);
+	_gnix_set_bit(test_bitmap, 17);
 
-	assert(find_first_set_bit(test_bitmap) == 17);
+	assert(_gnix_find_first_set_bit(test_bitmap) == 17);
 }
 
 Test(gnix_bitmap, ffz_clean_bitmap)
 {
 	__test_initialize_bitmap_clean(test_bitmap, 64);
 
-	assert(find_first_zero_bit(test_bitmap) == 0);
+	assert(_gnix_find_first_zero_bit(test_bitmap) == 0);
 }
 
 Test(gnix_bitmap, ffz_full_bitmap)
@@ -402,11 +431,11 @@ Test(gnix_bitmap, ffz_full_bitmap)
 	__test_initialize_bitmap_clean(test_bitmap, 64);
 
 	for (i = 0; i < test_bitmap->length; ++i) {
-		set_bit(test_bitmap, i);
-		assert(test_bit(test_bitmap, i));
+		_gnix_set_bit(test_bitmap, i);
+		assert(_gnix_test_bit(test_bitmap, i));
 	}
 
-	assert(find_first_zero_bit(test_bitmap) == -FI_EAGAIN);
+	assert(_gnix_find_first_zero_bit(test_bitmap) == -FI_EAGAIN);
 }
 
 Test(gnix_bitmap, ffz_first_half_set)
@@ -416,13 +445,13 @@ Test(gnix_bitmap, ffz_first_half_set)
 	__test_initialize_bitmap_clean(test_bitmap, 64);
 
 	for (i = 0; i < 32 ; ++i) {
-		set_bit(test_bitmap, i);
-		assert(test_bit(test_bitmap, i));
+		_gnix_set_bit(test_bitmap, i);
+		assert(_gnix_test_bit(test_bitmap, i));
 	}
 
 	expect(test_bitmap->length == 64);
 	expect(i == 32);
-	assert(find_first_zero_bit(test_bitmap) == i);
+	assert(_gnix_find_first_zero_bit(test_bitmap) == i);
 }
 
 Test(gnix_bitmap, map_fill_0)
@@ -432,24 +461,24 @@ Test(gnix_bitmap, map_fill_0)
 	__test_initialize_bitmap_clean(test_bitmap, 64);
 
 	for (i = 0; i < test_bitmap->length; ++i) {
-		set_bit(test_bitmap, i);
-		assert(test_bit(test_bitmap, i));
+		_gnix_set_bit(test_bitmap, i);
+		assert(_gnix_test_bit(test_bitmap, i));
 	}
 
-	assert(bitmap_full(test_bitmap));
+	assert(_gnix_bitmap_full(test_bitmap));
 
-	fill_bitmap(test_bitmap, 0);
+	_gnix_fill_bitmap(test_bitmap, 0);
 
-	assert(bitmap_empty(test_bitmap));
+	assert(_gnix_bitmap_empty(test_bitmap));
 }
 
 Test(gnix_bitmap, map_fill_1)
 {
 	__test_initialize_bitmap_clean(test_bitmap, 64);
 
-	fill_bitmap(test_bitmap, 1);
+	_gnix_fill_bitmap(test_bitmap, 1);
 
-	assert(bitmap_full(test_bitmap));
+	assert(_gnix_bitmap_full(test_bitmap));
 }
 
 Test(gnix_bitmap, bitmap_load)
@@ -458,7 +487,7 @@ Test(gnix_bitmap, bitmap_load)
 
 	__test_initialize_bitmap_clean(test_bitmap, 64);
 
-	fill_bitmap(test_bitmap, 1);
+	_gnix_fill_bitmap(test_bitmap, 1);
 
 	assert(expected == __gnix_load_block(test_bitmap, 0));
 }
@@ -486,16 +515,16 @@ Test(gnix_bitmap, performance_set_test)
 	gettimeofday(&start, 0);
 	for (i = 0; i < 100000; ++i) {
 		j = i % 8192;
-		set_bit(test_bitmap, j);
-		assert(test_bit(test_bitmap, j));
-		clear_bit(test_bitmap, j);
-		assert(!test_bit(test_bitmap, j));
+		_gnix_set_bit(test_bitmap, j);
+		assert(_gnix_test_bit(test_bitmap, j));
+		_gnix_clear_bit(test_bitmap, j);
+		assert(!_gnix_test_bit(test_bitmap, j));
 	}
 	gettimeofday(&end, 0);
 
 	calculate_time_difference(&start, &end, &secs, &usec);
 
-	assert(bitmap_empty(test_bitmap));
+	assert(_gnix_bitmap_empty(test_bitmap));
 
 	expect(secs < 1);
 }
@@ -513,16 +542,16 @@ Test(gnix_bitmap, performance_set_test_random)
 	gettimeofday(&start, 0);
 	for (i = 0; i < 100000; ++i) {
 		j = rand() % 8192;
-		set_bit(test_bitmap, j);
-		assert(test_bit(test_bitmap, j));
-		clear_bit(test_bitmap, j);
-		assert(!test_bit(test_bitmap, j));
+		_gnix_set_bit(test_bitmap, j);
+		assert(_gnix_test_bit(test_bitmap, j));
+		_gnix_clear_bit(test_bitmap, j);
+		assert(!_gnix_test_bit(test_bitmap, j));
 	}
 	gettimeofday(&end, 0);
 
 	calculate_time_difference(&start, &end, &secs, &usec);
 
-	assert(bitmap_empty(test_bitmap));
+	assert(_gnix_bitmap_empty(test_bitmap));
 
 	expect(secs < 1);
 }
@@ -534,9 +563,9 @@ Test(gnix_bitmap, fill_bitmap_60_ffz_eagain)
 	__test_initialize_bitmap_clean(test_bitmap, 60);
 
 	for (i = 0; i < 60; ++i)
-		set_bit(test_bitmap, i);
+		_gnix_set_bit(test_bitmap, i);
 
-	assert(find_first_zero_bit(test_bitmap) == -FI_EAGAIN);
+	assert(_gnix_find_first_zero_bit(test_bitmap) == -FI_EAGAIN);
 }
 
 Test(gnix_bitmap, fill_bitmap_60_ffs_eagain)
@@ -550,8 +579,8 @@ Test(gnix_bitmap, fill_bitmap_60_ffs_eagain)
 	 *   properly.
 	 */
 	for (i = 60; i < 64; ++i)
-		set_bit(test_bitmap, i);
+		_gnix_set_bit(test_bitmap, i);
 
-	assert(find_first_set_bit(test_bitmap) == -FI_EAGAIN);
+	assert(_gnix_find_first_set_bit(test_bitmap) == -FI_EAGAIN);
 }
 

--- a/prov/gni/test/hashtable.c
+++ b/prov/gni/test/hashtable.c
@@ -588,7 +588,7 @@ Test(gnix_hashtable_advanced, insert_8K_lookup_128K_random)
 	test_elements = calloc(test_size, sizeof(gnix_test_element_t));
 	assert(test_elements != NULL);
 
-	ret = alloc_bitmap(&allocated, bitmap_size);
+	ret = _gnix_alloc_bitmap(&allocated, bitmap_size);
 	assert(ret == 0);
 
 	srand(time(NULL));
@@ -596,7 +596,7 @@ Test(gnix_hashtable_advanced, insert_8K_lookup_128K_random)
 	for (i = 0; i < test_size; ++i) {
 		do {
 			index = rand() % bitmap_size;
-		} while (test_and_set_bit(&allocated, index));
+		} while (_gnix_test_and_set_bit(&allocated, index));
 
 		item = &test_elements[i];
 
@@ -624,7 +624,7 @@ Test(gnix_hashtable_advanced, insert_8K_lookup_128K_random)
 		assert(found->magic == __GNIX_MAGIC_VALUE);
 	}
 
-	ret = free_bitmap(&allocated);
+	ret = _gnix_free_bitmap(&allocated);
 	expect(ret == 0);
 
 	free(test_elements);


### PR DESCRIPTION
GNIX provider specific functions should use the '_gnix_*' naming
convention. This commit addresses this inconsistency.

Signed-off-by: James Swaro jswaro@cray.com

closes #167 
