### PR TITLE
Limit EPs per domain using GNI resources.  Convert nic lists to use

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -223,7 +223,7 @@ struct gnix_fid_domain {
 	/* used for fabric object llist of domains*/
 	struct list_node list;
 	/* list nics this domain is attached to, TODO: thread safety */
-	struct list_head nic_list;
+	struct dlist_entry nic_list;
 	struct gnix_fid_fabric *fabric;
 	uint8_t ptag;
 	uint32_t cookie;
@@ -242,6 +242,8 @@ struct gnix_fid_domain {
 	atomic_t ref_cnt;
 	gnix_mr_cache_t mr_cache;
 };
+
+#define GNIX_CQS_PER_EP		8
 
 /*
  *   gnix endpoint structure

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -48,6 +48,10 @@ extern "C" {
 #include <fi_list.h>
 #include <assert.h>
 
+#define GNIX_DEF_MAX_NICS_PER_PTAG	4
+
+extern uint32_t gnix_max_nics_per_ptag;
+
 /*
  * gnix nic struct - to be used for GNI_PostRdma/PostFma,
  *                   GNI_SmsgSend, GNI_CqGetEvent, etc.
@@ -76,8 +80,8 @@ extern "C" {
  */
 
 struct gnix_nic {
-	struct list_node list;          /* global NIC list */
-	struct list_node gnix_nic_list; /* domain list */
+	struct dlist_entry list;          /* global NIC list */
+	struct dlist_entry gnix_nic_list; /* domain list */
 	fastlock_t lock;
 	gni_cdm_handle_t gni_cdm_hndl;
 	gni_nic_handle_t gni_nic_hndl;

--- a/prov/gni/include/gnix_util.h
+++ b/prov/gni/include/gnix_util.h
@@ -68,6 +68,8 @@ static inline void dlist_remove_init(struct dlist_entry *e)
 	e->prev = e->next = e;
 }
 
+#define DLIST_HEAD(dlist)  struct dlist_entry dlist = { &(dlist), &(dlist) }
+
 #define dlist_entry(e, type, member) container_of(e, type, member)
 
 #define dlist_first_entry(h, type, member)				\
@@ -109,6 +111,7 @@ int _gnix_job_disable_affinity_apply(void);
 
 void _gnix_alps_cleanup(void);
 int _gnix_job_fma_limit(uint32_t dev_id, uint8_t ptag, uint32_t *limit);
+int _gnix_job_cq_limit(uint32_t dev_id, uint8_t ptag, uint32_t *limit);
 int _gnix_pes_on_node(uint32_t *num_pes);
 int _gnix_nics_per_rank(uint32_t *nics_per_rank);
 

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -108,15 +108,13 @@ static int gnix_domain_close(fid_t fid)
 	 *  drops to 0, destroy the cdm, remove from
 	 *  the global nic list.
 	 */
-	list_for_each_safe(&domain->nic_list, p, next, list)
+	dlist_for_each_safe(&domain->nic_list, p, next, list)
 	{
-		list_del(&p->list);
-		gnix_list_node_init(&p->list);
+		dlist_remove(&p->list);
 		v = atomic_dec(&p->ref_cnt);
 		assert(v >= 0);
 		if (v == 0) {
-			list_del(&p->gnix_nic_list);
-			gnix_list_node_init(&p->gnix_nic_list);
+			dlist_remove(&p->gnix_nic_list);
 			status = GNI_CdmDestroy(p->gni_cdm_hndl);
 			if (status != GNI_RC_SUCCESS)
 				GNIX_ERR(FI_LOG_DOMAIN,
@@ -221,7 +219,7 @@ int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	if (ret != FI_SUCCESS)
 		goto err;
 
-	list_head_init(&domain->nic_list);
+	dlist_init(&domain->nic_list);
 	gnix_list_node_init(&domain->list);
 
 	list_add_tail(&fabric_priv->domain_list, &domain->list);

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -407,6 +407,7 @@ GNI_INI
 	gni_return_t status;
 	gni_version_info_t lib_version;
 	int num_devices;
+	int rc;
 
 	/*
 	 * if no GNI devices available, don't register as provider
@@ -428,6 +429,14 @@ GNI_INI
 	    ((GNI_GET_MAJOR(lib_version.ugni_version) == GNI_MAJOR_REV) &&
 	     GNI_GET_MINOR(lib_version.ugni_version) >= GNI_MINOR_REV)) {
 		provider = &gnix_prov;
+	}
+
+	rc = _gnix_nics_per_rank(&gnix_max_nics_per_ptag);
+	if (rc == FI_SUCCESS) {
+		GNIX_INFO(FI_LOG_FABRIC, "gnix_max_nics_per_ptag: %u\n",
+			  gnix_max_nics_per_ptag);
+	} else {
+		GNIX_INFO(FI_LOG_FABRIC, "_gnix_nics_per_rank failed: %d\n", rc);
 	}
 
 	return (provider);

--- a/prov/gni/src/gnix_mr.c
+++ b/prov/gni/src/gnix_mr.c
@@ -362,7 +362,7 @@ int gnix_mr_reg(struct fid *fid, const void *buf, size_t len,
 		fi_gnix_access |= GNI_MEM_READ_ONLY;
 
 	/* If the nic list is empty, create a nic */
-	if (unlikely(list_empty(&domain->nic_list))) {
+	if (unlikely(dlist_empty(&domain->nic_list))) {
 		rc = gnix_nic_alloc(domain, &nic);
 		if (rc) {
 			GNIX_WARN(FI_LOG_MR, "could not allocate nic to do mr_reg,"
@@ -724,7 +724,7 @@ static int __mr_cache_register(
 		return -FI_ENOMEM;
 
 	/* TODO: should we just try the first nic we find? */
-	list_for_each(&domain->nic_list, nic, list)
+	dlist_for_each(&domain->nic_list, nic, list)
 	{
 		grc = GNI_MemRegister(nic->gni_nic_hndl, address, length,
 					dst_cq_hndl, flags,

--- a/prov/gni/test/utils.c
+++ b/prov/gni/test/utils.c
@@ -81,7 +81,7 @@ Test(utils, alps)
 {
 	int rc;
 	uint8_t ptag;
-	uint32_t cookie, fmas, npes, npr;
+	uint32_t cookie, fmas, cqs, npes, npr;
 	void *addr = NULL;
 
 	_gnix_alps_cleanup();
@@ -92,13 +92,16 @@ Test(utils, alps)
 	rc = _gnix_job_fma_limit(0, ptag, &fmas);
 	cr_expect(!rc);
 
+	rc = _gnix_job_cq_limit(0, ptag, &cqs);
+	cr_expect(!rc);
+
 	rc = _gnix_pes_on_node(&npes);
 	cr_expect(!rc);
 
 	rc = _gnix_nics_per_rank(&npr);
 	cr_expect(!rc);
 
-	cr_expect((fmas / npes) == npr);
+	cr_expect(((fmas > cqs ? cqs : fmas) / npes) == npr);
 
 	_gnix_alps_cleanup();
 }


### PR DESCRIPTION
Limit EPs per domain using GNI resources.  Convert nic lists to use struct dlist_entry.

Fixes ofi-cray/libfabric-cray#215.

Signed-off-by: Zach Tiffany ztiffany@cray.com
