### PR TITLE
Add threadsafety to memory registration cache for thread-hot support

### DIFF
--- a/prov/gni/include/gnix_mr.h
+++ b/prov/gni/include/gnix_mr.h
@@ -189,6 +189,7 @@ typedef struct gnix_mr_cache {
 	atomic_t inuse_elements;
 	atomic_t stale_elements;
 	struct dlist_entry lru_head;
+	fastlock_t lock;
 } gnix_mr_cache_t;
 
 /**


### PR DESCRIPTION
This commit adds coarse grained locks to each memory registration cache.
On a call to the cache functions, the cache lock is acquired and released
after the call. This provides a minimal level of threadsafety for now
until we can determine what level of granularity we will need

Signed-off-by: James Swaro jswaro@cray.com

@closes #263 

@sungeunchoi @hppritcha @ztiffany 

As a side note, the section to adding a nic, if one isn't present, is not covered under lock. Perhaps it should be? If they race, they end up creating nics that aren't unnecessary but that is the only danger I can see. 
