### PR TITLE
Fix MDH CRC generation

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -102,6 +102,10 @@ extern "C" {
 #define INOUT
 #endif
 
+#ifndef compiler_barrier
+#define compiler_barrier() asm volatile ("" ::: "memory")
+#endif
+
 /*
  * Cray gni provider supported flags for fi_getinfo argument for now, needs
  * refining (see fi_getinfo.3 man page)

--- a/prov/gni/src/gnix_mr.c
+++ b/prov/gni/src/gnix_mr.c
@@ -302,6 +302,7 @@ void _gnix_convert_key_to_mhdl(
 	GNI_MEMHNDL_SET_NPAGES((*mhdl), GNI_MEMHNDL_NPGS_MASK);
 	GNI_MEMHNDL_SET_FLAGS((*mhdl), flags);
 	GNI_MEMHNDL_SET_PAGESIZE((*mhdl), GNIX_MR_PAGE_SHIFT);
+	compiler_barrier();
 	GNI_MEMHNDL_SET_CRC((*mhdl));
 }
 


### PR DESCRIPTION
Some versions of GCC will reorder CRC calculation before all fields of the MDH
are set.  Add a compiler fence to prevent this.

Signed-off-by: Zach Tiffany ztiffany@cray.com

@hppritcha @jswaro @hppritcha
