### PR TITLE
Minor EP send fixes

### DIFF
--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -569,6 +569,7 @@ static ssize_t gnix_ep_send(struct fid_ep *ep, const void *buf, size_t len,
 	req->len = len;
 	req->user_context = context;
 	req->vc = vc;
+	req->flags = ep_priv->op_flags;
 
 	return _gnix_vc_queue_tx_req(req);
 }

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -227,8 +227,6 @@ static int __comp_eager_msg_w_data(void *data)
 		ret = (int)cq_len; /* ugh */
 	}
 
-	ret = _gnix_nic_tx_free(ep->nic, tdesc);
-
 	return ret;
 
 }


### PR DESCRIPTION
Signed-off-by: Zach Tiffany ztiffany@cray.com

@hppritcha @sungeunchoi @jswaro 

__nic_tx_progress calls the TXD callback function and then frees the TXD.  A TXD callback function should not free the TXD itself.
