### PR TITLE
prov/gni: fix assert test in _gnix_sfl_init

### DIFF
--- a/prov/gni/src/gnix_freelist.c
+++ b/prov/gni/src/gnix_freelist.c
@@ -93,7 +93,7 @@ int _gnix_sfl_init(int elem_size, int offset, int init_size,
 		   int max_refill_size, struct gnix_s_freelist *fl)
 {
 	assert(elem_size > 0);
-	assert(offset > 0);
+	assert(offset >= 0);
 	assert(init_size >= 0);
 	assert(refill_size >= 0);
 	assert(growth_factor >= 0);


### PR DESCRIPTION
The offset assert in _gnix_sfl_init was not
exactly correct.  A 0 offset value should be
allowed.

@ztiffany 
@jswaro 

I was seeing false asserts in the freelist.c criterion
test when building on the nersc/edison system. 
This commit fixes that problem.

Signed-off-by: Howard Pritchard howardp@lanl.gov
