### PR TITLE
prov/gni: minor fixes for send/recv

### DIFF
--- a/prov/gni/src/gnix_ep_rcv.c
+++ b/prov/gni/src/gnix_ep_rcv.c
@@ -64,8 +64,6 @@ int _gnix_ep_eager_msg_w_data_match(struct gnix_fid_ep *ep, void *msg,
 	uint64_t flags;
 	struct gnix_address *addr_ptr;
 
-	GNIX_TRACE(FI_LOG_EP_DATA, "\n");
-
 	flags = (sflags & FI_REMOTE_CQ_DATA) ? FI_REMOTE_CQ_DATA : 0;
 
 	/*

--- a/prov/gni/src/gnix_ep_send.c
+++ b/prov/gni/src/gnix_ep_send.c
@@ -60,6 +60,10 @@ int _gnix_ep_get_vc(struct gnix_fid_ep *ep, fi_addr_t dest_addr,
 
 	av = ep->av;
 	assert(av != NULL);
+
+	if (av->type == FI_AV_TABLE)
+		return -FI_ENOSYS;
+
 	if (av->type == FI_AV_MAP) {
 		memcpy(&key, &dest_addr, sizeof(gnix_ht_key_t));
 		vc = (struct gnix_vc *)_gnix_ht_lookup(ep->vc_ht,
@@ -70,7 +74,7 @@ int _gnix_ep_get_vc(struct gnix_fid_ep *ep, fi_addr_t dest_addr,
 					    &vc);
 			if (ret != FI_SUCCESS) {
 				GNIX_WARN(FI_LOG_EP_DATA,
-					  "_gnix_ht_alloc returned %d\n",
+					  "_gnix_vc_alloc returned %d\n",
 					  ret);
 				goto err;
 			}
@@ -85,7 +89,7 @@ int _gnix_ep_get_vc(struct gnix_fid_ep *ep, fi_addr_t dest_addr,
 				ret = _gnix_vc_connect(vc);
 				if (ret != FI_SUCCESS) {
 					GNIX_WARN(FI_LOG_EP_DATA,
-						"_gnix_ht_connect returned %d\n",
+						"_gnix_vc_connect returned %d\n",
 						   ret);
 					goto err;
 				}
@@ -115,13 +119,13 @@ int _gnix_ep_get_vc(struct gnix_fid_ep *ep, fi_addr_t dest_addr,
 				ret = _gnix_vc_connect(vc);
 				if (ret != FI_SUCCESS) {
 					GNIX_WARN(FI_LOG_EP_DATA,
-						  "_gnix_ht_connect returned %d\n",
+						  "_gnix_vc_connect returned %d\n",
 						   ret);
 					goto err;
 				}
 			} else {
 				GNIX_WARN(FI_LOG_EP_DATA,
-					  "_gnix_ht_alloc returned %d\n",
+					  "_gnix_vc_alloc returned %d\n",
 					   ret);
 				goto err;
 			}


### PR DESCRIPTION
return -FI_ENOSYS for looking up vc if av type is
table.  Not supported yet.

Fix an incorrect warning string.

Turn off tracing for matching function - too noisy.

@ztiffany 

Signed-off-by: Howard Pritchard howardp@lanl.gov
