### PR TITLE
prov/gni: initial rdma buffer work

### DIFF
--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -109,6 +109,8 @@ typedef int (*smsg_completer_fn_t)(void  *desc);
  * @var mem_per_mbox         number of bytes consumed per GNI SMSG mailbox associated
  *                           with this nic's vd_id_table
  * @var mbox_hndl            handle for the mailbox allocator bound to this nic
+ * @var s_rdma_buf_hndl      handle for send side rdma buffer allocator bound to this nic
+ * @var r_rdma_buf_hndl      handle for recv side rdma buffer allocator bound to this nic
  * @var ref_cnt              ref cnt for this nid
  * @var smsg_callbacks       pointer to table of GNI SMSG callback functions used
  *                           by this nic for processing incoming GNI SMS
@@ -142,6 +144,8 @@ struct gnix_nic {
 	gnix_bitmap_t vc_id_bitmap;
 	uint32_t mem_per_mbox;
 	struct gnix_mbox_alloc_handle *mbox_hndl;
+	struct gnix_mbox_alloc_handle *s_rdma_buf_hndl;
+	struct gnix_mbox_alloc_handle *r_rdma_buf_hndl;
 	atomic_t ref_cnt;
 	smsg_callback_fn_t const *smsg_callbacks;
 };

--- a/prov/gni/test/allocator.c
+++ b/prov/gni/test/allocator.c
@@ -159,12 +159,12 @@ static void open_close_allocator(enum gnix_page_size page_size,
 	ret = _gnix_mbox_allocator_create(ep_priv->nic, NULL, page_size,
 					  mbox_size, mpmmap, &allocator);
 	cr_assert_eq(ret, FI_SUCCESS, "_gnix_mbox_allocator_create failed.");
-	cr_expect_eq(verify_hugepages(), 2,
+	cr_expect_eq(verify_hugepages(), 4,
 		     "memory not found in /proc/self/maps.");
 
 	ret = _gnix_mbox_allocator_destroy(allocator);
 	cr_assert_eq(ret, FI_SUCCESS, "_gnix_mbox_allocator_destroy failed.");
-	cr_expect_eq(verify_hugepages(), 1,
+	cr_expect_eq(verify_hugepages(), 3,
 		     "memory not released in /proc/self/maps.");
 }
 
@@ -210,10 +210,10 @@ Test(mbox_creation, alloc_mbox)
 	cr_assert_eq(ret, FI_SUCCESS, "_gnix_mbox_allocator_create failed.");
 
 	/*
-	 *value is 2 because the provider has internally already opened
-	 * an mbox allocator at this point.
+	 *value is 4 because the provider has internally already opened
+	 * an mbox allocator and 2 rdma slabs at this point.
 	 */
-	cr_expect_eq(verify_hugepages(), 2,
+	cr_expect_eq(verify_hugepages(), 4,
 		  "memory not found in /proc/self/maps.");
 
 	ret = _gnix_mbox_alloc(allocator, &mail_box);
@@ -256,7 +256,7 @@ Test(mbox_creation, alloc_mbox)
 	ret = _gnix_mbox_allocator_destroy(allocator);
 	cr_assert_eq(ret, FI_SUCCESS, "_gnix_mbox_allocator_destroy failed.");
 
-	cr_expect_eq(verify_hugepages(), 1,
+	cr_expect_eq(verify_hugepages(), 3,
 		     "memory not released in /proc/self/maps.");
 }
 
@@ -274,10 +274,10 @@ Test(mbox_creation, page_size_fail)
 		     "Creating allocator with bogus page size succeeded.");
 	cr_assert_eq(allocator, NULL);
 	/*
-	 *value is 1 because the provider has internally already opened
-	 * an mbox allocator at this point.
+	 *value is 3 because the provider has internally already opened
+	 * an mbox allocator and two other slabs at this point.
 	 */
-	cr_expect_eq(verify_hugepages(), 1,
+	cr_expect_eq(verify_hugepages(), 3,
 		     "Huge page open, but shouldn't be");
 
 	ret = _gnix_mbox_allocator_destroy(allocator);
@@ -298,7 +298,7 @@ Test(mbox_creation, mbox_size_fail)
 		     "Creating allocator with zero mbox size succeeded.");
 
 	cr_assert_eq(allocator, NULL);
-	cr_expect_eq(verify_hugepages(), 1,
+	cr_expect_eq(verify_hugepages(), 3,
 		     "Huge page open, but shouldn't be");
 
 	ret = _gnix_mbox_allocator_destroy(allocator);
@@ -318,7 +318,7 @@ Test(mbox_creation, mpmmap_size_fail)
 	cr_assert_eq(ret, -FI_EINVAL,
 		  "Creating allocator with zero mailboxes per mmap succeeded.");
 	cr_assert_eq(allocator, NULL);
-	cr_expect_eq(verify_hugepages(), 1,
+	cr_expect_eq(verify_hugepages(), 3,
 		     "Huge page open, but shouldn't be");
 
 	ret = _gnix_mbox_allocator_destroy(allocator);
@@ -337,7 +337,7 @@ Test(mbox_creation, null_allocator_fail)
 					  1000, 100, NULL);
 	cr_assert_eq(ret, -FI_EINVAL,
 		     "Creating allocator with null allocator succeeded.");
-	cr_expect_eq(verify_hugepages(), 1,
+	cr_expect_eq(verify_hugepages(), 3,
 		     "Huge page open, but shouldn't be");
 
 	ret = _gnix_mbox_allocator_destroy(allocator);
@@ -360,7 +360,7 @@ Test(mbox_creation, multi_allocation)
 	ret = _gnix_mbox_allocator_create(ep_priv->nic, NULL, GNIX_PAGE_4MB,
 					  mbox_size, array_size, &allocator);
 	cr_assert_eq(ret, FI_SUCCESS, "_gnix_mbox_allocator_create failed.");
-	cr_expect_eq(verify_hugepages(), 2,
+	cr_expect_eq(verify_hugepages(), 4,
 		     "memory not found in /proc/self/maps.");
 
 	/*
@@ -400,7 +400,7 @@ Test(mbox_creation, multi_allocation)
 	ret = _gnix_mbox_allocator_destroy(allocator);
 	cr_assert_eq(ret, FI_SUCCESS, "_gnix_mbox_allocator_destroy failed.");
 
-	cr_expect_eq(verify_hugepages(), 1,
+	cr_expect_eq(verify_hugepages(), 3,
 		     "memory not released in /proc/self/maps.");
 }
 
@@ -413,7 +413,7 @@ Test(mbox_creation, double_free)
 	ret = _gnix_mbox_allocator_create(ep_priv->nic, NULL, GNIX_PAGE_4MB,
 					  1000, 12000, &allocator);
 	cr_assert_eq(ret, FI_SUCCESS, "_gnix_mbox_allocator_create failed.");
-	cr_expect_eq(verify_hugepages(), 2,
+	cr_expect_eq(verify_hugepages(), 4,
 		     "memory not found in /proc/self/maps.");
 
 	ret = _gnix_mbox_alloc(allocator, &mail_box);
@@ -435,7 +435,7 @@ Test(mbox_creation, double_free)
 	ret = _gnix_mbox_allocator_destroy(allocator);
 	cr_assert_eq(ret, FI_SUCCESS, "_gnix_mbox_allocator_destroy failed.");
 
-	cr_expect_eq(verify_hugepages(), 1,
+	cr_expect_eq(verify_hugepages(), 3,
 		     "memory not released in /proc/self/maps.");
 }
 
@@ -458,7 +458,7 @@ Test(mbox_creation, two_slabs)
 	ret = _gnix_mbox_allocator_create(ep_priv->nic, NULL, GNIX_PAGE_4MB,
 					  mbox_size, mpmmap, &allocator);
 	cr_assert_eq(ret, FI_SUCCESS, "_gnix_mbox_allocator_create failed.");
-	cr_expect_eq(verify_hugepages(), 2,
+	cr_expect_eq(verify_hugepages(), 4,
 		     "memory not found in /proc/self/maps.");
 
 	/*
@@ -493,6 +493,6 @@ Test(mbox_creation, two_slabs)
 	ret = _gnix_mbox_allocator_destroy(allocator);
 	cr_assert_eq(ret, FI_SUCCESS, "_gnix_mbox_allocator_destroy failed.");
 
-	cr_expect_eq(verify_hugepages(), 1,
+	cr_expect_eq(verify_hugepages(), 3,
 		     "memory not released in /proc/self/maps.");
 }


### PR DESCRIPTION
Initial work for setup/teardown of rdma
buffer pools to be used for buffered send/recv
path.  This can be used for eager messages
too big to go through SMSG path, as well as
for rendezvous when zero-copy can't be used.

The allocator test had to be adjusted again to
account for additional large page allocator pools
are being created when a nic is instantiated.

@sungeunchoi 
@ztiffany 
@jswaro 

Fixes #256

Signed-off-by: Howard Pritchard howardp@lanl.gov
