### PR TITLE
Rename mbox allocator functions

### DIFF
--- a/prov/gni/include/gnix_mbox_allocator.h
+++ b/prov/gni/include/gnix_mbox_allocator.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015 Cray Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -137,10 +138,12 @@ struct gnix_mbox_alloc_handle {
  * @return [Unspec]	If failure in GNI_MemRegister. Converts gni_return_t
  * status code to FI_ERRNO value.
  */
-int gnix_mbox_allocator_create(struct gnix_nic *nic, gni_cq_handle_t cq_handle,
-			       enum gnix_page_size page_size, size_t mbox_size,
-			       size_t mpmmap,
-			       struct gnix_mbox_alloc_handle **alloc_handle);
+int _gnix_mbox_allocator_create(struct gnix_nic *nic,
+				gni_cq_handle_t cq_handle,
+				enum gnix_page_size page_size,
+				size_t mbox_size,
+				size_t mpmmap,
+				struct gnix_mbox_alloc_handle **alloc_handle);
 
 /**
  * Releases all resources associated with an allocator handle.
@@ -152,7 +155,7 @@ int gnix_mbox_allocator_create(struct gnix_nic *nic, gni_cq_handle_t cq_handle,
  * @return -FI_EBUSY	Upon finding that there are still mailboxes allocated
  * that haven't been freed using gnix_mbox_free.
  */
-int gnix_mbox_allocator_destroy(struct gnix_mbox_alloc_handle *alloc_handle);
+int _gnix_mbox_allocator_destroy(struct gnix_mbox_alloc_handle *alloc_handle);
 
 /**
  * Allocate a new mailbox.
@@ -170,8 +173,8 @@ int gnix_mbox_allocator_destroy(struct gnix_mbox_alloc_handle *alloc_handle);
  * @return [Unspec]	Upon failure in GNI_MemRegister. Converts gni_return_t
  * to FI_ERRNO value.
  */
-int gnix_mbox_alloc(struct gnix_mbox_alloc_handle *alloc_handle,
-		    struct gnix_mbox **ptr);
+int _gnix_mbox_alloc(struct gnix_mbox_alloc_handle *alloc_handle,
+		     struct gnix_mbox **ptr);
 
 /**
  * Mark mailbox as free.
@@ -182,7 +185,7 @@ int gnix_mbox_alloc(struct gnix_mbox_alloc_handle *alloc_handle,
  * @return -FI_EINVAL	Upon an invalid parameter, or finding that the bitmap
  * is in a corrupted state.
  */
-int gnix_mbox_free(struct gnix_mbox *ptr);
+int _gnix_mbox_free(struct gnix_mbox *ptr);
 
 /*
  * Initialized in gnix_init.c, used for updating filename when creating

--- a/prov/gni/src/gnix_mbox_allocator.c
+++ b/prov/gni/src/gnix_mbox_allocator.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015 Cray Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -561,10 +562,12 @@ err_mbox_calloc:
 	return ret;
 }
 
-int gnix_mbox_allocator_create(struct gnix_nic *nic, gni_cq_handle_t cq_handle,
-			       enum gnix_page_size page_size, size_t mbox_size,
-			       size_t mpmmap,
-			       struct gnix_mbox_alloc_handle **alloc_handle)
+int _gnix_mbox_allocator_create(struct gnix_nic *nic,
+				gni_cq_handle_t cq_handle,
+				enum gnix_page_size page_size,
+				size_t mbox_size,
+				size_t mpmmap,
+				struct gnix_mbox_alloc_handle **alloc_handle)
 {
 	struct gnix_mbox_alloc_handle *handle;
 	char error_buf[256];
@@ -619,7 +622,7 @@ err_huge_page:
 	return ret;
 }
 
-int gnix_mbox_allocator_destroy(struct gnix_mbox_alloc_handle *alloc_handle)
+int _gnix_mbox_allocator_destroy(struct gnix_mbox_alloc_handle *alloc_handle)
 {
 	struct slist_entry *entry;
 	struct gnix_slab *temp;
@@ -667,8 +670,8 @@ int gnix_mbox_allocator_destroy(struct gnix_mbox_alloc_handle *alloc_handle)
 	return FI_SUCCESS;
 }
 
-int gnix_mbox_alloc(struct gnix_mbox_alloc_handle *alloc_handle,
-		    struct gnix_mbox **ptr)
+int _gnix_mbox_alloc(struct gnix_mbox_alloc_handle *alloc_handle,
+		     struct gnix_mbox **ptr)
 {
 	struct gnix_slab *slab;
 	int position;
@@ -704,7 +707,7 @@ err:
 	return ret;
 }
 
-int gnix_mbox_free(struct gnix_mbox *ptr)
+int _gnix_mbox_free(struct gnix_mbox *ptr)
 {
 	size_t position;
 	int ret;

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -170,10 +170,10 @@ int _gnix_nic_free(struct gnix_nic *nic)
 			goto err;
 		}
 
-		ret = gnix_mbox_allocator_destroy(nic->mbox_hndl);
+		ret = _gnix_mbox_allocator_destroy(nic->mbox_hndl);
 		if (ret != FI_SUCCESS)
 			GNIX_WARN(FI_LOG_EP_CTRL,
-				  "gnix_mbox_allocator_destroy returned %d\n",
+				  "_gnix_mbox_allocator_destroy returned %d\n",
 				  ret);
 
 		/*
@@ -410,15 +410,15 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 			goto err1;
 		}
 
-		ret = gnix_mbox_allocator_create(nic,
-						 nic->rx_cq,
-						 GNIX_PAGE_2MB,
-						 (size_t)nic->mem_per_mbox,
-						 2048,
-						 &nic->mbox_hndl);
+		ret = _gnix_mbox_allocator_create(nic,
+						  nic->rx_cq,
+						  GNIX_PAGE_2MB,
+						  (size_t)nic->mem_per_mbox,
+						  2048,
+						  &nic->mbox_hndl);
 		if (ret != FI_SUCCESS) {
 			GNIX_WARN(FI_LOG_EP_CTRL,
-				  "gnix_mbox_alloc returned %d\n", ret);
+				  "_gnix_mbox_alloc returned %d\n", ret);
 			goto err1;
 		}
 

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -399,7 +399,7 @@ static int __gnix_vc_hndl_con_match_con(struct gnix_datagram *dgram,
 	ret = _gnix_dgram_free(dgram);
 	if (ret != FI_SUCCESS)
 		GNIX_WARN(FI_LOG_EP_CTRL,
-			  "gnix_mbox_free returned %d\n", ret);
+			  "_gnix_dgram_free returned %d\n", ret);
 	vc->dgram = NULL;
 
 	ret = _gnix_vc_add_to_wq(vc);
@@ -582,7 +582,7 @@ static int __gnix_vc_hndl_wc_match_con(struct gnix_datagram *dgram,
 	ret = _gnix_dgram_free(dgram);
 	if (ret != FI_SUCCESS)
 		GNIX_WARN(FI_LOG_EP_CTRL,
-			  "gnix_mbox_free returned %d\n",
+			  "_gnix_dgram_free returned %d\n",
 			  ret);
 	vc->dgram = NULL;
 
@@ -751,8 +751,8 @@ static int __gnix_vc_connect_prog_fn(void *data, int *complete_ptr)
 	 */
 
 	if (vc->smsg_mbox == NULL) {
-		ret = gnix_mbox_alloc(vc->ep->nic->mbox_hndl,
-				 &mbox);
+		ret = _gnix_mbox_alloc(vc->ep->nic->mbox_hndl,
+				       &mbox);
 		if (ret == FI_SUCCESS)
 			vc->smsg_mbox = mbox;
 		else
@@ -833,17 +833,17 @@ static int __gnix_vc_connect_prog_fn(void *data, int *complete_ptr)
 
 	if (!(vc->modes & GNIX_VC_MODE_DG_POSTED) &&
 		(vc->conn_state != GNIX_VC_CONNECTED)) {
-		ret = gnix_mbox_free(vc->smsg_mbox);
+		ret = _gnix_mbox_free(vc->smsg_mbox);
 		if (ret != FI_SUCCESS)
 			GNIX_WARN(FI_LOG_EP_CTRL,
-				  "gnix_mbox_free returned %d\n",
+				  "_gnix_mbox_free returned %d\n",
 				  ret);
 		vc->smsg_mbox = NULL;
 
 		ret = _gnix_dgram_free(dgram);
 		if (ret != FI_SUCCESS)
 			GNIX_WARN(FI_LOG_EP_CTRL,
-				  "gnix_dgram_free returned %d\n",
+				  "_gnix_dgram_free returned %d\n",
 				  ret);
 	}
 
@@ -967,10 +967,10 @@ int _gnix_vc_destroy(struct gnix_vc *vc)
 	}
 
 	if (vc->smsg_mbox != NULL) {
-		ret = gnix_mbox_free(vc->smsg_mbox);
+		ret = _gnix_mbox_free(vc->smsg_mbox);
 		if (ret != FI_SUCCESS)
 			GNIX_WARN(FI_LOG_EP_CTRL,
-			      "gnix_mbox_free returned %d\n", ret);
+			      "_gnix_mbox_free returned %d\n", ret);
 		vc->smsg_mbox = NULL;
 	}
 
@@ -978,7 +978,7 @@ int _gnix_vc_destroy(struct gnix_vc *vc)
 		ret = _gnix_dgram_free(vc->dgram);
 		if (ret != FI_SUCCESS)
 			GNIX_WARN(FI_LOG_EP_CTRL,
-			      "gnix_dgram_free returned %d\n", ret);
+			      "_gnix_dgram_free returned %d\n", ret);
 		vc->dgram = NULL;
 	}
 
@@ -1099,8 +1099,8 @@ int _gnix_vc_accept(struct gnix_vc *vc)
 	/*
 	 * try to allocate a mailbox
 	 */
-	ret = gnix_mbox_alloc(nic->mbox_hndl,
-			      &mbox);
+	ret = _gnix_mbox_alloc(nic->mbox_hndl,
+			       &mbox);
 	if (ret == FI_SUCCESS)
 		vc->smsg_mbox = mbox;
 	else {
@@ -1168,7 +1168,7 @@ int _gnix_vc_accept(struct gnix_vc *vc)
 	return ret;
 
 err1:
-	ret = gnix_mbox_free(mbox);
+	ret = _gnix_mbox_free(mbox);
 err:
 	return ret;
 }

--- a/prov/gni/test/allocator.c
+++ b/prov/gni/test/allocator.c
@@ -156,14 +156,14 @@ static void open_close_allocator(enum gnix_page_size page_size,
 {
 	int ret;
 
-	ret = gnix_mbox_allocator_create(ep_priv->nic, NULL, page_size,
-					 mbox_size, mpmmap, &allocator);
-	cr_assert_eq(ret, FI_SUCCESS, "gnix_mbox_allocator_create failed.");
+	ret = _gnix_mbox_allocator_create(ep_priv->nic, NULL, page_size,
+					  mbox_size, mpmmap, &allocator);
+	cr_assert_eq(ret, FI_SUCCESS, "_gnix_mbox_allocator_create failed.");
 	cr_expect_eq(verify_hugepages(), 2,
 		     "memory not found in /proc/self/maps.");
 
-	ret = gnix_mbox_allocator_destroy(allocator);
-	cr_assert_eq(ret, FI_SUCCESS, "gnix_mbox_allocator_destroy failed.");
+	ret = _gnix_mbox_allocator_destroy(allocator);
+	cr_assert_eq(ret, FI_SUCCESS, "_gnix_mbox_allocator_destroy failed.");
 	cr_expect_eq(verify_hugepages(), 1,
 		     "memory not released in /proc/self/maps.");
 }
@@ -205,9 +205,9 @@ Test(mbox_creation, alloc_mbox)
 
 	char test_string[] = "hello allocator.";
 
-	ret = gnix_mbox_allocator_create(ep_priv->nic, NULL, GNIX_PAGE_4MB,
-					 1000, 12000, &allocator);
-	cr_assert_eq(ret, FI_SUCCESS, "gnix_mbox_allocator_create failed.");
+	ret = _gnix_mbox_allocator_create(ep_priv->nic, NULL, GNIX_PAGE_4MB,
+					  1000, 12000, &allocator);
+	cr_assert_eq(ret, FI_SUCCESS, "_gnix_mbox_allocator_create failed.");
 
 	/*
 	 *value is 2 because the provider has internally already opened
@@ -216,8 +216,8 @@ Test(mbox_creation, alloc_mbox)
 	cr_expect_eq(verify_hugepages(), 2,
 		  "memory not found in /proc/self/maps.");
 
-	ret = gnix_mbox_alloc(allocator, &mail_box);
-	cr_expect_eq(ret, FI_SUCCESS, "gnix_mbox_alloc failed.");
+	ret = _gnix_mbox_alloc(allocator, &mail_box);
+	cr_expect_eq(ret, FI_SUCCESS, "_gnix_mbox_alloc failed.");
 
 	cr_expect(mail_box);
 
@@ -243,18 +243,18 @@ Test(mbox_creation, alloc_mbox)
 	/*
 	 * Mailboxes haven't been returned so destroy will return -FI_EBUSY.
 	 */
-	ret = gnix_mbox_allocator_destroy(allocator);
+	ret = _gnix_mbox_allocator_destroy(allocator);
 	cr_assert_eq(ret, -FI_EBUSY,
-		  "gnix_mbox_allocator_destroy should have returned -FI_EBUSY.");
+		  "_gnix_mbox_allocator_destroy should have returned -FI_EBUSY.");
 
 	/*
 	 * Free allocated mailboxes so we can destroy cleanly.
 	 */
-	ret = gnix_mbox_free(mail_box);
-	cr_expect_eq(ret, FI_SUCCESS, "gnix_mbox_free failed.");
+	ret = _gnix_mbox_free(mail_box);
+	cr_expect_eq(ret, FI_SUCCESS, "_gnix_mbox_free failed.");
 
-	ret = gnix_mbox_allocator_destroy(allocator);
-	cr_assert_eq(ret, FI_SUCCESS, "gnix_mbox_allocator_destroy failed.");
+	ret = _gnix_mbox_allocator_destroy(allocator);
+	cr_assert_eq(ret, FI_SUCCESS, "_gnix_mbox_allocator_destroy failed.");
 
 	cr_expect_eq(verify_hugepages(), 1,
 		     "memory not released in /proc/self/maps.");
@@ -268,8 +268,8 @@ Test(mbox_creation, page_size_fail)
 {
 	int ret;
 
-	ret = gnix_mbox_allocator_create(ep_priv->nic, NULL, 2200,
-					 1000, 12000, &allocator);
+	ret = _gnix_mbox_allocator_create(ep_priv->nic, NULL, 2200,
+					  1000, 12000, &allocator);
 	cr_assert_eq(ret, -FI_EINVAL,
 		     "Creating allocator with bogus page size succeeded.");
 	cr_assert_eq(allocator, NULL);
@@ -280,9 +280,9 @@ Test(mbox_creation, page_size_fail)
 	cr_expect_eq(verify_hugepages(), 1,
 		     "Huge page open, but shouldn't be");
 
-	ret = gnix_mbox_allocator_destroy(allocator);
+	ret = _gnix_mbox_allocator_destroy(allocator);
 	cr_assert_eq(ret, -FI_EINVAL,
-		     "gnix_mbox_allocator_destroy succeeded on NULL handle.");
+		     "_gnix_mbox_allocator_destroy succeeded on NULL handle.");
 }
 
 Test(mbox_creation, mbox_size_fail)
@@ -292,8 +292,8 @@ Test(mbox_creation, mbox_size_fail)
 	/*
 	 * mbox_size can't be zero.
 	 */
-	ret = gnix_mbox_allocator_create(ep_priv->nic, NULL, GNIX_PAGE_4MB,
-					 0, 12000, &allocator);
+	ret = _gnix_mbox_allocator_create(ep_priv->nic, NULL, GNIX_PAGE_4MB,
+					  0, 12000, &allocator);
 	cr_assert_eq(ret, -FI_EINVAL,
 		     "Creating allocator with zero mbox size succeeded.");
 
@@ -301,9 +301,9 @@ Test(mbox_creation, mbox_size_fail)
 	cr_expect_eq(verify_hugepages(), 1,
 		     "Huge page open, but shouldn't be");
 
-	ret = gnix_mbox_allocator_destroy(allocator);
+	ret = _gnix_mbox_allocator_destroy(allocator);
 	cr_assert_eq(ret, -FI_EINVAL,
-		     "gnix_mbox_allocator_destroy succeeded on NULL handle.");
+		     "_gnix_mbox_allocator_destroy succeeded on NULL handle.");
 }
 
 Test(mbox_creation, mpmmap_size_fail)
@@ -313,17 +313,17 @@ Test(mbox_creation, mpmmap_size_fail)
 	/*
 	 * Can't have zero mailboxes per mmap.
 	 */
-	ret = gnix_mbox_allocator_create(ep_priv->nic, NULL, GNIX_PAGE_4MB,
-					 1000, 0, &allocator);
+	ret = _gnix_mbox_allocator_create(ep_priv->nic, NULL, GNIX_PAGE_4MB,
+					  1000, 0, &allocator);
 	cr_assert_eq(ret, -FI_EINVAL,
 		  "Creating allocator with zero mailboxes per mmap succeeded.");
 	cr_assert_eq(allocator, NULL);
 	cr_expect_eq(verify_hugepages(), 1,
 		     "Huge page open, but shouldn't be");
 
-	ret = gnix_mbox_allocator_destroy(allocator);
+	ret = _gnix_mbox_allocator_destroy(allocator);
 	cr_assert_eq(ret, -FI_EINVAL,
-		     "gnix_mbox_allocator_destroy succeeded on NULL handle.");
+		     "_gnix_mbox_allocator_destroy succeeded on NULL handle.");
 }
 
 Test(mbox_creation, null_allocator_fail)
@@ -333,16 +333,16 @@ Test(mbox_creation, null_allocator_fail)
 	/*
 	 * Can't have a NULL allocator.
 	 */
-	ret = gnix_mbox_allocator_create(ep_priv->nic, NULL, GNIX_PAGE_4MB,
-					 1000, 100, NULL);
+	ret = _gnix_mbox_allocator_create(ep_priv->nic, NULL, GNIX_PAGE_4MB,
+					  1000, 100, NULL);
 	cr_assert_eq(ret, -FI_EINVAL,
 		     "Creating allocator with null allocator succeeded.");
 	cr_expect_eq(verify_hugepages(), 1,
 		     "Huge page open, but shouldn't be");
 
-	ret = gnix_mbox_allocator_destroy(allocator);
+	ret = _gnix_mbox_allocator_destroy(allocator);
 	cr_assert_eq(ret, -FI_EINVAL,
-		     "gnix_mbox_allocator_destroy succeeded on NULL handle.");
+		     "_gnix_mbox_allocator_destroy succeeded on NULL handle.");
 }
 
 Test(mbox_creation, multi_allocation)
@@ -357,9 +357,9 @@ Test(mbox_creation, multi_allocation)
 
 	struct gnix_mbox *mbox_arr[array_size];
 
-	ret = gnix_mbox_allocator_create(ep_priv->nic, NULL, GNIX_PAGE_4MB,
-					 mbox_size, array_size, &allocator);
-	cr_assert_eq(ret, FI_SUCCESS, "gnix_mbox_allocator_create failed.");
+	ret = _gnix_mbox_allocator_create(ep_priv->nic, NULL, GNIX_PAGE_4MB,
+					  mbox_size, array_size, &allocator);
+	cr_assert_eq(ret, FI_SUCCESS, "_gnix_mbox_allocator_create failed.");
 	cr_expect_eq(verify_hugepages(), 2,
 		     "memory not found in /proc/self/maps.");
 
@@ -367,8 +367,8 @@ Test(mbox_creation, multi_allocation)
 	 * Create an array of mailboxes of size array_size.
 	 */
 	for (int i = 0; i < array_size; i++) {
-		ret = gnix_mbox_alloc(allocator, &(mbox_arr[i]));
-		cr_expect_eq(ret, FI_SUCCESS, "gnix_mbox_alloc failed.");
+		ret = _gnix_mbox_alloc(allocator, &(mbox_arr[i]));
+		cr_expect_eq(ret, FI_SUCCESS, "_gnix_mbox_alloc failed.");
 		cr_expect(mbox_arr[i]);
 	}
 
@@ -393,12 +393,12 @@ Test(mbox_creation, multi_allocation)
 	}
 
 	for (int i = 0; i < array_size; i++) {
-		ret = gnix_mbox_free(mbox_arr[i]);
-		cr_expect_eq(ret, FI_SUCCESS, "gnix_mbox_free failed.");
+		ret = _gnix_mbox_free(mbox_arr[i]);
+		cr_expect_eq(ret, FI_SUCCESS, "_gnix_mbox_free failed.");
 	}
 
-	ret = gnix_mbox_allocator_destroy(allocator);
-	cr_assert_eq(ret, FI_SUCCESS, "gnix_mbox_allocator_destroy failed.");
+	ret = _gnix_mbox_allocator_destroy(allocator);
+	cr_assert_eq(ret, FI_SUCCESS, "_gnix_mbox_allocator_destroy failed.");
 
 	cr_expect_eq(verify_hugepages(), 1,
 		     "memory not released in /proc/self/maps.");
@@ -410,30 +410,30 @@ Test(mbox_creation, double_free)
 
 	struct gnix_mbox *mail_box;
 
-	ret = gnix_mbox_allocator_create(ep_priv->nic, NULL, GNIX_PAGE_4MB,
-					 1000, 12000, &allocator);
-	cr_assert_eq(ret, FI_SUCCESS, "gnix_mbox_allocator_create failed.");
+	ret = _gnix_mbox_allocator_create(ep_priv->nic, NULL, GNIX_PAGE_4MB,
+					  1000, 12000, &allocator);
+	cr_assert_eq(ret, FI_SUCCESS, "_gnix_mbox_allocator_create failed.");
 	cr_expect_eq(verify_hugepages(), 2,
 		     "memory not found in /proc/self/maps.");
 
-	ret = gnix_mbox_alloc(allocator, &mail_box);
-	cr_expect_eq(ret, FI_SUCCESS, "gnix_mbox_alloc failed.");
+	ret = _gnix_mbox_alloc(allocator, &mail_box);
+	cr_expect_eq(ret, FI_SUCCESS, "_gnix_mbox_alloc failed.");
 
 	cr_expect(mail_box);
 	/*
 	 * Free allocated mailboxes so we can destroy cleanly.
 	 */
-	ret = gnix_mbox_free(mail_box);
-	cr_expect_eq(ret, FI_SUCCESS, "gnix_mbox_free failed.");
+	ret = _gnix_mbox_free(mail_box);
+	cr_expect_eq(ret, FI_SUCCESS, "_gnix_mbox_free failed.");
 
 	/*
 	 * Ensure double free fails.
 	 */
-	ret = gnix_mbox_free(mail_box);
+	ret = _gnix_mbox_free(mail_box);
 	cr_expect_eq(ret, -FI_EINVAL, "double free succeeded.");
 
-	ret = gnix_mbox_allocator_destroy(allocator);
-	cr_assert_eq(ret, FI_SUCCESS, "gnix_mbox_allocator_destroy failed.");
+	ret = _gnix_mbox_allocator_destroy(allocator);
+	cr_assert_eq(ret, FI_SUCCESS, "_gnix_mbox_allocator_destroy failed.");
 
 	cr_expect_eq(verify_hugepages(), 1,
 		     "memory not released in /proc/self/maps.");
@@ -455,23 +455,23 @@ Test(mbox_creation, two_slabs)
 
 	struct gnix_mbox *mbox_arr[2];
 
-	ret = gnix_mbox_allocator_create(ep_priv->nic, NULL, GNIX_PAGE_4MB,
-					 mbox_size, mpmmap, &allocator);
-	cr_assert_eq(ret, FI_SUCCESS, "gnix_mbox_allocator_create failed.");
+	ret = _gnix_mbox_allocator_create(ep_priv->nic, NULL, GNIX_PAGE_4MB,
+					  mbox_size, mpmmap, &allocator);
+	cr_assert_eq(ret, FI_SUCCESS, "_gnix_mbox_allocator_create failed.");
 	cr_expect_eq(verify_hugepages(), 2,
 		     "memory not found in /proc/self/maps.");
 
 	/*
 	 * Should use previously allocated slab
 	 */
-	ret = gnix_mbox_alloc(allocator, &(mbox_arr[0]));
-	cr_expect_eq(ret, FI_SUCCESS, "gnix_mbox_alloc failed.");
+	ret = _gnix_mbox_alloc(allocator, &(mbox_arr[0]));
+	cr_expect_eq(ret, FI_SUCCESS, "_gnix_mbox_alloc failed.");
 
 	/*
 	 * Will need another slab. Allocation will occur.
 	 */
-	ret = gnix_mbox_alloc(allocator, &(mbox_arr[1]));
-	cr_expect_eq(ret, FI_SUCCESS, "gnix_mbox_alloc failed.");
+	ret = _gnix_mbox_alloc(allocator, &(mbox_arr[1]));
+	cr_expect_eq(ret, FI_SUCCESS, "_gnix_mbox_alloc failed.");
 
 	/*
 	 * The bases should be different. The base is a per slab concept.
@@ -484,14 +484,14 @@ Test(mbox_creation, two_slabs)
 	 */
 	cr_expect_eq(2, count_slabs(allocator));
 
-	ret = gnix_mbox_free(mbox_arr[0]);
-	cr_expect_eq(ret, FI_SUCCESS, "gnix_mbox_free failed.");
+	ret = _gnix_mbox_free(mbox_arr[0]);
+	cr_expect_eq(ret, FI_SUCCESS, "_gnix_mbox_free failed.");
 
-	ret = gnix_mbox_free(mbox_arr[1]);
-	cr_expect_eq(ret, FI_SUCCESS, "gnix_mbox_free failed.");
+	ret = _gnix_mbox_free(mbox_arr[1]);
+	cr_expect_eq(ret, FI_SUCCESS, "_gnix_mbox_free failed.");
 
-	ret = gnix_mbox_allocator_destroy(allocator);
-	cr_assert_eq(ret, FI_SUCCESS, "gnix_mbox_allocator_destroy failed.");
+	ret = _gnix_mbox_allocator_destroy(allocator);
+	cr_assert_eq(ret, FI_SUCCESS, "_gnix_mbox_allocator_destroy failed.");
 
 	cr_expect_eq(verify_hugepages(), 1,
 		     "memory not released in /proc/self/maps.");


### PR DESCRIPTION
Rename mbox allocator functions to follow provider-internal function naming policy (and fix error message for gnix_dgram_free)

@jswaro @ztiffany 

Fixes #160 

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com
