### PR TITLE
prov/gni: initial gni nic progress function

### DIFF
--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -127,8 +127,8 @@ union gnix_tx_descriptor0 {
 		struct list_node          list;
 		gni_post_descriptor_t       gni_desc;
 		struct gnix_smsg_descriptor gnix_smsg_desc;
-		struct gnix_vc *vc;
-		struct gnix_fid_ep *ep;
+		struct gnix_fab_req *req;
+		int  (*completer_func)(void *);
 		int id;
 	};
 	char padding[GNIX_CACHELINE_SIZE];
@@ -150,6 +150,9 @@ extern uint32_t gnix_def_max_nics_per_ptag;
  * prototypes
  */
 
+int _gnix_nic_tx_freelist_init(struct gnix_nic *nic, int n_descs);
+int _gnix_nic_tx_alloc(struct gnix_nic *nic, struct gnix_tx_descriptor **tdesc);
+int _gnix_nic_tx_free(struct gnix_nic *nic, struct gnix_tx_descriptor *tdesc);
 int _gnix_nic_free(struct gnix_nic *nic);
 int gnix_nic_alloc(struct gnix_fid_domain *domain,
 			struct gnix_nic **nic_ptr);


### PR DESCRIPTION
Initial implementation of a gnix_nic progress function
for tx CQ and work queue.  RX CQ process needs to
be added.

More criterion tests will need to be added to test
this feature once at least a partial fi_send/fi_recv
is implemented.

@sungeunchoi 
@ztiffany 
@jswaro 

Signed-off-by: Howard Pritchard howardp@lanl.gov
