### PR TITLE
prov/gni: fix for converting mdh to fi_mr_key

### DIFF
--- a/prov/gni/include/gnix_mr.h
+++ b/prov/gni/include/gnix_mr.h
@@ -206,11 +206,9 @@ void _gnix_convert_key_to_mhdl(
  * @brief Converts a gni memory handle to a libfabric key
  *
  * @param[in]     mhdl  gni memory handle
- * @param[in,out] key   libfabric memory region key
+ * @return              fi_mr_key to be used by remote EPs.
  */
-void _gnix_convert_mhdl_to_key(
-		gni_mem_handle_t *mhdl,
-		gnix_mr_key_t    *key);
+uint64_t _gnix_convert_mhdl_to_key(gni_mem_handle_t *mhdl);
 
 /**
  * @brief Initializes a gnix memory registration cache


### PR DESCRIPTION
It seems the gnu compiler is having a hard time
with handling conversion of a gnix_mr_key_t to
a uint64_t.  The approach in this mod appears to
address this problem.

Also added trace macros to gnix_mr.

@jswaro 

Fixes #279.

Signed-off-by: Howard Pritchard howardp@lanl.gov
