### PR TITLE
prov/gni: set next field to NULL in slist element

### DIFF
--- a/include/fi_list.h
+++ b/include/fi_list.h
@@ -182,6 +182,7 @@ slist_remove_first_match(struct slist *list, slist_match_func_t *match, const vo
 			if (!item->next)
 				list->tail = prev;
 
+			item->next = NULL;
 			return item;
 		}
 	}

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -446,6 +446,13 @@ static inline void gnix_list_del_init(struct list_node *node)
 	node->prev = node->next = node;
 }
 
+static inline void gnix_slist_insert_tail(struct slist_entry *item,
+					  struct slist *list)
+{
+	item->next = NULL;
+	slist_insert_tail(item, list);
+}
+
 /*
  * prototypes for fi ops methods
  */

--- a/prov/gni/include/gnix_ep.h
+++ b/prov/gni/include/gnix_ep.h
@@ -182,6 +182,7 @@ _gnix_fr_alloc(struct gnix_fid_ep *ep)
 	if (ret == FI_SUCCESS) {
 		fr = container_of(se, struct gnix_fab_req, slist);
 		fr->gnix_ep = ep;
+		fr->slist.next = NULL;  /* slist stuff isn't too smart */
 	}
 
 	return fr;

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -401,7 +401,7 @@ static ssize_t gnix_ep_recv(struct fid_ep *ep, void *buf, size_t len,
 
 			_gnix_fr_free(ep_priv, req);
 		} else {
-			slist_insert_tail(&req->slist,
+			gnix_slist_insert_tail(&req->slist,
 					&ep_priv->pending_recv_comp_queue);
 			sched_req = 1;
 		}
@@ -419,8 +419,8 @@ static ssize_t gnix_ep_recv(struct fid_ep *ep, void *buf, size_t len,
 		req->loc_addr = (uint64_t)buf;
 		req->type = GNIX_FAB_RQ_RECV;
 		req->user_context = context;
-		slist_insert_tail(&req->slist,
-				  &ep_priv->posted_recv_queue);
+		gnix_slist_insert_tail(&req->slist,
+				       &ep_priv->posted_recv_queue);
 	}
 
 err:

--- a/prov/gni/src/gnix_ep_rcv.c
+++ b/prov/gni/src/gnix_ep_rcv.c
@@ -127,8 +127,8 @@ int _gnix_ep_eager_msg_w_data_match(struct gnix_fid_ep *ep, void *msg,
 			_gnix_fr_free(ep, req);
 
 		} else
-			slist_insert_tail(&req->slist,
-					&ep->pending_recv_comp_queue);
+			gnix_slist_insert_tail(&req->slist,
+					       &ep->pending_recv_comp_queue);
 
 	} else {
 
@@ -153,8 +153,8 @@ int _gnix_ep_eager_msg_w_data_match(struct gnix_fid_ep *ep, void *msg,
 		req->modes = GNIX_FAB_RQ_M_UNEXPECTED | GNIX_FAB_RQ_M_COMPLETE;
 		req->type = GNIX_FAB_RQ_RECV;
 
-		slist_insert_tail(&req->slist,
-				  &ep->unexp_recv_queue);
+		gnix_slist_insert_tail(&req->slist,
+					&ep->unexp_recv_queue);
 	}
 
 err:

--- a/prov/gni/src/gnix_mbox_allocator.c
+++ b/prov/gni/src/gnix_mbox_allocator.c
@@ -379,7 +379,7 @@ static int __create_slab(struct gnix_mbox_alloc_handle *handle)
 
 	slab->allocator = handle;
 
-	slist_insert_tail(&slab->list_entry, &handle->slab_list);
+	gnix_slist_insert_tail(&slab->list_entry, &handle->slab_list);
 
 	handle->last_offset += total_size;
 

--- a/prov/gni/src/gnix_queue.c
+++ b/prov/gni/src/gnix_queue.c
@@ -31,6 +31,7 @@
  */
 
 #include <stdlib.h>
+#include "gnix.h"
 #include "gnix_queue.h"
 
 int _gnix_queue_create(struct gnix_queue **queue, alloc_func alloc_item,
@@ -122,11 +123,11 @@ struct slist_entry *_gnix_queue_dequeue_free(struct gnix_queue *queue)
 
 void _gnix_queue_enqueue(struct gnix_queue *queue, struct slist_entry *item)
 {
-	slist_insert_tail(item, &queue->item_list);
+	gnix_slist_insert_tail(item, &queue->item_list);
 }
 
 void _gnix_queue_enqueue_free(struct gnix_queue *queue,
 			      struct slist_entry *item)
 {
-	slist_insert_tail(item, &queue->free_list);
+	gnix_slist_insert_tail(item, &queue->free_list);
 }

--- a/prov/gni/src/gnix_wait.c
+++ b/prov/gni/src/gnix_wait.c
@@ -72,7 +72,7 @@ int _gnix_wait_set_add(struct fid_wait *wait, struct fid *wait_obj)
 
 	wait_entry->wait_obj = wait_obj;
 
-	slist_insert_tail(&wait_entry->entry, &wait_priv->set);
+	gnix_slist_insert_tail(&wait_entry->entry, &wait_priv->set);
 
 	return FI_SUCCESS;
 }


### PR DESCRIPTION
Turns out the slist matching routine can get
easily messed up if next field in the element
being removed is invalid.  This can easily happen
if there's only a single element in the list,
or the match is made to the last element in the list.

@sungeunchoi 
@jswaro 
@ztiffany 

Signed-off-by: Howard Pritchard howardp@lanl.gov
