### PR TITLE
prov/gni: implement gnix_cntr_wait

### DIFF
--- a/prov/gni/include/gnix_wait.h
+++ b/prov/gni/include/gnix_wait.h
@@ -77,6 +77,7 @@ struct gnix_fid_wait {
 int gnix_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 		   struct fid_wait **waitset);
 int gnix_wait_close(struct fid *wait);
+int gnix_wait_wait(struct fid_wait *wait, int timeout);
 
 /*
  * Exposed internal functions.

--- a/prov/gni/src/gnix_wait.c
+++ b/prov/gni/src/gnix_wait.c
@@ -243,7 +243,7 @@ static int gnix_wait_control(struct fid *wait, int command, void *arg)
 	}
 }
 
-static int gnix_wait_wait(struct fid_wait *wait, int timeout)
+int gnix_wait_wait(struct fid_wait *wait, int timeout)
 {
 	return -FI_ENOSYS;
 }


### PR DESCRIPTION
Implement the cntr wait method since its important for
open shmem, etc.

Add Sung's criterion tests for do_write_wait and an
additional do_read_wait test.

Also minor fix for cntr close method.  

@sungeunchoi 
@ztiffany 
@jswaro 
@jshimek 

Signed-off-by: Howard Pritchard howardp@lanl.gov
