### PR TITLE
Convert from pthread_rwlock_t to rwlock_t

### DIFF
--- a/prov/gni/include/gnix_hashtable.h
+++ b/prov/gni/include/gnix_hashtable.h
@@ -39,6 +39,8 @@
 #include <fi.h>
 #include <fi_list.h>
 
+#include "gnix_util.h"
+
 typedef uint64_t gnix_ht_key_t;
 
 typedef enum gnix_ht_state {
@@ -54,7 +56,7 @@ typedef struct gnix_ht_entry {
 } gnix_ht_entry_t;
 
 typedef struct gnix_ht_lk_lh {
-	pthread_rwlock_t lh_lock;
+	rwlock_t lh_lock;
 	struct dlist_entry head;
 } gnix_ht_lk_lh_t;
 


### PR DESCRIPTION
To prevent future conflicts, switch to rwlock_t so that the lock type
can be determined at compile time

Signed-off-by: James Swaro jswaro@cray.com

```
modified:   prov/gni/include/gnix_hashtable.h
modified:   prov/gni/src/gnix_hashtable.c
```

@closes #207
