### PR TITLE
prov/gni: implement counter class

### DIFF
--- a/prov/gni/Makefile.am
+++ b/prov/gni/Makefile.am
@@ -18,6 +18,7 @@ _gni_files = \
 	prov/gni/src/gnix_queue.c \
 	prov/gni/src/gnix_ep.c \
 	prov/gni/src/gnix_ep_rcv.c \
+	prov/gni/src/gnix_cntr.c \
 	prov/gni/src/gnix_cq.c \
 	prov/gni/src/gnix_av.c \
 	prov/gni/src/gnix_eq.c \
@@ -57,7 +58,8 @@ prov_gni_test_gnitest_SOURCES = \
 	prov/gni/test/mr.c \
 	prov/gni/test/vc.c \
 	prov/gni/test/rdm_rma.c \
-	prov/gni/test/rdm_sr.c
+	prov/gni/test/rdm_sr.c \
+	prov/gni/test/cntr.c
 
 prov_gni_test_gnitest_LDFLAGS = -static
 prov_gni_test_gnitest_CPPFLAGS = $(AM_CPPFLAGS)

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -280,6 +280,10 @@ struct gnix_fid_ep {
 	uint64_t op_flags;
 	struct gnix_fid_cq *send_cq;
 	struct gnix_fid_cq *recv_cq;
+	struct gnix_fid_cntr *send_cntr;
+	struct gnix_fid_cntr *recv_cntr;
+	struct gnix_fid_cntr *read_cntr;
+	struct gnix_fid_cntr *write_cntr;
 	struct gnix_fid_av *av;
 	/* cm nic bound to this ep (FID_EP_RDM only) */
 	struct gnix_cm_nic *cm_nic;
@@ -470,6 +474,8 @@ int gnix_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 int gnix_mr_reg(struct fid *fid, const void *buf, size_t len,
 		uint64_t access, uint64_t offset, uint64_t requested_key,
 		uint64_t flags, struct fid_mr **mr_o, void *context);
+int gnix_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
+		 struct fid_cntr **cntr, void *context);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/prov/gni/include/gnix_cntr.h
+++ b/prov/gni/include/gnix_cntr.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _GNIX_CNTR_H_
+#define _GNIX_CNTR_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <fi.h>
+
+#include "gnix.h"
+#include "gnix_wait.h"
+
+/* many to many relationship between CQs and polled NICs */
+struct gnix_cntr_poll_nic {
+	struct dlist_entry list;
+	int ref_cnt;
+	struct gnix_nic *nic;
+};
+
+struct gnix_fid_cntr {
+	struct fid_cntr cntr_fid;
+	struct gnix_fid_domain *domain;
+	struct fid_wait *wait;
+	struct fi_cntr_attr attr;
+	rwlock_t nic_lock;
+	struct dlist_entry poll_nics;
+	atomic_t cnt;
+	atomic_t cnt_err;
+	atomic_t ref_cnt;
+};
+
+/**
+ * @brief              Increment event counter associated with a gnix_fid counter
+ *                     object
+ * @param[in] cntr     pointer to previously allocated gnix_fid_cntr structure
+ * @return             FI_SUCCESS on success, -FI_EINVAL on invalid argument
+ */
+int _gnix_cntr_inc(struct gnix_fid_cntr *cntr);
+
+/**
+ * @brief              Increment error event counter associated with a gnix_fid counter
+ *                     object
+ * @param[in] cntr     pointer to previously allocated gnix_fid_cntr structure
+ * @return             FI_SUCCESS on success, -FI_EINVAL on invalid argument
+ */
+int _gnix_cntr_inc_err(struct gnix_fid_cntr *cntr);
+
+/**
+ * @brief              Add a nic to the set of nics progressed when fi_cntr_read
+ *                     and related functions are called.
+ * @param[in] cntr     pointer to previously allocated gnix_fid_cntr structure
+ * @param[in] nic      pointer to previously allocated gnix_nic structure
+ * @return             FI_SUCCESS on success, -FI_EINVAL on invalid argument
+ */
+int _gnix_cntr_poll_nic_add(struct gnix_fid_cntr *cntr, struct gnix_nic *nic);
+
+/**
+ * @brief              remove a nic from the set of nics progressed when fi_cntr_read
+ *                     and related functions are called.
+ * @param[in] cntr     pointer to previously allocated gnix_fid_cntr structure
+ * @param[in] nic      pointer to previously allocated gnix_nic structure
+ * @return             FI_SUCCESS on success, -FI_EINVAL on invalid argument
+ */
+int _gnix_cntr_poll_nic_rem(struct gnix_fid_cntr *cntr, struct gnix_nic *nic);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/prov/gni/include/gnix_cntr.h
+++ b/prov/gni/include/gnix_cntr.h
@@ -42,7 +42,7 @@ extern "C" {
 #include "gnix.h"
 #include "gnix_wait.h"
 
-/* many to many relationship between CQs and polled NICs */
+/* many to many relationship between counters and polled NICs */
 struct gnix_cntr_poll_nic {
 	struct dlist_entry list;
 	int ref_cnt;

--- a/prov/gni/src/gnix_cntr.c
+++ b/prov/gni/src/gnix_cntr.c
@@ -1,0 +1,416 @@
+/*
+ * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * CNTR common code
+ */
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include "gnix.h"
+#include "gnix_cntr.h"
+#include "gnix_nic.h"
+
+/*******************************************************************************
+ * Forward declarations for filling functions.
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Forward declarations for ops structures.
+ ******************************************************************************/
+static struct fi_ops gnix_cntr_fi_ops;
+static struct fi_ops_cntr gnix_cntr_ops;
+
+/*******************************************************************************
+ * Internal helper functions
+ ******************************************************************************/
+
+static int __verify_cntr_attr(struct fi_cntr_attr *attr)
+{
+	int ret = FI_SUCCESS;
+
+	GNIX_TRACE(FI_LOG_CQ, "\n");
+
+	if (!attr)
+		return -FI_EINVAL;
+
+	if (attr->events != FI_CNTR_EVENTS_COMP) {
+		GNIX_WARN(FI_LOG_CQ, "cntr event type: %d unsupported.\n",
+			  attr->events);
+		return -FI_EINVAL;
+	}
+
+	/*
+	 * TODO: need to support wait objects on cntr
+	 */
+	switch (attr->wait_obj) {
+	case FI_WAIT_UNSPEC:
+	case FI_WAIT_NONE:
+		break;
+	case FI_WAIT_SET:
+	case FI_WAIT_FD:
+	case FI_WAIT_MUTEX_COND:
+	default:
+		GNIX_WARN(FI_LOG_CQ, "wait type: %d unsupported.\n",
+			  attr->wait_obj);
+		return -FI_EINVAL;
+		ret = -FI_ENOSYS;
+		break;
+	}
+
+	return ret;
+}
+
+static int __gnix_cntr_progress(struct gnix_fid_cntr *cntr)
+{
+	struct gnix_cq_poll_nic *pnic, *tmp;
+	int rc = FI_SUCCESS;
+
+	rwlock_rdlock(&cntr->nic_lock);
+
+	dlist_for_each_safe(&cntr->poll_nics, pnic, tmp, list) {
+		rc = _gnix_nic_progress(pnic->nic);
+		if (rc) {
+			GNIX_WARN(FI_LOG_CQ,
+				  "_gnix_nic_progress failed: %d\n", rc);
+		}
+	}
+
+	rwlock_unlock(&cntr->nic_lock);
+
+	return rc;
+}
+
+/*******************************************************************************
+ * Exposed helper functions
+ ******************************************************************************/
+
+int _gnix_cntr_inc(struct gnix_fid_cntr *cntr)
+{
+	if (cntr == NULL)
+		return -FI_EINVAL;
+
+	atomic_inc(&cntr->cnt);
+
+	if (cntr->wait)
+		_gnix_signal_wait_obj(cntr->wait);
+
+	return FI_SUCCESS;
+}
+
+int _gnix_cntr_inc_err(struct gnix_fid_cntr *cntr)
+{
+	if (cntr == NULL)
+		return -FI_EINVAL;
+
+	atomic_inc(&cntr->cnt_err);
+
+	if (cntr->wait)
+		_gnix_signal_wait_obj(cntr->wait);
+
+	return FI_SUCCESS;
+}
+
+int _gnix_cntr_poll_nic_add(struct gnix_fid_cntr *cntr, struct gnix_nic *nic)
+{
+	struct gnix_cntr_poll_nic *pnic, *tmp;
+
+	rwlock_wrlock(&cntr->nic_lock);
+
+	dlist_for_each_safe(&cntr->poll_nics, pnic, tmp, list) {
+		if (pnic->nic == nic) {
+			pnic->ref_cnt++;
+			rwlock_unlock(&cntr->nic_lock);
+			return FI_SUCCESS;
+		}
+	}
+
+	pnic = malloc(sizeof(struct gnix_cntr_poll_nic));
+	if (!pnic) {
+		GNIX_WARN(FI_LOG_CQ, "Failed to add NIC to CNTR poll list.\n");
+		rwlock_unlock(&cntr->nic_lock);
+		return -FI_ENOMEM;
+	}
+
+	/* EP holds a ref count on the NIC */
+	pnic->nic = nic;
+	pnic->ref_cnt = 1;
+	dlist_init(&pnic->list);
+	dlist_insert_tail(&pnic->list, &cntr->poll_nics);
+
+	rwlock_unlock(&cntr->nic_lock);
+
+	GNIX_INFO(FI_LOG_CQ, "Added NIC(%p) to CNTR(%p) poll list\n",
+		  nic, cntr);
+
+	return FI_SUCCESS;
+}
+
+int _gnix_cntr_poll_nic_rem(struct gnix_fid_cntr *cntr, struct gnix_nic *nic)
+{
+	struct gnix_cntr_poll_nic *pnic, *tmp;
+
+	rwlock_wrlock(&cntr->nic_lock);
+
+	dlist_for_each_safe(&cntr->poll_nics, pnic, tmp, list) {
+		if (pnic->nic == nic) {
+			if (!--pnic->ref_cnt) {
+				dlist_remove(&pnic->list);
+				free(pnic);
+				GNIX_INFO(FI_LOG_CQ,
+					  "Removed NIC(%p) from CNTR(%p) poll list\n",
+					  nic, cntr);
+			}
+			rwlock_unlock(&cntr->nic_lock);
+			return FI_SUCCESS;
+		}
+	}
+
+	rwlock_unlock(&cntr->nic_lock);
+
+	GNIX_WARN(FI_LOG_CQ, "NIC not found on CNTR poll list.\n");
+	return -FI_EINVAL;
+}
+
+/*******************************************************************************
+ * API functions.
+ ******************************************************************************/
+
+static int gnix_cntr_wait(struct fid_cntr *cntr, uint64_t threshold,
+			  int timeout)
+{
+	return -FI_ENOSYS;
+}
+
+static int gnix_cntr_close(fid_t fid)
+{
+	struct gnix_fid_cntr *cntr;
+
+	GNIX_TRACE(FI_LOG_CQ, "\n");
+
+	cntr = container_of(fid, struct gnix_fid_cntr, cntr_fid);
+	if (atomic_get(&cntr->ref_cnt) != 0) {
+		GNIX_INFO(FI_LOG_CQ, "CNTR ref count: %d, not closing.\n",
+			  cntr->ref_cnt);
+		return -FI_EBUSY;
+	}
+
+	atomic_dec(&cntr->domain->ref_cnt);
+	assert(atomic_get(&cntr->domain->ref_cnt) >= 0);
+
+	switch (cntr->attr.wait_obj) {
+	case FI_WAIT_NONE:
+		break;
+	case FI_WAIT_SET:
+		_gnix_wait_set_remove(cntr->wait, &cntr->cntr_fid.fid);
+		break;
+	case FI_WAIT_UNSPEC:
+	case FI_WAIT_FD:
+	case FI_WAIT_MUTEX_COND:
+		assert(cntr->wait);
+		gnix_wait_close(&cntr->wait->fid);
+		break;
+	default:
+		GNIX_WARN(FI_LOG_CQ, "format: %d unsupported\n.",
+			  cntr->attr.wait_obj);
+		break;
+	}
+
+	free(cntr);
+
+	return FI_SUCCESS;
+}
+
+static uint64_t gnix_cntr_readerr(struct fid_cntr *cntr)
+{
+	int v, ret;
+	struct gnix_fid_cntr *cntr_priv;
+
+	if (cntr == NULL)
+		return -FI_EINVAL;
+
+	cntr_priv = container_of(cntr, struct gnix_fid_cntr, cntr_fid);
+	v = atomic_get(&cntr_priv->cnt_err);
+
+	ret = __gnix_cntr_progress(cntr_priv);
+	if (ret != FI_SUCCESS)
+		GNIX_WARN(FI_LOG_CQ, " __gnix_cntr_progress returned %d.\n",
+			  ret);
+
+	return (uint64_t)v;
+}
+
+static uint64_t gnix_cntr_read(struct fid_cntr *cntr)
+{
+	int v, ret;
+	struct gnix_fid_cntr *cntr_priv;
+
+	if (cntr == NULL)
+		return -FI_EINVAL;
+
+	cntr_priv = container_of(cntr, struct gnix_fid_cntr, cntr_fid);
+	v = atomic_get(&cntr_priv->cnt);
+
+	ret = __gnix_cntr_progress(cntr_priv);
+	if (ret != FI_SUCCESS)
+		GNIX_WARN(FI_LOG_CQ, " __gnix_cntr_progress returned %d.\n",
+			  ret);
+
+	return (uint64_t)v;
+}
+
+static int gnix_cntr_add(struct fid_cntr *cntr, uint64_t value)
+{
+	struct gnix_fid_cntr *cntr_priv;
+
+	if (cntr == NULL)
+		return -FI_EINVAL;
+
+	cntr_priv = container_of(cntr, struct gnix_fid_cntr, cntr_fid);
+	atomic_add(&cntr_priv->cnt, (int)value);
+
+	if (cntr_priv->wait)
+		_gnix_signal_wait_obj(cntr_priv->wait);
+
+	return FI_SUCCESS;
+}
+
+static int gnix_cntr_set(struct fid_cntr *cntr, uint64_t value)
+{
+	struct gnix_fid_cntr *cntr_priv;
+
+	if (cntr == NULL)
+		return -FI_EINVAL;
+
+	cntr_priv = container_of(cntr, struct gnix_fid_cntr, cntr_fid);
+	atomic_set(&cntr_priv->cnt, (int)value);
+
+	if (cntr_priv->wait)
+		_gnix_signal_wait_obj(cntr_priv->wait);
+
+	return FI_SUCCESS;
+}
+
+static int gnix_cntr_control(struct fid *cntr, int command, void *arg)
+{
+	struct gnix_fid_cntr *cntr_priv;
+
+	if (cntr == NULL)
+		return -FI_EINVAL;
+
+	cntr_priv = container_of(cntr, struct gnix_fid_cntr, cntr_fid);
+
+	switch (command) {
+	case FI_SETOPSFLAG:
+		cntr_priv->attr.flags = *(uint64_t *)arg;
+		break;
+	case FI_GETOPSFLAG:
+		if (!arg)
+			return -FI_EINVAL;
+		*(uint64_t *)arg = cntr_priv->attr.flags;
+		break;
+	case FI_GETWAIT:
+		return _gnix_get_wait_obj(cntr_priv->wait, arg);
+	default:
+		return -FI_EINVAL;
+	}
+
+	return FI_SUCCESS;
+
+}
+
+
+int gnix_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
+		 struct fid_cntr **cntr, void *context)
+{
+	int ret = FI_SUCCESS;
+	struct gnix_fid_domain *domain_priv;
+	struct gnix_fid_cntr *cntr_priv;
+
+	GNIX_TRACE(FI_LOG_CQ, "\n");
+
+	ret = __verify_cntr_attr(attr);
+	if (ret)
+		goto err;
+
+	domain_priv = container_of(domain, struct gnix_fid_domain, domain_fid);
+	if (!domain_priv) {
+		ret = -FI_EINVAL;
+		goto err;
+	}
+
+	cntr_priv = calloc(1, sizeof(*cntr_priv));
+	if (!cntr_priv) {
+		ret = -FI_ENOMEM;
+		goto err;
+	}
+
+	cntr_priv->domain = domain_priv;
+	cntr_priv->attr = *attr;
+	atomic_initialize(&cntr_priv->ref_cnt, 0);
+	atomic_inc(&cntr_priv->domain->ref_cnt);
+	dlist_init(&cntr_priv->poll_nics);
+	rwlock_init(&cntr_priv->nic_lock);
+
+	cntr_priv->cntr_fid.fid.fclass = FI_CLASS_CNTR;
+	cntr_priv->cntr_fid.fid.context = context;
+	cntr_priv->cntr_fid.fid.ops = &gnix_cntr_fi_ops;
+	cntr_priv->cntr_fid.ops = &gnix_cntr_ops;
+
+	*cntr = &cntr_priv->cntr_fid;
+
+err:
+	return ret;
+}
+
+
+/*******************************************************************************
+ * FI_OPS_* data structures.
+ ******************************************************************************/
+static struct fi_ops gnix_cntr_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = gnix_cntr_close,
+	.bind = fi_no_bind,
+	.control = gnix_cntr_control,
+	.ops_open = fi_no_ops_open,
+};
+
+static struct fi_ops_cntr gnix_cntr_ops = {
+	.size = sizeof(struct fi_ops_cntr),
+	.readerr = gnix_cntr_readerr,
+	.read = gnix_cntr_read,
+	.add = gnix_cntr_add,
+	.set = gnix_cntr_set,
+	.wait = gnix_cntr_wait,
+};

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -278,8 +278,7 @@ static struct fi_ops_domain gnix_domain_ops = {
 	.av_open = gnix_av_open,
 	.cq_open = gnix_cq_open,
 	.endpoint = gnix_ep_open,
-	/* TODO: no cntrs for now in gnix */
-	.cntr_open = fi_no_cntr_open,
+	.cntr_open = gnix_cntr_open,
 	.poll_open = fi_no_poll_open,
 	.stx_ctx = fi_no_stx_context,
 	.srx_ctx = fi_no_srx_context

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -1115,7 +1115,7 @@ static int gnix_ep_close(fid_t fid)
 	}
 
 	if (ep->write_cntr) {
-		_gnix_cntr_poll_nic_rem(ep->read_cntr, ep->nic);
+		_gnix_cntr_poll_nic_rem(ep->write_cntr, ep->nic);
 		atomic_dec(&ep->write_cntr->ref_cnt);
 	}
 

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -48,6 +48,7 @@
 #include "gnix_hashtable.h"
 #include "gnix_vc.h"
 #include "gnix_rma.h"
+#include "gnix_cntr.h"
 
 
 /*******************************************************************************
@@ -229,6 +230,14 @@ static int __comp_eager_msg_w_data(void *data)
 		ret = (int)cq_len; /* ugh */
 	}
 
+	if (ep->send_cntr) {
+		ret = _gnix_cntr_inc(ep->send_cntr);
+		if (ret != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_CQ,
+			  "_gnix_cntr_inc returned %d\n",
+			   ret);
+	}
+
 	/* We could have requests waiting for TXDs or FI_FENCE operations.  Try
 	 * to push the queue now. */
 	atomic_dec(&req->vc->outstanding_tx_reqs);
@@ -404,6 +413,13 @@ static ssize_t gnix_ep_recv(struct fid_ep *ep, void *buf, size_t len,
 					  "_gnix_cq_add_event returned %d\n",
 					   cq_len);
 				ret = (int)cq_len; /* ugh */
+			}
+
+			if (ep_priv->recv_cntr) {
+				ret = _gnix_cntr_inc(ep_priv->recv_cntr);
+				if (ret != FI_SUCCESS)
+					GNIX_WARN(FI_LOG_CQ,
+					  "_gnix_cntr_inc() failed: %d\n", ret);
 			}
 
 			_gnix_fr_free(ep_priv, req);
@@ -1083,6 +1099,26 @@ static int gnix_ep_close(fid_t fid)
 		atomic_dec(&ep->recv_cq->ref_cnt);
 	}
 
+	if (ep->send_cntr) {
+		_gnix_cntr_poll_nic_rem(ep->send_cntr, ep->nic);
+		atomic_dec(&ep->send_cntr->ref_cnt);
+	}
+
+	if (ep->recv_cntr) {
+		_gnix_cntr_poll_nic_rem(ep->recv_cntr, ep->nic);
+		atomic_dec(&ep->recv_cntr->ref_cnt);
+	}
+
+	if (ep->read_cntr) {
+		_gnix_cntr_poll_nic_rem(ep->read_cntr, ep->nic);
+		atomic_dec(&ep->read_cntr->ref_cnt);
+	}
+
+	if (ep->write_cntr) {
+		_gnix_cntr_poll_nic_rem(ep->read_cntr, ep->nic);
+		atomic_dec(&ep->write_cntr->ref_cnt);
+	}
+
 	domain = ep->domain;
 	assert(domain != NULL);
 	atomic_dec(&domain->ref_cnt);
@@ -1168,6 +1204,7 @@ static int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 	struct gnix_fid_ep  *ep;
 	struct gnix_fid_av  *av;
 	struct gnix_fid_cq  *cq;
+	struct gnix_fid_cntr *cntr;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
@@ -1227,8 +1264,69 @@ static int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 		ep->av = av;
 		atomic_inc(&av->ref_cnt);
 		break;
-	case FI_CLASS_MR:/*TODO: got to figure this one out */
 	case FI_CLASS_CNTR: /* TODO: need to support cntrs someday */
+		cntr = container_of(bfid, struct gnix_fid_cntr, cntr_fid.fid);
+		if (ep->domain != cntr->domain) {
+			ret = -FI_EINVAL;
+			break;
+		}
+
+		if (flags & FI_SEND) {
+			/* don't allow rebinding */
+			if (ep->send_cntr) {
+				ret = -FI_EINVAL;
+				break;
+			}
+			ep->send_cntr = cntr;
+			_gnix_cntr_poll_nic_add(cntr, ep->nic);
+			atomic_inc(&cntr->ref_cnt);
+		}
+
+		if (flags & FI_RECV) {
+			/* don't allow rebinding */
+			if (ep->recv_cntr) {
+				ret = -FI_EINVAL;
+				break;
+			}
+			ep->recv_cntr = cntr;
+			_gnix_cntr_poll_nic_add(cntr, ep->nic);
+			atomic_inc(&cntr->ref_cnt);
+		}
+
+		if (flags & FI_READ) {
+			/* don't allow rebinding */
+			if (ep->read_cntr) {
+				ret = -FI_EINVAL;
+				break;
+			}
+			ep->read_cntr = cntr;
+			_gnix_cntr_poll_nic_add(cntr, ep->nic);
+			atomic_inc(&cntr->ref_cnt);
+		}
+
+		if (flags & FI_WRITE) {
+			/* don't allow rebinding */
+			if (ep->write_cntr) {
+				ret = -FI_EINVAL;
+				break;
+			}
+			ep->write_cntr = cntr;
+			_gnix_cntr_poll_nic_add(cntr, ep->nic);
+			atomic_inc(&cntr->ref_cnt);
+		}
+
+		/* TODO: don't support this option right now,
+		   never should have gotten here since gni provider
+		   doesn't claim cap FI_RMA_EVENT.  This
+		   option could be supported via Aries atomics
+		   or using SMSG cntrl messages */
+
+		if ((flags & FI_REMOTE_WRITE) ||
+			(flags & FI_REMOTE_READ))
+			ret = -FI_ENOSYS;
+		break;
+
+	case FI_CLASS_MR:/*TODO: got to figure this one out */
 	default:
 		ret = -FI_ENOSYS;
 		break;

--- a/prov/gni/src/gnix_ep_rcv.c
+++ b/prov/gni/src/gnix_ep_rcv.c
@@ -45,6 +45,7 @@
 #include "gnix_vc.h"
 #include "gnix_ep.h"
 #include "gnix_hashtable.h"
+#include "gnix_cntr.h"
 
 /*******************************************************************************
  * Helper functions used for handling receipt of messages on GNIX EPs
@@ -124,6 +125,14 @@ int _gnix_ep_eager_msg_w_data_match(struct gnix_fid_ep *ep, void *msg,
 					   cq_len);
 				ret = (int)cq_len; /* ugh */
 			}
+
+			if (ep->recv_cntr) {
+				ret = _gnix_cntr_inc(ep->recv_cntr);
+				if (ret != FI_SUCCESS)
+					GNIX_WARN(FI_LOG_CQ,
+					  "_gnix_cntr_inc() failed: %d\n", ret);
+			}
+
 			_gnix_fr_free(ep, req);
 
 		} else

--- a/prov/gni/test/cntr.c
+++ b/prov/gni/test/cntr.c
@@ -1,0 +1,473 @@
+/*
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <getopt.h>
+#include <poll.h>
+#include <time.h>
+#include <string.h>
+#include <pthread.h>
+
+#include <rdma/fabric.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_errno.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_cm.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <inttypes.h>
+
+#include "gnix_vc.h"
+#include "gnix_cm_nic.h"
+#include "gnix_hashtable.h"
+#include "gnix_rma.h"
+
+#include <criterion/criterion.h>
+
+#if 1
+#define dbg_printf(...)
+#else
+#define dbg_printf(...)		\
+do {				\
+	printf(__VA_ARGS__);	\
+	fflush(stdout);		\
+} while (0)
+#endif
+
+static struct fid_fabric *fab;
+static struct fid_domain *dom;
+static struct fid_ep *ep[2];
+static struct fid_av *av;
+static struct fi_info *hints;
+static struct fi_info *fi;
+void *ep_name[2];
+size_t gni_addr[2];
+static struct fid_cq *send_cq;
+static struct fid_cq *recv_cq;
+static struct fi_cq_attr cq_attr;
+static struct fid_cntr *write_cntr, *read_cntr, *rcv_cntr;
+static struct fi_cntr_attr cntr_attr = {.events = FI_CNTR_EVENTS_COMP,
+					.flags = 0};
+
+#define BUF_SZ (64*1024)
+char *target;
+char *source;
+struct fid_mr *rem_mr, *loc_mr;
+uint64_t mr_key;
+
+void cntr_setup(void)
+{
+	int ret = 0;
+	struct fi_av_attr attr;
+	size_t addrlen = 0;
+
+	hints = fi_allocinfo();
+	cr_assert(hints, "fi_allocinfo");
+
+	hints->domain_attr->cq_data_size = 4;
+	hints->mode = ~0;
+
+	hints->fabric_attr->name = strdup("gni");
+
+	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
+	cr_assert(!ret, "fi_getinfo");
+
+	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	cr_assert(!ret, "fi_fabric");
+
+	ret = fi_domain(fab, fi, &dom, NULL);
+	cr_assert(!ret, "fi_domain");
+
+	attr.type = FI_AV_MAP;
+	attr.count = 16;
+
+	ret = fi_av_open(dom, &attr, &av, NULL);
+	cr_assert(!ret, "fi_av_open");
+
+	ret = fi_endpoint(dom, fi, &ep[0], NULL);
+	cr_assert(!ret, "fi_endpoint");
+
+	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
+	cq_attr.size = 1024;
+	cq_attr.wait_obj = 0;
+
+	ret = fi_cq_open(dom, &cq_attr, &send_cq, 0);
+	cr_assert(!ret, "fi_cq_open");
+
+	ret = fi_cq_open(dom, &cq_attr, &recv_cq, 0);
+	cr_assert(!ret, "fi_cq_open");
+
+	ret = fi_cntr_open(dom, &cntr_attr, &write_cntr, 0);
+	cr_assert(!ret, "fi_cntr_open");
+
+	ret = fi_cntr_open(dom, &cntr_attr, &read_cntr, 0);
+	cr_assert(!ret, "fi_cntr_open");
+
+	ret = fi_cntr_open(dom, &cntr_attr, &rcv_cntr, 0);
+	cr_assert(!ret, "fi_cntr_open");
+
+	ret = fi_ep_bind(ep[0], &send_cq->fid, FI_SEND);
+	cr_assert(!ret, "fi_ep_bind");
+
+	ret = fi_ep_bind(ep[0], &recv_cq->fid, FI_RECV);
+	cr_assert(!ret, "fi_ep_bind");
+
+	ret = fi_ep_bind(ep[0], &write_cntr->fid, FI_WRITE | FI_SEND);
+	cr_assert(!ret, "fi_ep_bind");
+
+	ret = fi_ep_bind(ep[0], &read_cntr->fid, FI_READ);
+	cr_assert(!ret, "fi_ep_bind");
+
+	ret = fi_ep_bind(ep[0], &rcv_cntr->fid, FI_RECV);
+	cr_assert(!ret, "fi_ep_bind");
+
+	ret = fi_getname(&ep[0]->fid, NULL, &addrlen);
+	cr_assert(addrlen > 0);
+
+	ep_name[0] = malloc(addrlen);
+	cr_assert(ep_name[0] != NULL);
+
+	ep_name[1] = malloc(addrlen);
+	cr_assert(ep_name[1] != NULL);
+
+	ret = fi_getname(&ep[0]->fid, ep_name[0], &addrlen);
+	cr_assert(ret == FI_SUCCESS);
+
+	ret = fi_endpoint(dom, fi, &ep[1], NULL);
+	cr_assert(!ret, "fi_endpoint");
+
+	ret = fi_ep_bind(ep[1], &send_cq->fid, FI_SEND);
+	cr_assert(!ret, "fi_ep_bind");
+
+	ret = fi_ep_bind(ep[1], &recv_cq->fid, FI_RECV);
+	cr_assert(!ret, "fi_ep_bind");
+
+	ret = fi_ep_bind(ep[1], &write_cntr->fid, FI_WRITE | FI_SEND);
+	cr_assert(!ret, "fi_ep_bind");
+
+	ret = fi_ep_bind(ep[1], &read_cntr->fid, FI_READ);
+	cr_assert(!ret, "fi_ep_bind");
+
+	ret = fi_ep_bind(ep[1], &rcv_cntr->fid, FI_RECV);
+	cr_assert(!ret, "fi_ep_bind");
+
+	ret = fi_getname(&ep[1]->fid, ep_name[1], &addrlen);
+	cr_assert(ret == FI_SUCCESS);
+
+	ret = fi_av_insert(av, ep_name[0], 1, &gni_addr[0], 0,
+				NULL);
+	cr_assert(ret == 1);
+
+	ret = fi_av_insert(av, ep_name[1], 1, &gni_addr[1], 0,
+				NULL);
+	cr_assert(ret == 1);
+
+	ret = fi_ep_bind(ep[0], &av->fid, 0);
+	cr_assert(!ret, "fi_ep_bind");
+
+	ret = fi_ep_bind(ep[1], &av->fid, 0);
+	cr_assert(!ret, "fi_ep_bind");
+
+	ret = fi_enable(ep[0]);
+	cr_assert(!ret, "fi_ep_enable");
+
+	ret = fi_enable(ep[1]);
+	cr_assert(!ret, "fi_ep_enable");
+
+	target = malloc(BUF_SZ);
+	assert(target);
+
+	source = malloc(BUF_SZ);
+	assert(source);
+
+	ret = fi_mr_reg(dom, target, BUF_SZ,
+			FI_REMOTE_WRITE, 0, 0, 0, &rem_mr, &target);
+	cr_assert_eq(ret, 0);
+
+	ret = fi_mr_reg(dom, source, BUF_SZ,
+			FI_REMOTE_WRITE, 0, 0, 0, &loc_mr, &source);
+	cr_assert_eq(ret, 0);
+
+	mr_key = fi_mr_key(rem_mr);
+}
+
+void cntr_teardown(void)
+{
+	int ret = 0;
+
+	fi_close(&loc_mr->fid);
+	fi_close(&rem_mr->fid);
+
+	free(target);
+	free(source);
+
+	ret = fi_close(&ep[0]->fid);
+	cr_assert(!ret, "failure in closing ep.");
+
+	ret = fi_close(&ep[1]->fid);
+	cr_assert(!ret, "failure in closing ep.");
+
+	ret = fi_close(&send_cq->fid);
+	cr_assert(!ret, "failure in send cq.");
+
+	ret = fi_close(&recv_cq->fid);
+	cr_assert(!ret, "failure in send cq.");
+
+	ret = fi_close(&write_cntr->fid);
+	cr_assert(!ret, "failure in write_cntr.");
+
+	ret = fi_close(&read_cntr->fid);
+	cr_assert(!ret, "failure in read_cntr.");
+
+	ret = fi_close(&rcv_cntr->fid);
+	cr_assert(!ret, "failure in read_cntr.");
+
+	ret = fi_close(&av->fid);
+	cr_assert(!ret, "failure in closing av.");
+
+	ret = fi_close(&dom->fid);
+	cr_assert(!ret, "failure in closing domain.");
+
+	ret = fi_close(&fab->fid);
+	cr_assert(!ret, "failure in closing fabric.");
+
+	fi_freeinfo(fi);
+	fi_freeinfo(hints);
+	free(ep_name[0]);
+	free(ep_name[1]);
+}
+
+static void init_data(char *buf, int len, char seed)
+{
+	int i;
+
+	for (i = 0; i < len; i++)
+		buf[i] = seed++;
+}
+
+static int check_data(char *buf1, char *buf2, int len)
+{
+	int i;
+
+	for (i = 0; i < len; i++) {
+		if (buf1[i] != buf2[i]) {
+			printf("data mismatch, elem: %d, exp: %x, act: %x\n",
+			       i, buf1[i], buf2[i]);
+			return 0;
+		}
+	}
+
+	return 1;
+}
+
+static void xfer_for_each_size(void (*xfer)(int len), int slen, int elen)
+{
+	int i;
+
+	for (i = slen; i <= elen; i *= 2)
+		xfer(i);
+}
+
+/*******************************************************************************
+ * Test RMA functions
+ ******************************************************************************/
+
+TestSuite(cntr, .init = cntr_setup, .fini = cntr_teardown,
+	  .disabled = false);
+
+static void do_write(int len)
+{
+	uint64_t old_w_cnt, new_w_cnt;
+	uint64_t old_r_cnt, new_r_cnt;
+	ssize_t sz;
+
+	init_data(source, len, 0xab);
+	init_data(target, len, 0);
+
+
+	old_w_cnt = fi_cntr_read(write_cntr);
+	cr_assert(old_w_cnt >= 0);
+
+	old_r_cnt = fi_cntr_read(read_cntr);
+	cr_assert(old_r_cnt >= 0);
+
+	sz = fi_write(ep[0], source, len,
+			 loc_mr, gni_addr[1], (uint64_t)target, mr_key,
+			 target);
+	cr_assert_eq(sz, 0);
+
+	do {
+		new_w_cnt = fi_cntr_read(write_cntr);
+		cr_assert(new_w_cnt >= 0);
+		if (new_w_cnt == (old_w_cnt + 1))
+			break;
+		pthread_yield();
+	} while (1);
+
+	cr_assert(check_data(source, target, len), "Data mismatch");
+
+	new_r_cnt = fi_cntr_read(read_cntr);
+	cr_assert(new_r_cnt >= 0);
+
+	/*
+	 * no fi_read called so old and new read cnts should be equal
+	 */
+	cr_assert(new_r_cnt == old_r_cnt);
+}
+
+Test(cntr, write)
+{
+	xfer_for_each_size(do_write, 8, BUF_SZ);
+}
+
+static void do_read(int len)
+{
+	ssize_t sz;
+	uint64_t old_w_cnt, new_w_cnt;
+	uint64_t old_r_cnt, new_r_cnt;
+
+#define READ_CTX 0x4e3dda1aULL
+	init_data(source, len, 0);
+	init_data(target, len, 0xad);
+
+	old_w_cnt = fi_cntr_read(write_cntr);
+	cr_assert(old_w_cnt >= 0);
+
+	old_r_cnt = fi_cntr_read(read_cntr);
+	cr_assert(old_r_cnt >= 0);
+
+	sz = fi_read(ep[0], source, len,
+			loc_mr, gni_addr[1], (uint64_t)target, mr_key,
+			(void *)READ_CTX);
+	cr_assert_eq(sz, 0);
+
+	do {
+		new_r_cnt = fi_cntr_read(read_cntr);
+		cr_assert(new_r_cnt >= 0);
+		if (new_r_cnt == (old_r_cnt + 1))
+			break;
+		pthread_yield();
+	} while (1);
+
+	cr_assert(check_data(source, target, len), "Data mismatch");
+
+	new_w_cnt = fi_cntr_read(write_cntr);
+	cr_assert(new_w_cnt >= 0);
+
+	/*
+	 * no fi_read called so old and new read cnts should be equal
+	 */
+	cr_assert(new_w_cnt == old_w_cnt);
+}
+
+Test(cntr, read)
+{
+	xfer_for_each_size(do_read, 8, BUF_SZ);
+}
+
+Test(cntr, send_recv)
+{
+	int ret, i, got_r = 0;
+	struct fi_context r_context, s_context;
+	struct fi_cq_entry cqe;
+	uint64_t old_s_cnt, new_s_cnt;
+	uint64_t old_r_cnt, new_r_cnt;
+	char s_buffer[128], r_buffer[128];
+
+	old_s_cnt = fi_cntr_read(write_cntr);
+	cr_assert(old_s_cnt >= 0);
+
+	old_r_cnt = fi_cntr_read(rcv_cntr);
+	cr_assert(old_r_cnt >= 0);
+
+	for (i = 0; i < 16; i++) {
+		sprintf(s_buffer, "Hello there iter=%d", i);
+		memset(r_buffer, 0, 128);
+		ret = fi_recv(ep[1],
+			      r_buffer,
+			      sizeof(r_buffer),
+			      NULL,
+			      gni_addr[0],
+			      &r_context);
+		cr_assert_eq(ret, FI_SUCCESS, "fi_recv");
+		ret = fi_send(ep[0],
+			      s_buffer,
+			      strlen(s_buffer),
+			      NULL,
+			      gni_addr[1],
+			      &s_context);
+		cr_assert_eq(ret, FI_SUCCESS, "fi_send");
+
+		while ((ret = fi_cq_read(send_cq, &cqe, 1)) == -FI_EAGAIN)
+			pthread_yield();
+
+		cr_assert((cqe.op_context == &r_context) ||
+			(cqe.op_context == &s_context), "fi_cq_read");
+		got_r = (cqe.op_context == &r_context) ? 1 : 0;
+
+		if (got_r) {
+			new_r_cnt = fi_cntr_read(rcv_cntr);
+			old_r_cnt++;
+			cr_assert(new_r_cnt == old_r_cnt);
+		} else {
+			new_s_cnt = fi_cntr_read(write_cntr);
+			old_s_cnt++;
+			cr_assert(new_s_cnt == old_s_cnt);
+		}
+
+		while ((ret = fi_cq_read(recv_cq, &cqe, 1)) == -FI_EAGAIN)
+			pthread_yield();
+		if (got_r)
+			cr_assert((cqe.op_context == &s_context), "fi_cq_read");
+		else
+			cr_assert((cqe.op_context == &r_context), "fi_cq_read");
+
+		if (got_r) {
+			new_s_cnt = fi_cntr_read(write_cntr);
+			old_s_cnt++;
+			cr_assert(new_s_cnt == old_s_cnt);
+		} else {
+			new_r_cnt = fi_cntr_read(rcv_cntr);
+			old_r_cnt++;
+			cr_assert(new_r_cnt == old_r_cnt);
+		}
+
+		cr_assert(strcmp(s_buffer, r_buffer) == 0, "check message");
+
+		got_r = 0;
+	}
+
+}


### PR DESCRIPTION
This work implements the counter class functionality
for the gni provider.  Note the gni provider
currently does not claim the FI_RMA_EVENT
capability, so FI_REMOTE_WRITE and FI_REMOTE_READ
flags are not supported when binding a counter
to an ep.

Wait object functionality is also not fully implemented
yet.

@ztiffany 
@jswaro 
@jshimek 

We should eventually come up with some generic code for associating `gnix_nics`
with cntr and cq objects.

Signed-off-by: Howard Pritchard howardp@lanl.gov
