### PR TITLE
Initial RMA work

### DIFF
--- a/prov/gni/Makefile.am
+++ b/prov/gni/Makefile.am
@@ -33,7 +33,8 @@ _gni_files = \
 	prov/gni/src/gnix_freelist.c \
 	prov/gni/src/gnix_bitmap.c \
 	prov/gni/src/gnix_hashtable.c \
-	prov/gni/src/gnix_mbox_allocator.c
+	prov/gni/src/gnix_mbox_allocator.c \
+	prov/gni/src/gnix_rma.c
 
 if HAVE_CRITERION
 bin_PROGRAMS = prov/gni/test/gnitest
@@ -53,7 +54,8 @@ prov_gni_test_gnitest_SOURCES = \
 	prov/gni/test/hashtable.c \
 	prov/gni/test/allocator.c \
 	prov/gni/test/mr.c \
-	prov/gni/test/vc.c
+	prov/gni/test/vc.c \
+	prov/gni/test/rdm_rw.c
 
 prov_gni_test_gnitest_LDFLAGS = -static
 prov_gni_test_gnitest_CPPFLAGS = $(AM_CPPFLAGS)

--- a/prov/gni/include/gnix_ep.h
+++ b/prov/gni/include/gnix_ep.h
@@ -40,6 +40,9 @@
  * prototypes for GNI EP internal implementation
  */
 
+struct gnix_fab_req *_fr_alloc(struct gnix_fid_ep *ep);
+void _fr_free(struct gnix_fid_ep *ep, struct gnix_fab_req *fr);
+
 /*
  * typedefs for function vectors used to steer send/receive/rma/amo requests,
  * i.e. fi_send, fi_recv, etc. to ep type specific methods

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -127,8 +127,8 @@ union gnix_tx_descriptor0 {
 		struct list_node          list;
 		gni_post_descriptor_t       gni_desc;
 		struct gnix_smsg_descriptor gnix_smsg_desc;
-		struct gnix_vc *vc;
-		struct gnix_fid_ep *ep;
+		struct gnix_fab_req *req;
+		int  (*completer_func)(void *);
 		int id;
 	};
 	char padding[GNIX_CACHELINE_SIZE];
@@ -150,6 +150,9 @@ extern uint32_t gnix_def_max_nics_per_ptag;
  * prototypes
  */
 
+int _gnix_nic_tx_freelist_init(struct gnix_nic *nic, int n_descs);
+int _gnix_nic_tx_alloc(struct gnix_nic *nic, struct gnix_tx_descriptor **tdesc);
+int _gnix_nic_tx_free(struct gnix_nic *nic, struct gnix_tx_descriptor *tdesc);
 int _gnix_nic_free(struct gnix_nic *nic);
 int gnix_nic_alloc(struct gnix_fid_domain *domain,
 			struct gnix_nic **nic_ptr);

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -45,6 +45,7 @@ extern "C" {
 #include "gnix.h"
 #include "gnix_bitmap.h"
 #include "gnix_mbox_allocator.h"
+#include <fi_list.h>
 #include <assert.h>
 
 /*
@@ -75,8 +76,8 @@ extern "C" {
  */
 
 struct gnix_nic {
-	struct list_node list;
-	struct list_node gnix_nic_list;
+	struct list_node list;          /* global NIC list */
+	struct list_node gnix_nic_list; /* domain list */
 	fastlock_t lock;
 	gni_cdm_handle_t gni_cdm_hndl;
 	gni_nic_handle_t gni_nic_hndl;
@@ -84,8 +85,8 @@ struct gnix_nic {
 	gni_cq_handle_t rx_cq_blk;
 	gni_cq_handle_t tx_cq;
 	gni_cq_handle_t tx_cq_blk;
-	struct list_head tx_desc_active_list;
-	struct list_head tx_desc_free_list;
+	struct dlist_entry tx_desc_active_list;
+	struct dlist_entry tx_desc_free_list;
 	struct gnix_tx_descriptor *tx_desc_base;
 	atomic_t outstanding_fab_reqs_nic;
 	fastlock_t wq_lock;
@@ -124,7 +125,7 @@ struct gnix_smsg_descriptor {
 
 union gnix_tx_descriptor0 {
 	struct {
-		struct list_node          list;
+		struct dlist_entry          list;
 		gni_post_descriptor_t       gni_desc;
 		struct gnix_smsg_descriptor gnix_smsg_desc;
 		struct gnix_fab_req *req;

--- a/prov/gni/include/gnix_rma.h
+++ b/prov/gni/include/gnix_rma.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2015 Cray Inc.  All rights reserved.
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -30,70 +31,20 @@
  * SOFTWARE.
  */
 
-#ifndef _GNIX_CQ_H_
-#define _GNIX_CQ_H_
+#ifndef _GNIX_RMA_H_
+#define _GNIX_RMA_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+ssize_t _gnix_write(struct gnix_vc *vc, uint64_t loc_addr, size_t len,
+		    void *mdesc, uint64_t rem_addr, uint64_t mkey,
+		    void *context, uint64_t flags, uint64_t data);
 
-#include <fi.h>
+ssize_t _gnix_write_imm(struct gnix_vc *vc, uint64_t loc_addr, size_t len,
+		        void *mdesc, uint64_t rem_addr, uint64_t mkey,
+		        void *context, uint64_t flags, uint64_t data);
 
-#include "gnix_queue.h"
-#include "gnix_wait.h"
-#include "gnix_util.h"
-#include <fi_list.h>
+ssize_t _gnix_read(struct gnix_vc *vc, uint64_t loc_addr, size_t len,
+		   void *mdesc, uint64_t rem_addr, uint64_t mkey,
+		   void *context, uint64_t flags, uint64_t data);
 
-#define GNIX_CQ_DEFAULT_FORMAT struct fi_cq_entry
-#define GNIX_CQ_DEFAULT_SIZE   256
+#endif /* _GNIX_RMA_H_ */
 
-struct gnix_cq_entry {
-	void *the_entry;
-	fi_addr_t source;
-	struct slist_entry item;
-};
-
-/* many to many relationship between CQs and polled NICs */
-struct gnix_cq_poll_nic {
-	struct dlist_entry list;
-	int ref_cnt;
-	struct gnix_nic *nic;
-};
-
-struct gnix_fid_cq {
-	struct fid_cq cq_fid;
-	struct gnix_fid_domain *domain;
-
-	struct gnix_queue *events;
-	struct gnix_queue *errors;
-
-	struct fi_cq_attr attr;
-	size_t entry_size;
-
-	struct fid_wait *wait;
-
-	fastlock_t lock;
-	atomic_t ref_cnt;
-
-	struct dlist_entry poll_nics;
-	rwlock_t nic_lock;
-};
-
-
-ssize_t _gnix_cq_add_event(struct gnix_fid_cq *cq, void *op_context,
-			  uint64_t flags, size_t len, void *buf,
-			  uint64_t data, uint64_t tag);
-
-ssize_t _gnix_cq_add_error(struct gnix_fid_cq *cq, void *op_context,
-			  uint64_t flags, size_t len, void *buf,
-			  uint64_t data, uint64_t tag, size_t olen,
-			  int err, int prov_errno, void *err_data);
-
-int _gnix_cq_poll_nic_add(struct gnix_fid_cq *cq, struct gnix_nic *nic);
-int _gnix_cq_poll_nic_rem(struct gnix_fid_cq *cq, struct gnix_nic *nic);
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif

--- a/prov/gni/include/gnix_util.h
+++ b/prov/gni/include/gnix_util.h
@@ -87,6 +87,14 @@ static inline void dlist_remove_init(struct dlist_entry *e)
 	     e && (&e->member != h);					\
 	     e = n, n = dlist_entry((&e->member)->next, typeof(*e), member))
 
+
+#define rwlock_t pthread_rwlock_t
+#define rwlock_init(lock) pthread_rwlock_init(lock, NULL)
+#define rwlock_destroy(lock) pthread_rwlock_destroy(lock)
+#define rwlock_wrlock(lock) pthread_rwlock_wrlock(lock)
+#define rwlock_rdlock(lock) pthread_rwlock_rdlock(lock)
+#define rwlock_unlock(lock) pthread_rwlock_unlock(lock)
+
 /*
  * prototypes
  */

--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include "gnix.h"
+#include "gnix_nic.h"
+#include "gnix_vc.h"
+#include "gnix_ep.h"
+#include "gnix_mr.h"
+#include "gnix_cm_nic.h"
+#include "gnix_mbox_allocator.h"
+#include <gni_pub.h>
+
+static int __gnix_rma_fab_req_complete(void *arg)
+{
+	struct gnix_fab_req *req = (struct gnix_fab_req *)arg;
+	struct gnix_fid_ep *ep = req->gnix_ep;
+	int rc;
+
+	/* more transaction needed for request? */
+
+	/* write completions */
+	if (ep->send_cq && (!ep->send_selective_completion ||
+			    (req->flags & FI_COMPLETION))) {
+		rc = _gnix_cq_add_event(ep->send_cq, req->user_context,
+					req->flags, req->len,
+					(void *)req->loc_addr,
+					req->data, req->tag);
+		if (rc) {
+			GNIX_WARN(FI_LOG_CQ,
+				  "_gnix_cq_add_event() failed: %d\n", rc);
+		}
+	}
+
+	_fr_free(ep, req);
+
+	return FI_SUCCESS;
+}
+
+static int __gnix_rma_txd_complete(void *arg)
+{
+	struct gnix_tx_descriptor *txd = (struct gnix_tx_descriptor *)arg;
+
+	/* Progress fabric operation in the fab_req completer.  Can we call
+	 * fab_req->completer_func directly from __gnix_tx_progress? */
+	return txd->desc.req->completer_func(txd->desc.req->completer_data);
+}
+
+static gni_post_type_t __gnix_fr_post_type(int fr_type)
+{
+	switch (fr_type) {
+	case GNIX_FAB_RQ_RDMA_WRITE:
+	case GNIX_FAB_RQ_RDMA_WRITE_IMM_DATA:
+		return GNI_POST_RDMA_PUT;
+	case GNIX_FAB_RQ_RDMA_READ:
+		return GNI_POST_RDMA_GET;
+	default:
+		break;
+	}
+
+	GNIX_WARN(FI_LOG_EP_DATA, "Unsupported post type: %d", fr_type);
+	return -FI_ENOSYS;
+}
+
+static int __gnix_post_req(struct gnix_fab_req *fab_req)
+{
+	struct gnix_fid_ep *ep = fab_req->gnix_ep;
+	struct gnix_nic *nic = ep->nic;
+	struct gnix_fid_mem_desc *md;
+	struct gnix_tx_descriptor *txd;
+	gni_mem_handle_t mdh;
+	gni_return_t status;
+	int rc;
+
+	fastlock_acquire(&nic->lock);
+
+	rc = _gnix_nic_tx_alloc(nic, &txd);
+	if (rc) {
+		GNIX_INFO(FI_LOG_EP_DATA, "_gnix_nic_tx_alloc() failed: %d\n", rc);
+		fastlock_release(&nic->lock);
+		return -FI_ENOSPC;
+	}
+
+	txd->desc.completer_func = __gnix_rma_txd_complete;
+	txd->desc.req = fab_req;
+
+	_gnix_convert_key_to_mhdl((gnix_mr_key_t *)&fab_req->rem_mr_key, &mdh);
+	md = (struct gnix_fid_mem_desc *)fab_req->loc_md;
+
+	//txd->desc.gni_desc.post_id = (uint64_t)fab_req; /* unused */
+	txd->desc.gni_desc.type = __gnix_fr_post_type(fab_req->type);
+	txd->desc.gni_desc.cq_mode = GNI_CQMODE_GLOBAL_EVENT; /* check flags */
+	txd->desc.gni_desc.dlvr_mode = GNI_DLVMODE_PERFORMANCE; /* check flags */
+	txd->desc.gni_desc.local_addr = (uint64_t)fab_req->loc_addr;
+	txd->desc.gni_desc.local_mem_hndl = md->mem_hndl;
+	txd->desc.gni_desc.remote_addr = (uint64_t)fab_req->rem_addr;
+	txd->desc.gni_desc.remote_mem_hndl = mdh;
+	txd->desc.gni_desc.length = fab_req->len;
+	txd->desc.gni_desc.rdma_mode = 0; /* check flags */
+	txd->desc.gni_desc.src_cq_hndl = nic->tx_cq; /* check flags */
+
+	{
+		gni_mem_handle_t *tl_mdh = &txd->desc.gni_desc.local_mem_hndl;
+		gni_mem_handle_t *tr_mdh = &txd->desc.gni_desc.remote_mem_hndl;
+		GNIX_INFO(FI_LOG_EP_DATA, "la: %llx ra: %llx len: %d\n",
+			  txd->desc.gni_desc.local_addr, txd->desc.gni_desc.remote_addr,
+			  txd->desc.gni_desc.length);
+		GNIX_INFO(FI_LOG_EP_DATA, "lmdh: %llx:%llx rmdh: %llx:%llx key: %llx\n",
+			  *(uint64_t *)tl_mdh, *(((uint64_t *)tl_mdh) + 1),
+			  *(uint64_t *)tr_mdh, *(((uint64_t *)tr_mdh) + 1),
+			  fab_req->rem_mr_key);
+	}
+
+	status = GNI_PostRdma(fab_req->vc->gni_ep, &txd->desc.gni_desc);
+	if (status != GNI_RC_SUCCESS) {
+		GNIX_INFO(FI_LOG_EP_DATA, "GNI_PostRdma() failed: %d\n", status);
+	}
+
+	fastlock_release(&nic->lock);
+
+	return gnixu_to_fi_errno(status);
+}
+
+ssize_t _gnix_rma(struct gnix_vc *vc, enum gnix_fab_req_type fr_type,
+		  uint64_t loc_addr, size_t len,
+		  void *mdesc, uint64_t rem_addr, uint64_t mkey,
+		  void *context, uint64_t flags, uint64_t data)
+{
+	struct gnix_fid_ep *ep = vc->ep;
+	struct gnix_fab_req *req;
+	struct gnix_fid_mem_desc *md;
+	int rc;
+
+	/* I need a connected VC and valid local memory descriptor */
+	if (!vc || !mdesc) {
+		return -FI_EINVAL;
+	}
+
+	/* setup fabric request */
+	req = _fr_alloc(ep);
+	if (!req) {
+		GNIX_INFO(FI_LOG_EP_DATA, "_fr_alloc() failed\n");
+		return -FI_ENOSPC;
+	}
+
+	req->type = fr_type;
+	req->gnix_ep = ep;
+	req->vc = vc;
+	req->completer_func = __gnix_rma_fab_req_complete;
+	req->completer_data = req;
+	req->user_context = context;
+
+	md = container_of(mdesc, struct gnix_fid_mem_desc, mr_fid);
+	req->loc_addr = loc_addr;
+	req->loc_md = (void *)md;
+	req->rem_addr = rem_addr;
+	req->rem_mr_key = mkey;
+	req->len = len;
+	req->flags = flags;
+
+	/* try post */
+	rc = __gnix_post_req(req);
+	if (rc) {
+		/* queue request */
+		return rc;
+	}
+
+	return FI_SUCCESS;
+}
+
+ssize_t _gnix_write(struct gnix_vc *vc, uint64_t loc_addr, size_t len,
+		    void *mdesc, uint64_t rem_addr, uint64_t mkey,
+		    void *context, uint64_t flags, uint64_t data)
+{
+	return _gnix_rma(vc, GNIX_FAB_RQ_RDMA_WRITE, loc_addr, len, mdesc,
+			 rem_addr, mkey, context, flags, data);
+}
+
+ssize_t _gnix_write_imm(struct gnix_vc *vc, uint64_t loc_addr, size_t len,
+		        void *mdesc, uint64_t rem_addr, uint64_t mkey,
+		        void *context, uint64_t flags, uint64_t data)
+{
+	return _gnix_rma(vc, GNIX_FAB_RQ_RDMA_WRITE_IMM_DATA, loc_addr, len,
+			 mdesc, rem_addr, mkey, context, flags, data);
+}
+
+ssize_t _gnix_read(struct gnix_vc *vc, uint64_t loc_addr, size_t len,
+		   void *mdesc, uint64_t rem_addr, uint64_t mkey,
+		   void *context, uint64_t flags, uint64_t data)
+{
+	return _gnix_rma(vc, GNIX_FAB_RQ_RDMA_READ, loc_addr, len, mdesc,
+			 rem_addr, mkey, context, flags, data);
+}
+
+#if 0
+gnix_vc *_gnix_ep_vc_lookup(gnix_fid_ep *ep_priv, fi_addr addr)
+{
+	
+}
+
+static ssize_t gnix_ep_rma_write(struct fid_ep *ep, const void *buf,
+				 size_t len, void *desc, fi_addr_t dest_addr,
+				 uint64_t addr, uint64_t key, void *context)
+{
+	gnix_vc *vc;
+
+	/* find VC for target, connect if necessary */
+	vc = _gnix_ep_vc_lookup(ep_priv, dest_addr);
+	if (!vc) {
+		return -FI_EINVAL;
+	}
+
+	return _gnix_write(vc, buf, len, desc, addr, key, context, 0, 0);
+}
+#endif
+

--- a/prov/gni/test/rdm_rw.c
+++ b/prov/gni/test/rdm_rw.c
@@ -1,0 +1,324 @@
+/*
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <getopt.h>
+#include <poll.h>
+#include <time.h>
+#include <string.h>
+#include <pthread.h>
+
+#include <rdma/fabric.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_errno.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_cm.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <inttypes.h>
+
+#include "gnix_vc.h"
+#include "gnix_cm_nic.h"
+#include "gnix_hashtable.h"
+#include "gnix_rma.h"
+
+#include <criterion/criterion.h>
+
+#define dbg_printf(...)
+
+static struct fid_fabric *fab;
+static struct fid_domain *dom;
+static struct fid_ep *ep[2];
+static struct fid_av *av;
+static struct fi_info *hints;
+static struct fi_info *fi;
+void *ep_name[2];
+size_t gni_addr[2];
+static struct fid_cq *send_cq;
+static struct fi_cq_attr cq_attr;
+
+void rdm_rma_setup(void)
+{
+	int ret = 0;
+	struct fi_av_attr attr;
+	size_t addrlen = 0;
+
+	hints = fi_allocinfo();
+	cr_assert(hints, "fi_allocinfo");
+
+	hints->domain_attr->cq_data_size = 4;
+	hints->mode = ~0;
+
+	hints->fabric_attr->name = strdup("gni");
+
+	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
+	cr_assert(!ret, "fi_getinfo");
+
+	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	cr_assert(!ret, "fi_fabric");
+
+	ret = fi_domain(fab, fi, &dom, NULL);
+	cr_assert(!ret, "fi_domain");
+
+	attr.type = FI_AV_MAP;
+	attr.count = 16;
+
+	ret = fi_av_open(dom, &attr, &av, NULL);
+	cr_assert(!ret, "fi_av_open");
+
+	ret = fi_endpoint(dom, fi, &ep[0], NULL);
+	cr_assert(!ret, "fi_endpoint");
+
+	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
+	cq_attr.size = 1024;
+	cq_attr.wait_obj = 0;
+
+	ret = fi_cq_open(dom, &cq_attr, &send_cq, 0);
+	cr_assert(!ret, "fi_cq_open");
+
+	ret = fi_ep_bind(ep[0], &send_cq->fid, FI_TRANSMIT);
+	cr_assert(!ret, "fi_ep_bind");
+
+	ret = fi_getname(&ep[0]->fid, NULL, &addrlen);
+	cr_assert(addrlen > 0);
+
+	ep_name[0] = malloc(addrlen);
+	cr_assert(ep_name[0] != NULL);
+
+	ep_name[1] = malloc(addrlen);
+	cr_assert(ep_name[1] != NULL);
+
+	ret = fi_getname(&ep[0]->fid, ep_name[0], &addrlen);
+	cr_assert(ret == FI_SUCCESS);
+
+	ret = fi_endpoint(dom, fi, &ep[1], NULL);
+	cr_assert(!ret, "fi_endpoint");
+
+	ret = fi_getname(&ep[1]->fid, ep_name[1], &addrlen);
+	cr_assert(ret == FI_SUCCESS);
+
+	ret = fi_av_insert(av, ep_name[0], 1, &gni_addr[0], 0,
+				NULL);
+	cr_assert(ret == 1);
+
+	ret = fi_av_insert(av, ep_name[1], 1, &gni_addr[1], 0,
+				NULL);
+	cr_assert(ret == 1);
+
+	ret = fi_ep_bind(ep[0], &av->fid, 0);
+	cr_assert(!ret, "fi_ep_bind");
+
+	ret = fi_ep_bind(ep[1], &av->fid, 0);
+	cr_assert(!ret, "fi_ep_bind");
+}
+
+void rdm_rma_teardown(void)
+{
+	int ret = 0;
+
+	ret = fi_close(&ep[0]->fid);
+	cr_assert(!ret, "failure in closing ep.");
+
+	ret = fi_close(&ep[1]->fid);
+	cr_assert(!ret, "failure in closing ep.");
+
+	ret = fi_close(&send_cq->fid);
+	cr_assert(!ret, "failure in send cq.");
+
+	ret = fi_close(&av->fid);
+	cr_assert(!ret, "failure in closing av.");
+
+	ret = fi_close(&dom->fid);
+	cr_assert(!ret, "failure in closing domain.");
+
+	ret = fi_close(&fab->fid);
+	cr_assert(!ret, "failure in closing fabric.");
+
+	fi_freeinfo(fi);
+	fi_freeinfo(hints);
+	free(ep_name[0]);
+	free(ep_name[1]);
+}
+
+/*******************************************************************************
+ * Test vc functions.
+ ******************************************************************************/
+
+TestSuite(rdm_rma, .init = rdm_rma_setup, .fini = rdm_rma_teardown,
+	  .disabled = false);
+
+#define BUF_SZ 4096
+Test(rdm_rma, rw)
+{
+	int ret, l;
+	struct gnix_vc *vc_conn, *vc_listen;
+	struct gnix_fid_ep *ep_priv[2];
+	struct gnix_cm_nic *cm_nic[2];
+	gnix_ht_key_t key;
+	enum gnix_vc_conn_state state;
+	struct fid_mr *rem_mr, *loc_mr;
+	uint64_t mr_key;
+	uint64_t stack_target[BUF_SZ];
+	uint64_t stack_source[BUF_SZ];
+	ssize_t sz;
+	struct fi_cq_entry cqe;
+
+	ep_priv[0] = container_of(ep[0], struct gnix_fid_ep, ep_fid);
+	cm_nic[0] = ep_priv[0]->cm_nic;
+
+	ep_priv[1] = container_of(ep[1], struct gnix_fid_ep, ep_fid);
+	cm_nic[1] = ep_priv[1]->cm_nic;
+
+	ret = _gnix_vc_alloc(ep_priv[0], gni_addr[1], &vc_conn);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	memcpy(&key, &gni_addr[1],
+		sizeof(gnix_ht_key_t));
+
+	ret = _gnix_ht_insert(ep_priv[0]->vc_ht, key, vc_conn);
+	cr_assert_eq(ret, FI_SUCCESS);
+	vc_conn->modes |= GNIX_VC_MODE_IN_HT;
+
+	ret = _gnix_vc_alloc(ep_priv[1], FI_ADDR_UNSPEC, &vc_listen);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	ret = _gnix_vc_accept(vc_listen);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	/*
+	 * this is the moral equivalent of fi_enable(ep[0]),
+	 * but we don't want to do that in our prologue since
+	 * the fi_enable would consume all of the available wc datagrams.
+	 */
+	dlist_insert_tail(&vc_listen->entry, &ep_priv[1]->wc_vc_list);
+
+	ret = _gnix_vc_connect(vc_conn);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	/*
+	 * progress the cm_nic
+	 */
+
+	state = GNIX_VC_CONN_NONE;
+	while (state != GNIX_VC_CONNECTED) {
+		ret = _gnix_cm_nic_progress(cm_nic[0]);
+		cr_assert_eq(ret, FI_SUCCESS);
+		pthread_yield();
+		state = _gnix_vc_state(vc_conn);
+	}
+
+	state = GNIX_VC_CONN_NONE;
+	while (state != GNIX_VC_CONNECTED) {
+		ret = _gnix_cm_nic_progress(cm_nic[1]);
+		cr_assert_eq(ret, FI_SUCCESS);
+		pthread_yield();
+		state = _gnix_vc_state(vc_listen);
+	}
+
+	ret = fi_mr_reg(dom, &stack_target, sizeof(stack_target),
+			FI_REMOTE_WRITE, 0, 0, 0, &rem_mr, &stack_target);
+	cr_assert_eq(ret, 0);
+
+	ret = fi_mr_reg(dom, &stack_source, sizeof(stack_source),
+			FI_REMOTE_WRITE, 0, 0, 0, &loc_mr, &stack_source);
+	cr_assert_eq(ret, 0);
+
+	mr_key = fi_mr_key(rem_mr);
+
+	stack_source[BUF_SZ-1] = 0xdeadbeef;
+	stack_target[BUF_SZ-1] = 0;
+	sz = _gnix_write(vc_conn, (uint64_t)&stack_source, sizeof(stack_target),
+			 loc_mr, (uint64_t)&stack_target, mr_key,
+			 &stack_target, 0, 0);
+	cr_assert_eq(sz, 0);
+
+	while ((ret = fi_cq_read(send_cq, &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	cr_assert_eq((uint64_t)cqe.op_context, (uint64_t)&stack_target);
+
+	dbg_printf("got write context event!\n");
+
+	l = 0;
+	while(stack_target[BUF_SZ-1] != stack_source[BUF_SZ-1]) {
+		pthread_yield();
+		l++;
+	}
+
+	dbg_printf("got write data in %d loops!\n", l);
+
+#define READ_CTX 0x4e3dda1aULL
+	stack_source[BUF_SZ-1] = 0;
+	stack_target[BUF_SZ-1] = 0xbeefdead;
+	sz = _gnix_read(vc_conn, (uint64_t)&stack_source, sizeof(stack_target),
+			loc_mr, (uint64_t)&stack_target, mr_key,
+			(void *)READ_CTX, 0, 0);
+	cr_assert_eq(sz, 0);
+
+	while ((ret = fi_cq_read(send_cq, &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	cr_assert_eq((uint64_t)cqe.op_context, READ_CTX);
+
+	dbg_printf("got read context event!\n");
+
+	l = 0;
+	while(stack_target[BUF_SZ-1] != stack_source[BUF_SZ-1]) {
+		pthread_yield();
+		l++;
+	}
+
+	dbg_printf("got read data in %d loops!\n", l);
+
+	fi_close(&loc_mr->fid);
+	fi_close(&rem_mr->fid);
+
+	ret = _gnix_vc_disconnect(vc_conn);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	ret = _gnix_vc_destroy(vc_conn);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	ret = _gnix_vc_disconnect(vc_listen);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	ret = _gnix_vc_destroy(vc_listen);
+	cr_assert_eq(ret, FI_SUCCESS);
+}


### PR DESCRIPTION
```
Implement internal RMA interface.

1. Implement NIC TX list alloc/free.  Make TX list use dlist_entry.
2. Implement CQ NIC poll list.
3. Progress NICs used by a CQ during fi_cq_read()
4. Add internal RMA interface.
  -allocate fab_req, txd
  -issue GNI RDMA op
  -write libfabric CQ events after GNI TX completion
```

@jswaro @sungeunchoi @hppritcha
