### PR TITLE
Reorganize NIC progress.

### DIFF
--- a/prov/gni/include/gnix_ep.h
+++ b/prov/gni/include/gnix_ep.h
@@ -80,19 +80,6 @@ extern smsg_completer_fn_t gnix_ep_smsg_completers[];
 int _gnix_ep_eager_msg_w_data_match(struct gnix_fid_ep *ep, void *msg,
 				    struct gnix_address addr, size_t len,
 				    uint64_t imm, uint64_t sflags);
-
-/**
- * @brief  dequeue smsg messages that arrived before vc fully
- *         initialized at receiver
- *
- * @param[in] vc        pointer to a previously allocated vc
- * @return              FI_SUCCESS on success meaning that no errors
- *                      were encountered dequeing SMSG messages, -FI_EINVAL
- *                      if an invalid argument is supplied,
- *                      -FI_EAGAIN if the SMSG channel is in an
- *                      invalid state.
- */
-int _gnix_ep_vc_dequeue_smsg(struct gnix_vc *vc);
 /*
  * typedefs for function vectors used to steer send/receive/rma/amo requests,
  * i.e. fi_send, fi_recv, etc. to ep type specific methods

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -131,8 +131,8 @@ struct gnix_nic {
 	struct dlist_entry tx_desc_free_list;
 	struct gnix_tx_descriptor *tx_desc_base;
 	atomic_t outstanding_fab_reqs_nic;
-	fastlock_t wq_lock;
-	struct list_head nic_wq;
+	fastlock_t pending_vc_lock;
+	struct slist pending_vcs;
 	uint8_t ptag;
 	uint32_t cookie;
 	uint32_t device_id;

--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -43,6 +43,7 @@ extern "C" {
 #endif /* HAVE_CONFIG_H */
 
 #include "gnix.h"
+#include "gnix_bitmap.h"
 
 /*
  * mode bits
@@ -51,6 +52,10 @@ extern "C" {
 #define GNIX_VC_MODE_IN_HT		(1U << 1)
 #define GNIX_VC_MODE_DG_POSTED		(1U << 2)
 #define GNIX_VC_MODE_PENDING_MSGS	(1U << 3)
+
+/* VC flags */
+#define GNIX_VC_FLAG_SCHEDULED		0
+#define GNIX_VC_FLAG_RX_PENDING		1
 
 /*
  * defines for connection state for gnix VC
@@ -106,6 +111,8 @@ struct gnix_vc {
 	enum gnix_vc_conn_state conn_state;
 	int vc_id;
 	int modes;
+	struct slist_entry pending_list;
+	gnix_bitmap_t flags; /* We're missing regular bit ops */
 };
 
 /*
@@ -200,7 +207,11 @@ static inline enum gnix_vc_conn_state _gnix_vc_state(struct gnix_vc *vc)
 }
 
 
-int _gnix_vc_push_tx_reqs(struct gnix_vc *vc);
+int _gnix_vc_schedule(struct gnix_vc *vc);
+int _gnix_vc_schedule_tx(struct gnix_vc *vc);
+struct gnix_vc *_gnix_nic_next_pending_vc(struct gnix_nic *nic);
+int _gnix_vc_dequeue_smsg(struct gnix_vc *vc);
+int _gnix_vc_progress(struct gnix_vc *vc);
 int _gnix_vc_queue_tx_req(struct gnix_fab_req *req);
 
 /**

--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -256,7 +256,6 @@ static int __gnix_cq_progress(struct gnix_fid_cq *cq)
 	rwlock_rdlock(&cq->nic_lock);
 
 	dlist_for_each_safe(&cq->poll_nics, pnic, tmp, list) {
-		GNIX_INFO(FI_LOG_CQ, "progressing nic %p\n", pnic->nic);
 		rc = _gnix_nic_progress(pnic->nic);
 		if (rc) {
 			GNIX_WARN(FI_LOG_CQ,

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -238,10 +238,11 @@ static int __comp_eager_msg_w_data(void *data)
 			   ret);
 	}
 
-	/* We could have requests waiting for TXDs or FI_FENCE operations.  Try
-	 * to push the queue now. */
 	atomic_dec(&req->vc->outstanding_tx_reqs);
-	_gnix_vc_push_tx_reqs(req->vc);
+
+	/* We could have requests waiting for TXDs or FI_FENCE operations.
+	 * Schedule this VC to push any such TXs. */
+	_gnix_vc_schedule_tx(req->vc);
 
 	_gnix_fr_free(ep, req);
 

--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -83,10 +83,11 @@ static int __gnix_rma_fab_req_complete(void *arg)
 				  "_gnix_cntr_inc() failed: %d\n", rc);
 	}
 
-	/* We could have requests waiting for TXDs or FI_FENCE operations.  Try
-	 * to push the queue now. */
 	atomic_dec(&req->vc->outstanding_tx_reqs);
-	_gnix_vc_push_tx_reqs(req->vc);
+
+	/* We could have requests waiting for TXDs or FI_FENCE operations.
+	 * Schedule this VC to push any such TXs. */
+	_gnix_vc_schedule_tx(req->vc);
 
 	_gnix_fr_free(ep, req);
 


### PR DESCRIPTION
Signed-off-by: Zach Tiffany ztiffany@cray.com

@sungeunchoi @hppritcha @jswaro @jshimek

I attempted to improve the speed, thread safety and organization of _gnix_nic_progress() with this mod.  It ended up being a lot of changes for no improvement in performance for our set of micro benchmarks.  Hopefully it's appreciated still.  We'll have to talk about it.  I like my changes to:
1. Make a clear line between NIC progress/VC progress interfaces
2. Remove the malloc() from _gnix_vc_add_to_wq().  _gnix_vc_schedule replaces _gnix_vc_add_to_wq.  VC progress should be more thread safe.
3. Experiment with deferred SMSG processing.
