### PR TITLE
Reorganize NIC progress.

### DIFF
--- a/prov/gni/include/gnix_ep.h
+++ b/prov/gni/include/gnix_ep.h
@@ -80,19 +80,6 @@ extern smsg_completer_fn_t gnix_ep_smsg_completers[];
 int _gnix_ep_eager_msg_w_data_match(struct gnix_fid_ep *ep, void *msg,
 				    struct gnix_address addr, size_t len,
 				    uint64_t imm, uint64_t sflags);
-
-/**
- * @brief  dequeue smsg messages that arrived before vc fully
- *         initialized at receiver
- *
- * @param[in] vc        pointer to a previously allocated vc
- * @return              FI_SUCCESS on success meaning that no errors
- *                      were encountered dequeing SMSG messages, -FI_EINVAL
- *                      if an invalid argument is supplied,
- *                      -FI_EAGAIN if the SMSG channel is in an
- *                      invalid state.
- */
-int _gnix_ep_vc_dequeue_smsg(struct gnix_vc *vc);
 /*
  * typedefs for function vectors used to steer send/receive/rma/amo requests,
  * i.e. fi_send, fi_recv, etc. to ep type specific methods

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -131,8 +131,8 @@ struct gnix_nic {
 	struct dlist_entry tx_desc_free_list;
 	struct gnix_tx_descriptor *tx_desc_base;
 	atomic_t outstanding_fab_reqs_nic;
-	fastlock_t wq_lock;
-	struct list_head nic_wq;
+	fastlock_t pending_vc_lock;
+	struct slist pending_vcs;
 	uint8_t ptag;
 	uint32_t cookie;
 	uint32_t device_id;

--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -43,6 +43,7 @@ extern "C" {
 #endif /* HAVE_CONFIG_H */
 
 #include "gnix.h"
+#include "gnix_bitmap.h"
 
 /*
  * mode bits
@@ -51,6 +52,10 @@ extern "C" {
 #define GNIX_VC_MODE_IN_HT		(1U << 1)
 #define GNIX_VC_MODE_DG_POSTED		(1U << 2)
 #define GNIX_VC_MODE_PENDING_MSGS	(1U << 3)
+
+/* VC flags */
+#define GNIX_VC_FLAG_SCHEDULED		0
+#define GNIX_VC_FLAG_RX_PENDING		1
 
 /*
  * defines for connection state for gnix VC
@@ -106,6 +111,8 @@ struct gnix_vc {
 	enum gnix_vc_conn_state conn_state;
 	int vc_id;
 	int modes;
+	struct slist_entry pending_list;
+	gnix_bitmap_t flags; /* We're missing regular bit ops */
 };
 
 /*
@@ -200,7 +207,11 @@ static inline enum gnix_vc_conn_state _gnix_vc_state(struct gnix_vc *vc)
 }
 
 
-int _gnix_vc_push_tx_reqs(struct gnix_vc *vc);
+int _gnix_vc_schedule(struct gnix_vc *vc);
+int _gnix_vc_schedule_tx(struct gnix_vc *vc);
+struct gnix_vc *_gnix_nic_next_pending_vc(struct gnix_nic *nic);
+int _gnix_vc_dequeue_smsg(struct gnix_vc *vc);
+int _gnix_vc_progress(struct gnix_vc *vc);
 int _gnix_vc_queue_tx_req(struct gnix_fab_req *req);
 
 /**

--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -256,7 +256,6 @@ static int __gnix_cq_progress(struct gnix_fid_cq *cq)
 	rwlock_rdlock(&cq->nic_lock);
 
 	dlist_for_each_safe(&cq->poll_nics, pnic, tmp, list) {
-		GNIX_INFO(FI_LOG_CQ, "progressing nic %p\n", pnic->nic);
 		rc = _gnix_nic_progress(pnic->nic);
 		if (rc) {
 			GNIX_WARN(FI_LOG_CQ,

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -238,10 +238,11 @@ static int __comp_eager_msg_w_data(void *data)
 			   ret);
 	}
 
-	/* We could have requests waiting for TXDs or FI_FENCE operations.  Try
-	 * to push the queue now. */
 	atomic_dec(&req->vc->outstanding_tx_reqs);
-	_gnix_vc_push_tx_reqs(req->vc);
+
+	/* We could have requests waiting for TXDs or FI_FENCE operations.
+	 * Schedule this VC to push any such TXs. */
+	_gnix_vc_schedule_tx(req->vc);
 
 	_gnix_fr_free(ep, req);
 

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -65,136 +65,120 @@ __desc_lkup_by_id(struct gnix_nic *nic, int desc_id)
 	return tx_desc;
 }
 
-/*
- * function to process GNI CQ RX CQES to progress a gnix_nic
- * -note that the callback functions for the vc's are suppose to
- * include the following call sequence to release the SMSG message
- * and unlock the nic lock:
- *
-	status = GNI_SmsgRelease(vc->ep);
-	fastlock_release(&nic->lock);
- *
- * The idea here is that is possible that the callback function
- * may need to have some kind of post-nic-lock work to do.
- * Want to avoid using recursive locks.
- */
-static inline int __process_smsg(struct gnix_vc *vc)
+static int __nic_rx_overrun(struct gnix_nic *nic)
 {
-	int ret = FI_SUCCESS;
-	int status = GNI_RC_SUCCESS;
-	struct gnix_nic *nic = vc->ep->nic;
-	uint8_t tag = GNI_SMSG_ANY_TAG;
-	void *msg_ptr;
+	int i, max_id, ret;
+	struct gnix_vc *vc;
+	gni_return_t status;
+	gni_cq_entry_t cqe;
 
+	/* clear out the CQ */
+	while ((status = GNI_CqGetEvent(nic->rx_cq, &cqe)) == GNI_RC_SUCCESS);
+	assert(status == GNI_RC_NOT_DONE);
+
+	fastlock_acquire(&nic->vc_id_lock);
+	max_id = nic->vc_id_table_count;
+	fastlock_release(&nic->vc_id_lock);
 	/*
-	 * the nic lock is already held when this
-	 * function is invoked
+	 * TODO: optimization would
+	 * be to keep track of last time
+	 * this happened and where smsg msgs.
+	 * were found.
 	 */
-
-	do {
-		status = GNI_SmsgGetNextWTag(vc->gni_ep,
-					     &msg_ptr,
-					     &tag);
-		if (status == GNI_RC_SUCCESS) {
-			ret = nic->smsg_callbacks[tag](vc,
-						       msg_ptr);
+	for (i = 0; i < max_id; i++) {
+		ret = _gnix_test_bit(&nic->vc_id_bitmap, i);
+		if (ret) {
+			vc = __gnix_nic_elem_by_rem_id(nic, i);
+			ret = _gnix_vc_schedule(vc);
 			assert(ret == FI_SUCCESS);
 		}
-	} while (status == GNI_RC_SUCCESS);
-
-	if (status != GNI_RC_NOT_DONE) {
-		GNIX_WARN(FI_LOG_EP_DATA,
-			  "GNI_SmsgGetNextWTag returned %s\n",
-			  gni_err_str[status]);
-		ret = gnixu_to_fi_errno(status);
 	}
+
+	return FI_SUCCESS;
+}
+
+static int process_rx_cqe(struct gnix_nic *nic, gni_cq_entry_t cqe)
+{
+	int ret = FI_SUCCESS, vc_id = 0;
+	struct gnix_vc *vc;
+
+	vc_id =  GNI_CQ_GET_INST_ID(cqe);
+	vc = __gnix_nic_elem_by_rem_id(nic, vc_id);
+
+#if 1 /* Process RX inline with arrival of an RX CQE. */
+	if (unlikely(vc->conn_state != GNIX_VC_CONNECTED)) {
+		GNIX_INFO(FI_LOG_EP_CTRL,
+			  "Scheduling VC for RX processing (%p)\n",
+			  vc);
+		_gnix_set_bit(&vc->flags, GNIX_VC_FLAG_RX_PENDING);
+		ret = _gnix_vc_schedule(vc);
+		assert(ret == FI_SUCCESS);
+	} else {
+		GNIX_INFO(FI_LOG_EP_CTRL,
+			  "Processing VC RX (%p)\n",
+			  vc);
+		ret = _gnix_vc_dequeue_smsg(vc);
+		if (ret != FI_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+					"_gnix_vc_dqueue_smsg returned %d\n",
+					ret);
+		}
+	}
+#else /* Defer RX processing until after the RX CQ is cleared. */
+	_gnix_set_bit(&vc->flags, GNIX_VC_FLAG_RX_PENDING);
+	ret = _gnix_vc_schedule(vc);
+	assert(ret == FI_SUCCESS);
+#endif
 
 	return ret;
 }
 
 static int __nic_rx_progress(struct gnix_nic *nic)
 {
-	int i, ret = FI_SUCCESS;
-	int vc_id = 0;
-	int max_id;
-	gni_return_t  status = GNI_RC_NOT_DONE;
+	int ret = FI_SUCCESS;
+	gni_return_t status = GNI_RC_NOT_DONE;
 	gni_cq_entry_t cqe;
-	struct gnix_vc *vc;
 
-	/*
-	 * first see if there are any CQE's on the
-	 * tx cq. Calling GNI_CqTestEvent does not require
-	 * getting the nic lock
-	 */
-
-#if 0
 	status = GNI_CqTestEvent(nic->rx_cq);
 	if (status == GNI_RC_NOT_DONE)
 		return FI_SUCCESS;
-#endif
 
 	fastlock_acquire(&nic->lock);
-try_again:
-	status = GNI_CqGetEvent(nic->rx_cq, &cqe);
-	if (status  == GNI_RC_NOT_DONE) {
-		fastlock_release(&nic->lock);
-		return FI_SUCCESS;
-	}
 
-	/*
-	 * no CQ overrun
-	 */
-	if (status == GNI_RC_SUCCESS) {
-
-		vc_id =  GNI_CQ_GET_INST_ID(cqe);
-		vc = __gnix_nic_elem_by_rem_id(nic, vc_id);
-		if (vc->conn_state != GNIX_VC_CONNECTED) {
-			vc->modes |= GNIX_VC_MODE_PENDING_MSGS;
-			ret = _gnix_vc_add_to_wq(vc);
-			goto out;
+	do {
+		status = GNI_CqGetEvent(nic->rx_cq, &cqe);
+		if (unlikely(status == GNI_RC_NOT_DONE)) {
+			ret = FI_SUCCESS;
+			break;
 		}
 
-		ret = __process_smsg(vc);
-		if (ret == FI_SUCCESS)
-			goto try_again;
-
-	} else if (status == GNI_RC_ERROR_RESOURCE) {
-		assert(GNI_CQ_OVERRUN(cqe));
-		/*
-		 * okay, CQ is overrun, have to check
-		 * all vc's - this is considered a kind of
-		 * recovery mode
-		 */
-		fastlock_acquire(&nic->vc_id_lock);
-		max_id = nic->vc_id_table_count;
-		fastlock_release(&nic->vc_id_lock);
-		/*
-		 * TODO: optimization would
-		 * be to keep track of last time
-		 * this happened and where smsg msgs.
-		 * were found.
-		 */
-		for (i = 0; i < max_id; i++) {
-			ret = _gnix_test_bit(&nic->vc_id_bitmap, i);
-			if (ret) {
-				vc = __gnix_nic_elem_by_rem_id(nic, i);
-				ret = __process_smsg(vc);
-				assert(ret == FI_SUCCESS);
+		if (likely(status == GNI_RC_SUCCESS)) {
+			/* Find and schedule the associated VC. */
+			ret = process_rx_cqe(nic, cqe);
+			if (ret != FI_SUCCESS) {
+				GNIX_WARN(FI_LOG_EP_DATA,
+					  "process_rx_cqe() failed: %d\n",
+					  ret);
 			}
+		} else if (status == GNI_RC_ERROR_RESOURCE) {
+			/* The remote CQ was overrun.  Events related to any VC
+			 * could have been missed.  Schedule each VC to be sure
+			 * all messages are processed. */
+			assert(GNI_CQ_OVERRUN(cqe));
+			__nic_rx_overrun(nic);
+		} else {
+			GNIX_WARN(FI_LOG_EP_DATA,
+				  "GNI_CqGetEvent returned %s\n",
+				  gni_err_str[status]);
+			ret = gnixu_to_fi_errno(status);
+			break;
 		}
-		goto try_again;
-	} else {
-		GNIX_WARN(FI_LOG_EP_DATA,
-			"GNI_SmsgGetNextWTag returned %s\n",
-			gni_err_str[status]);
-		ret = gnixu_to_fi_errno(status);
-	}
+	} while (1);
 
-out:
 	fastlock_release(&nic->lock);
+
 	return ret;
 }
-
 
 /*
  * function to process GNI CQ TX CQES to progress a gnix_nic
@@ -209,12 +193,6 @@ static int __nic_tx_progress(struct gnix_nic *nic)
 	gni_cq_entry_t cqe;
 	struct gnix_tx_descriptor *gnix_tdesc = NULL;
 	unsigned int recov;
-
-	/*
-	 * first see if there are any CQE's on the
-	 * tx cq. Calling GNI_CqTestEvent does not require
-	 * getting the nic lock
-	 */
 
 try_again:
 	fastlock_acquire(&nic->lock);
@@ -317,63 +295,40 @@ err:
 
 }
 
+int __nic_vc_progress(struct gnix_nic *nic)
+{
+	struct gnix_vc *vc;
+	int ret;
+
+	while ((vc = _gnix_nic_next_pending_vc(nic))) {
+		ret = _gnix_vc_progress(vc);
+		if (ret != FI_SUCCESS) {
+			GNIX_INFO(FI_LOG_EP_CTRL,
+				  "Rescheduling VC (%p)\n", vc);
+			ret = _gnix_vc_schedule(vc);
+			assert(ret == FI_SUCCESS);
+		}
+	}
+
+	return FI_SUCCESS;
+}
+
 int _gnix_nic_progress(struct gnix_nic *nic)
 {
 	int ret = FI_SUCCESS;
-	int complete;
-	struct gnix_work_req *p = NULL;
 
 	ret =  __nic_tx_progress(nic);
-	if (ret != FI_SUCCESS)
+	if (unlikely(ret != FI_SUCCESS))
 		return ret;
 
 	ret = __nic_rx_progress(nic);
-	if (ret != FI_SUCCESS)
+	if (unlikely(ret != FI_SUCCESS))
 		return ret;
 
-	/*
-	 * see what's going in the work queue
-	 */
-
-check_again:
-	if (list_empty(&nic->nic_wq))
+	ret = __nic_vc_progress(nic);
+	if (unlikely(ret != FI_SUCCESS))
 		return ret;
 
-	fastlock_acquire(&nic->wq_lock);
-	p = list_top(&nic->nic_wq, struct gnix_work_req, list);
-	if (p == NULL) {
-		fastlock_release(&nic->wq_lock);
-		return ret;
-	}
-
-	gnix_list_del_init(&p->list);
-	fastlock_release(&nic->wq_lock);
-
-	assert(p->progress_fn);
-
-	ret = p->progress_fn(p->data, &complete);
-	if (ret != FI_SUCCESS) {
-		GNIX_WARN(FI_LOG_EP_DATA,
-			  "progress_func returned with erro - %d\n",
-			  ret );
-		goto err;
-	}
-
-	if (complete == 1) {
-		if (p->completer_fn) {
-			ret = p->completer_fn(p->completer_data);
-			free(p);
-			if (ret != FI_SUCCESS)
-				goto err;
-		}
-		goto check_again;  /* we're getting stuff done, try again */
-	} else {
-		fastlock_acquire(&nic->wq_lock);
-		list_add_tail(&nic->nic_wq, &p->list);
-		fastlock_release(&nic->wq_lock);
-	}
-
-err:
 	return ret;
 }
 
@@ -814,8 +769,8 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 		if (ret != FI_SUCCESS)
 			goto err1;
 
-		fastlock_init(&nic->wq_lock);
-		list_head_init(&nic->nic_wq);
+		fastlock_init(&nic->pending_vc_lock);
+		slist_init(&nic->pending_vcs);
 
 		atomic_initialize(&nic->ref_cnt, 1);
 		atomic_initialize(&nic->outstanding_fab_reqs_nic, 0);

--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -83,10 +83,11 @@ static int __gnix_rma_fab_req_complete(void *arg)
 				  "_gnix_cntr_inc() failed: %d\n", rc);
 	}
 
-	/* We could have requests waiting for TXDs or FI_FENCE operations.  Try
-	 * to push the queue now. */
 	atomic_dec(&req->vc->outstanding_tx_reqs);
-	_gnix_vc_push_tx_reqs(req->vc);
+
+	/* We could have requests waiting for TXDs or FI_FENCE operations.
+	 * Schedule this VC to push any such TXs. */
+	_gnix_vc_schedule_tx(req->vc);
 
 	_gnix_fr_free(ep, req);
 

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -334,7 +334,7 @@ static int __gnix_vc_hndl_con_match_con(struct gnix_datagram *dgram,
 			  "_gnix_dgram_free returned %d\n", ret);
 	vc->dgram = NULL;
 
-	ret = _gnix_vc_add_to_wq(vc);
+	ret = _gnix_vc_schedule(vc);
 	if (ret == FI_SUCCESS)
 		ret = _gnix_nic_progress(nic);
 
@@ -551,7 +551,7 @@ static int __gnix_vc_hndl_wc_match_con(struct gnix_datagram *dgram,
 	 * put the connected vc in to the work queue of the gnix_nic
 	 */
 
-	ret = _gnix_vc_add_to_wq(vc);
+	ret = _gnix_vc_schedule(vc);
 	if (ret == FI_SUCCESS) {
 		ret = _gnix_nic_progress(nic);
 		goto out;
@@ -808,76 +808,6 @@ static int __gnix_vc_connect_comp_fn(void *data)
 	return FI_SUCCESS;
 }
 
-static int __gnix_vc_prog_fn(void *data, int *complete_ptr)
-{
-	int ret;
-	struct gnix_vc *vc = (struct gnix_vc *)data;
-	struct gnix_cm_nic *cm_nic;
-
-	*complete_ptr = 0;
-
-	/*
-	 * TODO: this is temporary and will be removed
-	 * once the cm_nic functionality goes in to
-	 * nic functionality (see issue 218)
-	 */
-	if (vc->conn_state < GNIX_VC_CONNECTED) {
-		cm_nic = vc->ep->cm_nic;
-		ret = _gnix_cm_nic_progress(cm_nic);
-		if (ret != FI_SUCCESS)
-			GNIX_WARN(FI_LOG_EP_CTRL,
-				  "_gnix_cm_nic_progress returned %d\n",
-				   ret);
-		goto err;
-	}
-
-	/*
-	 * check for pending messages
-	 */
-
-	if ((vc->modes & GNIX_VC_MODE_PENDING_MSGS) &&
-		(vc->conn_state == GNIX_VC_CONNECTED)) {
-		ret = _gnix_ep_vc_dequeue_smsg(vc);
-		if (ret != FI_SUCCESS) {
-			GNIX_WARN(FI_LOG_EP_CTRL,
-				  "_gnix_ep_vc_dqueue returned %d\n",
-				   ret);
-			goto err;
-		}
-	}
-
-	ret = _gnix_vc_push_tx_reqs(vc);
-	if (ret != FI_SUCCESS) {
-		GNIX_WARN(FI_LOG_EP_CTRL,
-			  "_gnix_ep_push_vc_sendq returned %d\n",
-			   ret);
-		goto err;
-	}
-
-	fastlock_acquire(&vc->tx_queue_lock);
-
-	if (slist_empty(&vc->tx_queue) &&
-	    !(vc->modes & GNIX_VC_MODE_PENDING_MSGS))
-		*complete_ptr = 1;
-
-	fastlock_release(&vc->tx_queue_lock);
-#if 0
-		if ((ret == -FI_ENOSPC) || (ret == -FI_EOPBADSTATE))
-			ret = FI_SUCCESS;  /* FI_ENOSPC is not an error */
-#endif
-
-err:
-	return ret;
-}
-
-static int __gnix_vc_comp_fn(void *data)
-{
-	struct gnix_vc *vc = (struct gnix_vc *)data;
-
-	vc->modes &= ~GNIX_VC_MODE_IN_WQ;
-	return FI_SUCCESS;
-}
-
 /*******************************************************************************
  * Internal API functions
  ******************************************************************************/
@@ -925,6 +855,8 @@ int _gnix_vc_alloc(struct gnix_fid_ep *ep_priv, fi_addr_t dest_addr,
 	slist_init(&vc_ptr->tx_queue);
 	fastlock_init(&vc_ptr->tx_queue_lock);
 	atomic_initialize(&vc_ptr->outstanding_tx_reqs, 0);
+	ret = _gnix_alloc_bitmap(&vc_ptr->flags, 1);
+	assert(!ret);
 
 	/*
 	 * we need an id for the vc to allow for quick lookup
@@ -1220,37 +1152,96 @@ int _gnix_vc_disconnect(struct gnix_vc *vc)
 	return FI_SUCCESS;
 }
 
-int _gnix_vc_add_to_wq(struct gnix_vc *vc)
+int _gnix_vc_schedule(struct gnix_vc *vc)
 {
 	struct gnix_nic *nic = vc->ep->nic;
-	struct gnix_work_req *work_req;
 
-	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
-
-	if (!(vc->modes & GNIX_VC_MODE_IN_WQ)) {
-
-		work_req = calloc(1, sizeof(*work_req));
-		if (work_req == NULL)
-			return -FI_ENOMEM;
-
-		work_req->progress_fn = __gnix_vc_prog_fn;
-		work_req->data = vc;
-
-		work_req->completer_fn = __gnix_vc_comp_fn;
-		work_req->completer_data = vc;
-
-		fastlock_acquire(&nic->wq_lock);
-		list_add_tail(&nic->nic_wq, &work_req->list);
-		fastlock_release(&nic->wq_lock);
-		vc->modes |= GNIX_VC_MODE_IN_WQ;
+	if (!_gnix_test_and_set_bit(&vc->flags, GNIX_VC_FLAG_SCHEDULED)) {
+		fastlock_acquire(&nic->pending_vc_lock);
+		slist_insert_tail(&vc->pending_list, &nic->pending_vcs);
+		fastlock_release(&nic->pending_vc_lock);
+		GNIX_INFO(FI_LOG_EP_CTRL, "Scheduled VC (%p)\n", vc);
 	}
 
 	return FI_SUCCESS;
 }
 
+int _gnix_vc_schedule_tx(struct gnix_vc *vc)
+{
+	int ret __attribute__((unused));
+
+	if (!slist_empty(&vc->tx_queue)) {
+		ret = _gnix_vc_schedule(vc);
+		assert(ret == FI_SUCCESS);
+	}
+
+	return FI_SUCCESS;
+}
+
+struct gnix_vc *_gnix_nic_next_pending_vc(struct gnix_nic *nic)
+{
+	struct slist_entry *entry;
+	struct gnix_vc *vc = NULL;
+
+	fastlock_acquire(&nic->pending_vc_lock);
+	entry = slist_remove_head(&nic->pending_vcs);
+	fastlock_release(&nic->pending_vc_lock);
+
+	if (entry) {
+		vc = (struct gnix_vc *)container_of(entry,
+						    struct gnix_vc,
+						    pending_list);
+		GNIX_INFO(FI_LOG_EP_CTRL, "Dequeued VC (%p)\n", vc);
+
+		_gnix_clear_bit(&vc->flags, GNIX_VC_FLAG_SCHEDULED);
+	}
+
+	return vc;
+}
+
+int _gnix_vc_dequeue_smsg(struct gnix_vc *vc)
+{
+	int ret = FI_SUCCESS;
+	struct gnix_nic *nic;
+	gni_return_t status;
+	void *msg_ptr;
+	uint8_t tag = GNI_SMSG_ANY_TAG;
+
+	GNIX_TRACE(FI_LOG_EP_DATA, "\n");
+
+	assert(vc->gni_ep != NULL);
+	assert(vc->conn_state == GNIX_VC_CONNECTED);
+
+	nic = vc->ep->nic;
+	assert(nic != NULL);
+
+	do {
+		status = GNI_SmsgGetNextWTag(vc->gni_ep,
+					     &msg_ptr,
+					     &tag);
+
+		if (status == GNI_RC_SUCCESS) {
+			GNIX_INFO(FI_LOG_EP_DATA, "Found RX (%p)\n", vc);
+			ret = nic->smsg_callbacks[tag](vc, msg_ptr);
+			assert(ret == FI_SUCCESS);
+		} else if (status == GNI_RC_NOT_DONE) {
+			break;
+		} else {
+			GNIX_WARN(FI_LOG_EP_DATA,
+				"GNI_SmsgGetNextWTag returned %s\n",
+				gni_err_str[status]);
+			ret = gnixu_to_fi_errno(status);
+			assert(0);
+			break;
+		}
+	} while (status != GNI_RC_NOT_DONE);
+
+	return ret;
+}
+
 int _gnix_vc_queue_tx_req(struct gnix_fab_req *req)
 {
-	int rc, add_vc_to_wq = 0;
+	int rc, queue_tx = 0;
 	struct gnix_vc *vc = req->vc;
 
 	fastlock_acquire(&vc->tx_queue_lock);
@@ -1259,61 +1250,47 @@ int _gnix_vc_queue_tx_req(struct gnix_fab_req *req)
 		/* Fence request must be queued until all outstanding TX
 		 * requests are completed.  Subsequent requests will be queued
 		 * due to non-empty tx_queue. */
-		req->modes |= GNIX_FAB_RQ_M_IN_SEND_QUEUE;
-		slist_insert_tail(&req->slist, &vc->tx_queue);
-		add_vc_to_wq = 1;
+		queue_tx = 1;
 		GNIX_INFO(FI_LOG_EP_DATA,
 			  "Queued FI_FENCE request (%p) on VC\n",
 			  req);
-	} else if (likely(vc->conn_state == GNIX_VC_CONNECTED) &&
+	} else if (vc->conn_state == GNIX_VC_CONNECTED &&
 		   slist_empty(&vc->tx_queue)) {
 		/* try to initiate request */
 		rc = req->send_fn(req);
-		if (rc) {
-			req->modes |= GNIX_FAB_RQ_M_IN_SEND_QUEUE;
-			slist_insert_tail(&req->slist, &vc->tx_queue);
+		if (rc != FI_SUCCESS) {
+			queue_tx = 1;
 			GNIX_INFO(FI_LOG_EP_DATA,
 				  "Queued request (%p) on full VC\n",
 				  req);
-			add_vc_to_wq = 1;
 		}
 		atomic_inc(&vc->outstanding_tx_reqs);
 	} else {
-		req->modes |= GNIX_FAB_RQ_M_IN_SEND_QUEUE;
-		slist_insert_tail(&req->slist, &vc->tx_queue);
+		queue_tx = 1;
 		GNIX_INFO(FI_LOG_EP_DATA,
 			  "Queued request (%p) on busy VC\n",
 			  req);
-		add_vc_to_wq = 1;
+	}
+
+	if (unlikely(queue_tx)) {
+		slist_insert_tail(&req->slist, &vc->tx_queue);
+		_gnix_vc_schedule(vc);
 	}
 
 	fastlock_release(&vc->tx_queue_lock);
-
-	if (add_vc_to_wq)
-		rc = _gnix_vc_add_to_wq(vc);
-
-	/* TODO unlock VC */
 
 	return FI_SUCCESS;
 }
 
 int _gnix_vc_push_tx_reqs(struct gnix_vc *vc)
 {
-	int ret = FI_SUCCESS;
+	int ret, fi_rc = FI_SUCCESS;
 	struct slist *list;
 	struct slist_entry *item;
 	struct gnix_fab_req *req;
 
-	/*
-	 * TODO: lock VC
-	 */
-
-	/*
-	 * if VC is not in connected state can't push sends
-	 */
-
 	if (vc->conn_state != GNIX_VC_CONNECTED)
-		return -FI_EAGAIN;
+		return FI_SUCCESS;
 
 	fastlock_acquire(&vc->tx_queue_lock);
 
@@ -1333,30 +1310,83 @@ int _gnix_vc_push_tx_reqs(struct gnix_vc *vc)
 		}
 
 		ret = req->send_fn(req);
-		if (ret == -EAGAIN) {
-			GNIX_INFO(FI_LOG_EP_DATA,
-				  "TX request queue stalled: %p\n",
-				  req);
-			break;
-		} else if (ret) {
-			GNIX_WARN(FI_LOG_EP_DATA,
-				  "Failed to push TX request %p: %d\n",
-				  req, ret);
-		} else {
+		if (ret == FI_SUCCESS) {
 			atomic_inc(&vc->outstanding_tx_reqs);
 			GNIX_INFO(FI_LOG_EP_DATA,
 				  "TX request processed: %p\n",
 				  req);
+		} else if (ret == -FI_EAGAIN) {
+			GNIX_INFO(FI_LOG_EP_DATA,
+				  "TX request queue stalled: %p\n",
+				  req);
+			break;
+		} else {
+			GNIX_WARN(FI_LOG_EP_DATA,
+				  "Failed to push TX request %p: %d\n",
+				  req, ret);
+			fi_rc = ret;
+			assert(0);
+			break;
 		}
 
 		slist_remove_head(&vc->tx_queue);
-		req->modes &= ~GNIX_FAB_RQ_M_IN_SEND_QUEUE;
 		item = list->head;
 	}
 
 	fastlock_release(&vc->tx_queue_lock);
 
-	return ret;
+	return fi_rc;
+}
+
+int _gnix_vc_progress(struct gnix_vc *vc)
+{
+	int ret;
+	struct gnix_cm_nic *cm_nic;
+
+	/*
+	 * TODO: this is temporary and will be removed
+	 * once the cm_nic functionality goes in to
+	 * nic functionality (see issue 218)
+	 */
+	if (unlikely(vc->conn_state < GNIX_VC_CONNECTED)) {
+		cm_nic = vc->ep->cm_nic;
+		ret = _gnix_cm_nic_progress(cm_nic);
+		if (ret != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "_gnix_cm_nic_progress() failed: %d\n",
+				   ret);
+	}
+
+	if (unlikely(vc->conn_state < GNIX_VC_CONNECTED)) {
+		/* waiting to connect, check back later */
+		return -FI_EAGAIN;
+	}
+
+	/* Process pending RXs */
+	if (unlikely(
+	    _gnix_test_and_clear_bit(&vc->flags, GNIX_VC_FLAG_RX_PENDING))) {
+		fastlock_acquire(&vc->ep->nic->lock);
+		ret = _gnix_vc_dequeue_smsg(vc);
+		fastlock_release(&vc->ep->nic->lock);
+		if (unlikely(ret != FI_SUCCESS)) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "_gnix_vc_dequeue_smsg() failed: %d\n",
+				  ret);
+			return ret;
+		}
+	}
+
+	/* Initiate pending TXs */
+	if (!slist_empty(&vc->tx_queue)) {
+		ret = _gnix_vc_push_tx_reqs(vc);
+		if ((ret != FI_SUCCESS)) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "_gnix_vc_push_tx_reqs() failed: %d\n",
+				  ret);
+		}
+	}
+
+	return FI_SUCCESS;
 }
 
 static int __gnix_ep_get_vc(struct gnix_fid_ep *ep, fi_addr_t dest_addr,


### PR DESCRIPTION
-Make a clear line between NIC progress/VC progress interfaces
-Remove the malloc() from _gnix_vc_add_to_wq().
-_gnix_vc_schedule replaces _gnix_vc_add_to_wq.
-Improve VC progress thread safety.
-Experiment with deferred SMSG processing.

Signed-off-by: Zach Tiffany ztiffany@cray.com

@sungeunchoi @hppritcha @jswaro @jshimek

This is PR #284 applied cleanly to master.  This also includes 2 changes that Sung suggested in PR #284.
