### PR TITLE
prov/gni: fix missing atomic_init in ep_open

### DIFF
--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -694,6 +694,7 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 	ep_priv->type = info->ep_attr->type;
 	dlist_init(&ep_priv->wc_vc_list);
 	atomic_initialize(&ep_priv->active_fab_reqs, 0);
+	atomic_initialize(&ep_priv->ref_cnt, 0);
 	ret = __fr_freelist_init(ep_priv);
 	if (ret != FI_SUCCESS) {
 		GNIX_ERR(FI_LOG_EP_CTRL,

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -83,6 +83,8 @@ static int _gnix_vc_get_id(struct gnix_vc *vc)
 	struct gnix_nic *nic;
 	struct gnix_vc **table_base;
 
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
 	ep = vc->ep;
 	if (ep == NULL)
 		return -FI_EINVAL;

--- a/prov/gni/test/vc.c
+++ b/prov/gni/test/vc.c
@@ -164,7 +164,7 @@ void vc_teardown(void)
  ******************************************************************************/
 
 TestSuite(vc_management, .init = vc_setup, .fini = vc_teardown,
-	  .disabled = true);
+	  .disabled = false);
 
 Test(vc_management, vc_alloc_simple)
 {


### PR DESCRIPTION
Add more trace macros to gnix_vc.c

reenable vc tests

@sungeunchoi 

Signed-off-by: Howard Pritchard howardp@lanl.gov
