### PR TITLE
Implement fi_send variants

### DIFF
--- a/prov/gni/Makefile.am
+++ b/prov/gni/Makefile.am
@@ -36,7 +36,8 @@ _gni_files = \
 	prov/gni/src/gnix_bitmap.c \
 	prov/gni/src/gnix_hashtable.c \
 	prov/gni/src/gnix_mbox_allocator.c \
-	prov/gni/src/gnix_rma.c
+	prov/gni/src/gnix_rma.c \
+	prov/gni/src/gnix_msg.c
 
 if HAVE_CRITERION
 bin_PROGRAMS += prov/gni/test/gnitest

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -116,6 +116,7 @@ extern "C" {
 
 #define GNIX_SUPPRESS_COMPLETION	(1ULL << 60)	/* TX only flag */
 #define GNIX_RMA_RDMA			(1ULL << 61)	/* RMA only flag */
+#define GNIX_MSG_RENDEVOUS		(1ULL << 61)	/* MSG only flag */
 
 /*
  * Cray gni provider supported flags for fi_getinfo argument for now, needs
@@ -359,7 +360,6 @@ enum gnix_fab_req_type {
 };
 
 struct gnix_fab_req_rma {
-	void *loc_md;
 	uint64_t rem_addr;
 	uint64_t rem_mr_key;
 };
@@ -397,6 +397,7 @@ struct gnix_fab_req {
 	int retries;
 	/* common to rma/amo/msg */
 	uint64_t loc_addr;
+	void *loc_md;
 	uint64_t imm;
 	size_t len;
 	uint64_t flags;

--- a/prov/gni/include/gnix_ep_rdm.h
+++ b/prov/gni/include/gnix_ep_rdm.h
@@ -42,39 +42,6 @@
  * This file is intended to be included only in gnix_ep.c
  */
 
-static ssize_t gnix_ep_sendv_rdm(struct fid_ep *ep, const struct iovec *iov,
-				 void **desc, size_t count, fi_addr_t dest_addr,
-				 void *context)
-{
-	return -FI_ENOSYS;
-}
-
-static ssize_t gnix_ep_sendmsg_rdm(struct fid_ep *ep, const struct fi_msg *msg,
-				   uint64_t flags)
-{
-	return -FI_ENOSYS;
-}
-
-static ssize_t gnix_ep_msg_inject_rdm(struct fid_ep *ep, const void *buf,
-				      size_t len, fi_addr_t dest_addr)
-{
-	return -FI_ENOSYS;
-}
-
-
-static ssize_t gnix_ep_recvv_rdm(struct fid_ep *ep, const struct iovec *iov,
-				 void **desc, size_t count, fi_addr_t dest_addr,
-				 void *context)
-{
-	return -FI_ENOSYS;
-}
-
-static ssize_t gnix_ep_recvmsg_rdm(struct fid_ep *ep, const struct fi_msg *msg,
-				   uint64_t flags)
-{
-	return -FI_ENOSYS;
-}
-
 static ssize_t gnix_ep_tsend_rdm(struct fid_ep *ep, const void *buf, size_t len,
 				 void *desc, fi_addr_t dest_addr, uint64_t tag,
 				 void *context)

--- a/prov/gni/include/gnix_msg.h
+++ b/prov/gni/include/gnix_msg.h
@@ -31,13 +31,12 @@
  * SOFTWARE.
  */
 
-#ifndef _GNIX_RMA_H_
-#define _GNIX_RMA_H_
+#ifndef _GNIX_MSG_H_
+#define _GNIX_MSG_H_
 
-ssize_t _gnix_rma(struct gnix_fid_ep *ep, enum gnix_fab_req_type fr_type,
-		  uint64_t loc_addr, size_t len, void *mdesc,
-		  uint64_t dest_addr, uint64_t rem_addr, uint64_t mkey,
-		  void *context, uint64_t flags, uint64_t data);
+ssize_t _gnix_send(struct gnix_fid_ep *ep, uint64_t loc_addr, size_t len,
+		   void *mdesc, uint64_t dest_addr, void *context,
+		   uint64_t flags, uint64_t data);
 
-#endif /* _GNIX_RMA_H_ */
+#endif /* _GNIX_MSG_H_ */
 

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include "gnix.h"
+#include "gnix_cm_nic.h"
+#include "gnix_nic.h"
+#include "gnix_util.h"
+#include "gnix_ep.h"
+#include "gnix_hashtable.h"
+#include "gnix_vc.h"
+#include "gnix_cntr.h"
+
+/*******************************************************************************
+ * GNI SMSG callbacks invoked upon completion of an SMSG message at the sender.
+ ******************************************************************************/
+
+static int __comp_eager_msg_w_data(void *data)
+{
+	int ret = FI_SUCCESS;
+	struct gnix_tx_descriptor *tdesc;
+	struct gnix_fid_ep *ep;
+	struct gnix_fid_cq *cq;
+	struct fi_context *user_context;
+	ssize_t cq_len;
+	struct gnix_fab_req *req;
+
+	tdesc = (struct gnix_tx_descriptor *)data;
+	req = tdesc->desc.req;
+
+	ep = tdesc->desc.ep;
+	assert(ep != NULL);
+
+	cq = ep->send_cq;
+	assert(cq != NULL);
+
+	if (req != NULL)
+		user_context = req->user_context;
+	else
+		user_context = tdesc->desc.context;
+
+	cq_len = _gnix_cq_add_event(cq,
+				    user_context,
+				    FI_SEND | FI_MSG,
+				    0,
+				    0,
+				    0,
+				    0);
+	if (cq_len != FI_SUCCESS)  {
+		GNIX_WARN((FI_LOG_CQ | FI_LOG_EP_DATA),
+			  "_gnix_cq_add_event returned %d\n",
+			   cq_len);
+		ret = (int)cq_len; /* ugh */
+	}
+
+	if (ep->send_cntr) {
+		ret = _gnix_cntr_inc(ep->send_cntr);
+		if (ret != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_CQ,
+			  "_gnix_cntr_inc returned %d\n",
+			   ret);
+	}
+
+	/* We could have requests waiting for TXDs or FI_FENCE operations.  Try
+	 * to push the queue now. */
+	atomic_dec(&req->vc->outstanding_tx_reqs);
+	_gnix_vc_push_tx_reqs(req->vc);
+
+	_gnix_fr_free(ep, req);
+
+	return ret;
+
+}
+
+static int __comp_eager_msg_w_data_ack(void *data)
+{
+	return -FI_ENOSYS;
+}
+
+static int __comp_eager_msg_data_at_src(void *data)
+{
+	return -FI_ENOSYS;
+}
+
+static int __comp_eager_msg_data_at_src_ack(void *data)
+{
+	return -FI_ENOSYS;
+}
+
+static int __comp_rndzv_msg_rts(void *data)
+{
+	return -FI_ENOSYS;
+}
+
+static int __comp_rndzv_msg_rtr(void *data)
+{
+	return -FI_ENOSYS;
+}
+
+static int __comp_rndzv_msg_cookie(void *data)
+{
+	return -FI_ENOSYS;
+}
+
+static int __comp_rndzv_msg_send_done(void *data)
+{
+	return -FI_ENOSYS;
+}
+
+static int __comp_rndzv_msg_recv_done(void *data)
+{
+	return -FI_ENOSYS;
+}
+
+smsg_completer_fn_t gnix_ep_smsg_completers[] = {
+	[GNIX_SMSG_T_EGR_W_DATA] = __comp_eager_msg_w_data,
+	[GNIX_SMSG_T_EGR_W_DATA_ACK] = __comp_eager_msg_w_data_ack,
+	[GNIX_SMSG_T_EGR_GET] = __comp_eager_msg_data_at_src,
+	[GNIX_SMSG_T_EGR_GET_ACK] = __comp_eager_msg_data_at_src_ack,
+	[GNIX_SMSG_T_RNDZV_RTS] = __comp_rndzv_msg_rts,
+	[GNIX_SMSG_T_RNDZV_RTR] = __comp_rndzv_msg_rtr,
+	[GNIX_SMSG_T_RNDZV_COOKIE] = __comp_rndzv_msg_cookie,
+	[GNIX_SMSG_T_RNDZV_SDONE] = __comp_rndzv_msg_send_done,
+	[GNIX_SMSG_T_RNDZV_RDONE] = __comp_rndzv_msg_recv_done
+};
+
+static int _gnix_send_req(void *data)
+{
+	struct gnix_fab_req *req = (struct gnix_fab_req *)data;
+	struct gnix_nic *nic;
+	struct gnix_fid_ep *ep;
+	struct gnix_tx_descriptor *tdesc;
+	gni_return_t status;
+	int rc;
+	int rendevous = !!(req->flags & GNIX_MSG_RENDEVOUS);
+	int len;
+
+	ep = req->gnix_ep;
+	assert(ep != NULL);
+
+	nic = ep->nic;
+	assert(nic != NULL);
+
+	rc = _gnix_nic_tx_alloc(nic, &tdesc);
+	if (rc != FI_SUCCESS) {
+		GNIX_INFO(FI_LOG_EP_DATA, "_gnix_nic_tx_alloc() failed: %d\n",
+			  rc);
+		return -FI_EAGAIN;
+	}
+	assert(rc == FI_SUCCESS);
+
+	tdesc->desc.req = req;
+	tdesc->desc.ep = ep;
+	tdesc->desc.completer_fn =
+			gnix_ep_smsg_completers[GNIX_SMSG_T_EGR_W_DATA];
+
+	if (rendevous) {
+		/* Fill SMSG header with local buffer info. */
+
+		len = 0;
+		assert(0);
+	} else {
+		tdesc->desc.smsg_desc.hdr.len = req->len;
+		tdesc->desc.smsg_desc.hdr.flags = 0;
+		tdesc->desc.smsg_desc.buf = (void *)req->loc_addr;
+		len = req->len;
+	}
+
+	fastlock_acquire(&nic->lock);
+
+	status = GNI_SmsgSendWTag(req->vc->gni_ep,
+			&tdesc->desc.smsg_desc.hdr,
+			sizeof(struct gnix_smsg_hdr),
+			(void *)req->loc_addr, len,
+			tdesc->desc.id,
+			GNIX_SMSG_T_EGR_W_DATA);
+
+	fastlock_release(&nic->lock);
+
+	if (status == GNI_RC_NOT_DONE) {
+		_gnix_nic_tx_free(nic, tdesc);
+		GNIX_INFO(FI_LOG_EP_DATA,
+			  "GNI_SmsgSendWTag returned %s\n",
+			  gni_err_str[status]);
+	} else if (status != GNI_RC_SUCCESS) {
+		_gnix_nic_tx_free(nic, tdesc);
+		GNIX_WARN(FI_LOG_EP_DATA,
+			  "GNI_SmsgSendWTag returned %s\n",
+			  gni_err_str[status]);
+	}
+
+	return gnixu_to_fi_errno(status);
+}
+
+#define GNIX_MSG_RENDEVOUS_THRESH (16*1024)
+
+ssize_t _gnix_send(struct gnix_fid_ep *ep, uint64_t loc_addr, size_t len,
+		   void *mdesc, uint64_t dest_addr, void *context,
+		   uint64_t flags, uint64_t data)
+{
+	int ret = FI_SUCCESS;
+	struct gnix_vc *vc = NULL;
+	struct gnix_fab_req *req;
+	struct gnix_fid_mem_desc *md = NULL;
+	int rendevous;
+
+	if (!ep) {
+		return -FI_EINVAL;
+	}
+
+	if ((flags & FI_INJECT) && (len > GNIX_INJECT_SIZE)) {
+		GNIX_INFO(FI_LOG_EP_DATA,
+			  "Send length %d exceeds inject max size: %d\n",
+			  len, GNIX_INJECT_SIZE);
+		return -FI_EINVAL;
+	}
+
+	rendevous = len >= GNIX_MSG_RENDEVOUS_THRESH;
+
+	/* need a memory descriptor for large sends */
+	if (rendevous && !mdesc) {
+		GNIX_INFO(FI_LOG_EP_DATA,
+			  "Send of length %d requires memory descriptor\n",
+			  len);
+		return -FI_EINVAL;
+	}
+
+	ret = _gnix_ep_get_vc(ep, dest_addr, &vc);
+	if (ret) {
+		return ret;
+	}
+
+	req = _gnix_fr_alloc(ep);
+	if (req == NULL)
+		return -FI_EAGAIN;
+
+	req->type = GNIX_FAB_RQ_SEND;
+	req->gnix_ep = ep;
+	req->vc = vc;
+	req->user_context = context;
+	req->send_fn = _gnix_send_req;
+
+	if (mdesc) {
+		md = container_of(mdesc, struct gnix_fid_mem_desc, mr_fid);
+	}
+	req->loc_md = (void *)md;
+
+	req->len = len;
+	req->flags = flags;
+
+	if (req->flags & FI_INJECT) {
+		memcpy(req->inject_buf, (void *)loc_addr, len);
+		req->loc_addr = (uint64_t)req->inject_buf;
+	} else {
+		req->loc_addr = loc_addr;
+	}
+
+	if (rendevous) {
+		req->flags |= GNIX_MSG_RENDEVOUS;
+	}
+
+	return _gnix_vc_queue_tx_req(req);
+}
+

--- a/prov/gni/test/rdm_rma.c
+++ b/prov/gni/test/rdm_rma.c
@@ -239,8 +239,6 @@ int check_data(char *buf1, char *buf2, int len)
 	return 1;
 }
 
-;
-
 void xfer_for_each_size(void (*xfer)(int len), int slen, int elen)
 {
 	int i;
@@ -451,7 +449,7 @@ void do_inject_write(int len)
 
 	init_data(source, len, 0x23);
 	init_data(target, len, 0);
-	sz = fi_inject_write(ep[0], source, INJECT_SIZE,
+	sz = fi_inject_write(ep[0], source, len,
 			     gni_addr[1], (uint64_t)target, mr_key);
 	cr_assert_eq(sz, 0);
 
@@ -470,7 +468,7 @@ void do_inject_write(int len)
 
 Test(rdm_rma, inject_write)
 {
-	xfer_for_each_size(do_inject_write, 8, BUF_SZ);
+	xfer_for_each_size(do_inject_write, 8, INJECT_SIZE);
 }
 
 void do_writedata(int len)

--- a/prov/gni/test/rdm_sr.c
+++ b/prov/gni/test/rdm_sr.c
@@ -57,7 +57,11 @@
 
 #include <criterion/criterion.h>
 
+#if 1
 #define dbg_printf(...)
+#else
+#define dbg_printf(...) fprintf(stderr, __VA_ARGS__); fflush(stderr)
+#endif
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
@@ -67,8 +71,14 @@ static struct fi_info *hints;
 static struct fi_info *fi;
 void *ep_name[2];
 size_t gni_addr[2];
-static struct fid_cq *msg_cq;
+static struct fid_cq *msg_cq[2];
 static struct fi_cq_attr cq_attr;
+
+#define BUF_SZ (8*1024)
+char *target;
+char *source;
+struct fid_mr *rem_mr, *loc_mr;
+uint64_t mr_key;
 
 void rdm_sr_setup(void)
 {
@@ -106,10 +116,13 @@ void rdm_sr_setup(void)
 	cq_attr.size = 1024;
 	cq_attr.wait_obj = 0;
 
-	ret = fi_cq_open(dom, &cq_attr, &msg_cq, 0);
+	ret = fi_cq_open(dom, &cq_attr, &msg_cq[0], 0);
 	cr_assert(!ret, "fi_cq_open");
 
-	ret = fi_ep_bind(ep[0], &msg_cq->fid, FI_SEND | FI_RECV);
+	ret = fi_cq_open(dom, &cq_attr, &msg_cq[1], 0);
+	cr_assert(!ret, "fi_cq_open");
+
+	ret = fi_ep_bind(ep[0], &msg_cq[0]->fid, FI_SEND | FI_RECV);
 	cr_assert(!ret, "fi_ep_bind");
 
 	ret = fi_getname(&ep[0]->fid, NULL, &addrlen);
@@ -124,7 +137,7 @@ void rdm_sr_setup(void)
 	ret = fi_endpoint(dom, fi, &ep[1], NULL);
 	cr_assert(!ret, "fi_endpoint");
 
-	ret = fi_ep_bind(ep[1], &msg_cq->fid, FI_SEND | FI_RECV);
+	ret = fi_ep_bind(ep[1], &msg_cq[1]->fid, FI_SEND | FI_RECV);
 	cr_assert(!ret, "fi_ep_bind");
 
 	ep_name[1] = malloc(addrlen);
@@ -152,11 +165,33 @@ void rdm_sr_setup(void)
 
 	ret = fi_enable(ep[1]);
 	cr_assert(!ret, "fi_ep_enable");
+
+	target = malloc(BUF_SZ);
+	assert(target);
+
+	source = malloc(BUF_SZ);
+	assert(source);
+
+	ret = fi_mr_reg(dom, target, BUF_SZ,
+			FI_REMOTE_WRITE, 0, 0, 0, &rem_mr, &target);
+	cr_assert_eq(ret, 0);
+
+	ret = fi_mr_reg(dom, source, BUF_SZ,
+			FI_REMOTE_WRITE, 0, 0, 0, &loc_mr, &source);
+	cr_assert_eq(ret, 0);
+
+	mr_key = fi_mr_key(rem_mr);
 }
 
 void rdm_sr_teardown(void)
 {
 	int ret = 0;
+
+	fi_close(&loc_mr->fid);
+	fi_close(&rem_mr->fid);
+
+	free(target);
+	free(source);
 
 	ret = fi_close(&ep[0]->fid);
 	cr_assert(!ret, "failure in closing ep.");
@@ -164,8 +199,11 @@ void rdm_sr_teardown(void)
 	ret = fi_close(&ep[1]->fid);
 	cr_assert(!ret, "failure in closing ep.");
 
-	ret = fi_close(&msg_cq->fid);
+	ret = fi_close(&msg_cq[0]->fid);
 	cr_assert(!ret, "failure in send cq.");
+
+	ret = fi_close(&msg_cq[1]->fid);
+	cr_assert(!ret, "failure in recv cq.");
 
 	ret = fi_close(&av->fid);
 	cr_assert(!ret, "failure in closing av.");
@@ -182,55 +220,317 @@ void rdm_sr_teardown(void)
 	free(ep_name[1]);
 }
 
+void rdm_sr_init_data(char *buf, int len, char seed)
+{
+	int i;
+
+	for (i = 0; i < len; i++) {
+		buf[i] = seed++;
+	}
+}
+
+int rdm_sr_check_data(char *buf1, char *buf2, int len)
+{
+	int i;
+
+	for (i = 0; i < len; i++) {
+		if (buf1[i] != buf2[i]) {
+			printf("data mismatch, elem: %d, exp: %x, act: %x\n",
+			       i, buf1[i], buf2[i]);
+			return 0;
+		}
+	}
+
+	return 1;
+}
+
+void rdm_sr_xfer_for_each_size(void (*xfer)(int len), int slen, int elen)
+{
+	int i;
+
+	for (i = slen; i <= elen; i *= 2) {
+		xfer(i);
+	}
+}
+
 /*******************************************************************************
- * Test vc functions.
+ * Test MSG functions
  ******************************************************************************/
 
 TestSuite(rdm_sr, .init = rdm_sr_setup, .fini = rdm_sr_teardown,
 	  .disabled = false);
 
-Test(rdm_sr, pingpong)
+/*
+ * ssize_t fi_send(struct fid_ep *ep, void *buf, size_t len,
+ *		void *desc, fi_addr_t dest_addr, void *context);
+ *
+ * ssize_t fi_recv(struct fid_ep *ep, void * buf, size_t len,
+ *		void *desc, fi_addr_t src_addr, void *context);
+ */
+void do_send(int len)
 {
-	int ret, i, got_r = 0;
-	struct fi_context r_context, s_context;
+	int ret;
+	ssize_t sz;
 	struct fi_cq_entry cqe;
-	char s_buffer[128], r_buffer[128];
 
-	for (i = 0; i < 16; i++) {
-		sprintf(s_buffer, "Hello there iter=%d", i);
-		memset(r_buffer, 0, 128);
-		ret = fi_recv(ep[1],
-			      r_buffer,
-			      sizeof(r_buffer),
-			      NULL,
-			      gni_addr[0],
-			      &r_context);
-		cr_assert_eq(ret, FI_SUCCESS, "fi_recv");
-		ret = fi_send(ep[0],
-			      s_buffer,
-			      strlen(s_buffer),
-			      NULL,
-			      gni_addr[1],
-			      &s_context);
-		cr_assert_eq(ret, FI_SUCCESS, "fi_send");
+	rdm_sr_init_data(source, len, 0xab);
+	rdm_sr_init_data(target, len, 0);
 
-		while ((ret = fi_cq_read(msg_cq, &cqe, 1)) == -FI_EAGAIN)
-			pthread_yield();
+	sz = fi_send(ep[0], source, len, NULL, gni_addr[1], target);
+	cr_assert_eq(sz, 0);
 
-		cr_assert((cqe.op_context == &r_context) ||
-			(cqe.op_context == &s_context), "fi_cq_read");
-		got_r = (cqe.op_context == &r_context) ? 1 : 0;
+	sz = fi_recv(ep[1], target, len, NULL, gni_addr[0], source);
+	cr_assert_eq(sz, 0);
 
-		while ((ret = fi_cq_read(msg_cq, &cqe, 1)) == -FI_EAGAIN)
-			pthread_yield();
-
-		if (got_r)
-			cr_assert((cqe.op_context == &s_context), "fi_cq_read");
-		else
-			cr_assert((cqe.op_context == &r_context), "fi_cq_read");
-		got_r = 0;
-
-		cr_assert(strcmp(s_buffer, r_buffer) == 0, "check message");
+	while ((ret = fi_cq_read(msg_cq[0], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
 	}
 
+	cr_assert_eq(ret, 1);
+	cr_assert_eq((uint64_t)cqe.op_context, (uint64_t)target);
+
+	dbg_printf("got send context event!\n");
+
+	while ((ret = fi_cq_read(msg_cq[1], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	cr_assert_eq((uint64_t)cqe.op_context, (uint64_t)source);
+
+	dbg_printf("got recv context event!\n");
+
+	cr_assert(rdm_sr_check_data(source, target, len), "Data mismatch");
+}
+
+Test(rdm_sr, send)
+{
+	rdm_sr_xfer_for_each_size(do_send, 1, BUF_SZ);
+}
+
+/*
+ssize_t fi_sendv(struct fid_ep *ep, const struct iovec *iov,
+		void **desc, size_t count, fi_addr_t dest_addr, void *context);
+ */
+void do_sendv(int len)
+{
+	int ret;
+	ssize_t sz;
+	struct fi_cq_entry cqe;
+	struct iovec iov;
+
+	iov.iov_base = source;
+	iov.iov_len = len;
+
+	rdm_sr_init_data(source, len, 0x25);
+	rdm_sr_init_data(target, len, 0);
+
+	sz = fi_sendv(ep[0], &iov, NULL, 1, gni_addr[1], target);
+	cr_assert_eq(sz, 0);
+
+	sz = fi_recv(ep[1], target, len, NULL, gni_addr[0], source);
+	cr_assert_eq(sz, 0);
+
+	while ((ret = fi_cq_read(msg_cq[0], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	cr_assert_eq((uint64_t)cqe.op_context, (uint64_t)target);
+
+	dbg_printf("got send context event!\n");
+
+	while ((ret = fi_cq_read(msg_cq[1], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	cr_assert_eq((uint64_t)cqe.op_context, (uint64_t)source);
+
+	dbg_printf("got recv context event!\n");
+
+	cr_assert(rdm_sr_check_data(source, target, len), "Data mismatch");
+}
+
+Test(rdm_sr, sendv)
+{
+	rdm_sr_xfer_for_each_size(do_sendv, 1, BUF_SZ);
+}
+
+/*
+ssize_t fi_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
+		uint64_t flags);
+*/
+void do_sendmsg(int len)
+{
+	int ret;
+	ssize_t sz;
+	struct fi_cq_entry cqe;
+	struct fi_msg msg;
+	struct iovec iov;
+
+	iov.iov_base = source;
+	iov.iov_len = len;
+
+	msg.msg_iov = &iov;
+	msg.desc = (void **)&loc_mr;
+	msg.iov_count = 1;
+	msg.addr = gni_addr[1];
+	msg.context = target;
+	msg.data = (uint64_t)target;
+
+	rdm_sr_init_data(source, len, 0xef);
+	rdm_sr_init_data(target, len, 0);
+
+	sz = fi_sendmsg(ep[0], &msg, 0);
+	cr_assert_eq(sz, 0);
+
+	sz = fi_recv(ep[1], target, len, NULL, gni_addr[0], source);
+	cr_assert_eq(sz, 0);
+
+	while ((ret = fi_cq_read(msg_cq[0], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	cr_assert_eq((uint64_t)cqe.op_context, (uint64_t)target);
+
+	dbg_printf("got send context event!\n");
+
+	while ((ret = fi_cq_read(msg_cq[1], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	cr_assert_eq((uint64_t)cqe.op_context, (uint64_t)source);
+
+	dbg_printf("got recv context event!\n");
+
+	cr_assert(rdm_sr_check_data(source, target, len), "Data mismatch");
+}
+
+Test(rdm_sr, sendmsg)
+{
+	rdm_sr_xfer_for_each_size(do_sendmsg, 1, BUF_SZ);
+}
+
+/*
+ssize_t fi_inject(struct fid_ep *ep, void *buf, size_t len,
+		fi_addr_t dest_addr);
+*/
+#define INJECT_SIZE 64
+void do_inject(int len)
+{
+	int ret;
+	ssize_t sz;
+	struct fi_cq_entry cqe;
+
+	rdm_sr_init_data(source, len, 0x23);
+	rdm_sr_init_data(target, len, 0);
+
+	sz = fi_inject(ep[0], source, len, gni_addr[1]);
+	cr_assert_eq(sz, 0);
+
+	sz = fi_recv(ep[1], target, len, NULL, gni_addr[0], source);
+	cr_assert_eq(sz, 0);
+
+	while ((ret = fi_cq_read(msg_cq[1], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	cr_assert_eq((uint64_t)cqe.op_context, (uint64_t)source);
+
+	dbg_printf("got recv context event!\n");
+
+	cr_assert(rdm_sr_check_data(source, target, len), "Data mismatch");
+}
+
+Test(rdm_sr, inject)
+{
+	rdm_sr_xfer_for_each_size(do_inject, 1, INJECT_SIZE);
+}
+
+/*
+ssize_t fi_senddata(struct fid_ep *ep, void *buf, size_t len,
+		void *desc, uint64_t data, fi_addr_t dest_addr, void *context);
+*/
+void do_senddata(int len)
+{
+	int ret;
+	ssize_t sz;
+	struct fi_cq_entry cqe;
+
+	rdm_sr_init_data(source, len, 0xab);
+	rdm_sr_init_data(target, len, 0);
+
+	sz = fi_senddata(ep[0], source, len, loc_mr, (uint64_t)source,
+			 gni_addr[1], target);
+	cr_assert_eq(sz, 0);
+
+	sz = fi_recv(ep[1], target, len, NULL, gni_addr[0], source);
+	cr_assert_eq(sz, 0);
+
+	while ((ret = fi_cq_read(msg_cq[0], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	cr_assert_eq((uint64_t)cqe.op_context, (uint64_t)target);
+
+	dbg_printf("got send context event!\n");
+
+	/* TODO get REMOTE_CQ_DATA */
+	while ((ret = fi_cq_read(msg_cq[1], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	cr_assert_eq((uint64_t)cqe.op_context, (uint64_t)source);
+
+	dbg_printf("got recv context event!\n");
+
+	cr_assert(rdm_sr_check_data(source, target, len), "Data mismatch");
+}
+
+Test(rdm_sr, senddata)
+{
+	rdm_sr_xfer_for_each_size(do_senddata, 1, BUF_SZ);
+}
+
+/*
+ssize_t fi_injectdata(struct fid_ep *ep, const void *buf, size_t len,
+		uint64_t data, fi_addr_t dest_addr)
+*/
+void do_injectdata(int len)
+{
+	int ret;
+	ssize_t sz;
+	struct fi_cq_entry cqe;
+
+	rdm_sr_init_data(source, len, 0xab);
+	rdm_sr_init_data(target, len, 0);
+
+	sz = fi_injectdata(ep[0], source, len, (uint64_t)source, gni_addr[1]);
+	cr_assert_eq(sz, 0);
+
+	sz = fi_recv(ep[1], target, len, NULL, gni_addr[0], source);
+	cr_assert_eq(sz, 0);
+
+	/* TODO get REMOTE_CQ_DATA */
+	while ((ret = fi_cq_read(msg_cq[1], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	cr_assert_eq((uint64_t)cqe.op_context, (uint64_t)source);
+
+	dbg_printf("got recv context event!\n");
+
+	cr_assert(rdm_sr_check_data(source, target, len), "Data mismatch");
+}
+
+Test(rdm_sr, injectdata)
+{
+	rdm_sr_xfer_for_each_size(do_injectdata, 1, INJECT_SIZE);
 }


### PR DESCRIPTION
-Modify fi_send() to use generic _gnix_send() function.
-Implement send, sendv, sendmsg, inject, senddata, injectdata.
-Add gnix_msg.c/h to hold EP send/recv logic.
-Add tests for each fi_send variant to test/rdm_sr.c

Signed-off-by: Zach Tiffany ztiffany@cray.com

@sungeunchoi @hppritcha @jswaro @jshimek
