### PR TITLE
Don't use CqTestEvent on GNI TX CQ.

### DIFF
--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -216,10 +216,6 @@ static int __nic_tx_progress(struct gnix_nic *nic)
 	 * getting the nic lock
 	 */
 
-	status = GNI_CqTestEvent(nic->tx_cq);
-	if (status == GNI_RC_NOT_DONE)
-		return FI_SUCCESS;
-
 try_again:
 	fastlock_acquire(&nic->lock);
         status = GNI_CqGetEvent(nic->tx_cq, &cqe);


### PR DESCRIPTION
GNI_CqTestEvent does not progress the GNI DLA CQ and should not be exclusively
used on a TX CQ.  This may explain hangs seen in send/recv tests.

Fixes #275 

Signed-off-by: Zach Tiffany ztiffany@cray.com
