### PR TITLE
Initial implementation of the tag matching system

### DIFF
--- a/prov/gni/Makefile.am
+++ b/prov/gni/Makefile.am
@@ -35,7 +35,8 @@ _gni_files = \
 	prov/gni/src/gnix_hashtable.c \
 	prov/gni/src/gnix_mbox_allocator.c \
 	prov/gni/src/gnix_rma.c \
-	prov/gni/src/gnix_msg.c
+	prov/gni/src/gnix_msg.c \
+	prov/gni/src/gnix_tags.c
 
 if HAVE_CRITERION
 bin_PROGRAMS += prov/gni/test/gnitest
@@ -59,7 +60,8 @@ prov_gni_test_gnitest_SOURCES = \
 	prov/gni/test/rdm_rma.c \
 	prov/gni/test/rdm_sr.c \
 	prov/gni/test/cntr.c \
-	prov/gni/test/dom.c
+	prov/gni/test/dom.c \
+	prov/gni/test/tags.c
 
 prov_gni_test_gnitest_LDFLAGS = -static
 prov_gni_test_gnitest_CPPFLAGS = $(AM_CPPFLAGS)

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -68,6 +68,7 @@ extern "C" {
 #include "gnix_mr.h"
 #include "gnix_cq.h"
 #include "fi_ext_gni.h"
+#include "gnix_tags.h"
 
 #define GNI_MAJOR_VERSION 0
 #define GNI_MINOR_VERSION 5
@@ -381,7 +382,7 @@ struct gnix_fab_req_msg {
 struct gnix_fab_req {
 	struct slist_entry        slist;
 	uint64_t tag;
-	uint64_t mask_bits;
+	uint64_t ignore_bits;
 	struct gnix_address addr;
 	enum gnix_fab_req_type    type;
 	struct gnix_fid_ep        *gnix_ep;
@@ -404,6 +405,7 @@ struct gnix_fab_req {
 	uint64_t imm;
 	size_t len;
 	uint64_t flags;
+	struct gnix_tag_list_element tle;
 	union {
 		struct gnix_fab_req_rma rma;
 		struct gnix_fab_req_msg msg;

--- a/prov/gni/include/gnix_tags.h
+++ b/prov/gni/include/gnix_tags.h
@@ -1,0 +1,369 @@
+/*
+ * Copyright (c) 2015 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * Examples:
+ *
+ * Init:
+ *
+ * _gnix_posted_tag_storage_init(&ep->posted_recvs, NULL);
+ * _gnix_unexpected_tag_storage_init(&ep->unexpected_recvs, NULL);
+ *
+ * On receipt of a message:
+ *
+ * fastlock_acquire(&ep->tag_lock);
+ * req = _gnix_remove_by_tag(&ep->posted_recvs, msg->tag, 0);
+ * if (!req)
+ *     _gnix_insert_by_tag(&ep->unexpected_recvs, msg->tag, msg->req);
+ * fastlock_release(&ep->tag_lock);
+ *
+ * On post of receive:
+ *
+ * fastlock_acquire(&ep->tag_lock);
+ * tag_req = _gnix_remove_by_tag(&ep->unexpected_recvs,
+ *           req->tag, req->ignore);
+ * if (!tag_req)
+ *     _gnix_insert_by_tag(&ep->posted_recvs, tag, req);
+ * fastlock_release(&ep->tag_lock);
+ *
+ */
+
+#ifndef PROV_GNI_SRC_GNIX_TAGS_H_
+#define PROV_GNI_SRC_GNIX_TAGS_H_
+
+#include <fi.h>
+#include <fi_list.h>
+
+#include "gnix_util.h"
+
+/* enumerations */
+
+/**
+ * Enumeration for determining the underlying data structure for a
+ * tag storage.
+ *
+ * Using auto will choose one of list, hlist or kdtree based on mem_tag_format.
+ */
+enum {
+	GNIX_TAG_AUTOSELECT = 0,//!< GNIX_TAG_AUTOSELECT
+	GNIX_TAG_LIST,          //!< GNIX_TAG_LIST
+	GNIX_TAG_HLIST,         //!< GNIX_TAG_HLIST
+	GNIX_TAG_KDTREE,        //!< GNIX_TAG_KDTREE
+	GNIX_TAG_MAXTYPES,      //!< GNIX_TAG_MAXTYPES
+};
+
+/**
+ * Enumeration for the tag storage states
+ */
+enum {
+	GNIX_TS_STATE_UNINITIALIZED = 0,//!< GNIX_TS_STATE_UNINITIALIZED
+	GNIX_TS_STATE_INITIALIZED,      //!< GNIX_TS_STATE_INITIALIZED
+	GNIX_TS_STATE_DESTROYED,        //!< GNIX_TS_STATE_DESTROYED
+};
+
+/* forward declarations */
+struct gnix_tag_storage;
+struct gnix_fab_req;
+struct gnix_address;
+
+/* structure declarations */
+/**
+ * @brief Function dispatch table for the different types of underlying structures
+ * used in the tag storage.
+ *
+ * @var insert_tag    insert a request into the tag storage
+ * @var remove_tag    remove a request from the tag storage
+ * @var peek_tag      probe tag storage for a specific tag
+ * @var init          performs specific initialization based on underlying
+ *                     data structure
+ * @var fini          performs specific finalization based on underlying
+ *                     data structure
+ */
+struct gnix_tag_storage_ops {
+	int (*insert_tag)(struct gnix_tag_storage *ts, uint64_t tag,
+			struct gnix_fab_req *req);
+	struct gnix_fab_req *(*remove_tag)(struct gnix_tag_storage *ts,
+			uint64_t tag, uint64_t ignore,
+			uint64_t flags, void *context,
+			struct gnix_address *addr);
+	struct gnix_fab_req *(*peek_tag)(struct gnix_tag_storage *ts,
+			uint64_t tag, uint64_t ignore,
+			uint64_t flags, void *context,
+			struct gnix_address *addr);
+	int (*init)(struct gnix_tag_storage *ts);
+	int (*fini)(struct gnix_tag_storage *ts);
+};
+
+/**
+ * @note The sequence and generation numbers will be used in the future for
+ *       optimizing the search with branch and bound.
+ */
+struct gnix_tag_list_element {
+	 /* entry to the next element in the list */
+	struct slist_entry free;
+    /* has element been claimed with FI_CLAIM? */
+	int claimed;
+    /* associated fi_context with claimed element */
+	void *context;
+	/* sequence number */
+	uint32_t seq;
+	/* generation number */
+	uint32_t gen;
+};
+
+/**
+ * @note The type field is based on the GNIX_TAG_* enumerations listed above
+ */
+struct gnix_tag_storage_attr {
+	/* one of 'auto', 'list', 'hlist' or 'kdtree' */
+	int type;
+	/* should the tag storage check addresses? */
+	int use_src_addr_matching;
+};
+
+/**
+ * @note Unused. This will be used in the future for the init heuristic when
+ *         performing auto detection based on the mem_tag_format.
+ */
+struct gnix_tag_field {
+	uint64_t mask;
+	uint64_t len;
+};
+
+/**
+ * @note Unused. This will be used in the future for the init heuristic when
+ *         performing auto detection based on the mem_tag_format.
+ */
+struct gnix_tag_format {
+	int field_cnt;
+	struct gnix_tag_field *fields;
+};
+
+struct gnix_tag_list {
+	struct slist list;
+};
+
+struct gnix_tag_hlist {
+	struct dlist_entry *array;
+	int elements;
+};
+
+struct gnix_tag_kdtree {
+
+};
+
+/**
+ * @brief gnix tag storage structure
+ *
+ * Used to store gnix_fab_requests by tag, and optionally, by address.
+ *
+ * @var seq         sequence counter for elements
+ * @var state       state of the tag storage structure
+ * @var gen         generation counter for elements
+ * @var match_func  matching function for the tag storage, either posted or
+ *                    unexpected
+ * @var attr        tag storage attributes
+ * @var ops         function dispatch table for underlying data structures
+ * @var tag_format  unused. used during init for determining what type of
+ *                  data structure to use for storing data
+ */
+struct gnix_tag_storage {
+	atomic_t seq;
+	int state;
+	int gen;
+	int (*match_func)(struct slist_entry *entry, const void *arg);
+	struct gnix_tag_storage_attr attr;
+	struct gnix_tag_storage_ops *ops;
+	struct gnix_tag_format tag_format;
+	union {
+		struct gnix_tag_list list;
+		struct gnix_tag_hlist hlist;
+		struct gnix_tag_kdtree kdtree;
+	};
+};
+
+/* function declarations */
+/**
+ * @brief generic matching function for posted and unexpected tag storages
+ *
+ * @param req                     gnix fabric request to match
+ * @param tag                     tag to match
+ * @param ignore                  bits to ignore in the tags
+ * @param flags                   fi_tagged flags
+ * @param context                 fi_context to match in request
+ * @param uses_src_addr_matching  should we check addresses?
+ * @param addr                    gnix address to match
+ * @param matching_posted         is matching on a posted tag storage?
+ * @return 1 if this request matches the parameters, 0 otherwise
+ */
+int _gnix_req_matches_params(
+		struct gnix_fab_req *req,
+		uint64_t tag,
+		uint64_t ignore,
+		uint64_t flags,
+		void *context,
+		int use_src_addr_matching,
+		struct gnix_address *addr,
+		int matching_posted);
+
+/**
+ * @brief matching function for unexpected tag storages
+ *
+ * @param entry  slist entry pointing to the request to search
+ * @param arg    search parameters as a gnix_tag_search_element
+ * @return 1 if this request matches the parameters, 0 otherwise
+ */
+int _gnix_match_unexpected_tag(struct slist_entry *entry, const void *arg);
+
+/**
+ * @brief matching function for posted tag storages
+ *
+ * @param entry  slist entry pointing to the request to search
+ * @param arg    search parameters as a gnix_tag_search_element
+ * @return 1 if this request matches the parameters, 0 otherwise
+ */
+int _gnix_match_posted_tag(struct slist_entry *entry, const void *arg);
+
+/**
+ * @brief base initialization function for tag storages
+ * @note  This function should never be called directly. It is exposed for the
+ *        purpose of allowing the test suite to reinitialize tag storages
+ *        without knowing what type of tag storage is being reinitialized
+ *
+ * @param ts          tag storage pointer
+ * @param attr        tag storage attributes
+ * @param match_func  match function to be used on individual list elements
+ * @return -FI_EINVAL, if any invalid parameters were given
+ *         FI_SUCCESS, otherwise
+ */
+int _gnix_tag_storage_init(
+		struct gnix_tag_storage *ts,
+		struct gnix_tag_storage_attr *attr,
+		int (*match_func)(struct slist_entry *, const void *));
+
+/**
+ * @brief initialization function for posted tag storages
+ *
+ * @param ts          tag storage pointer
+ * @param attr        tag storage attributes
+ * @param match_func  match function to be used on individual list elements
+ * @return -FI_EINVAL, if any invalid parameters were given
+ *         FI_SUCCESS, otherwise
+ */
+static inline int _gnix_posted_tag_storage_init(
+		struct gnix_tag_storage *ts,
+		struct gnix_tag_storage_attr *attr)
+{
+	return _gnix_tag_storage_init(ts, attr, _gnix_match_posted_tag);
+}
+
+/**
+ * @brief initialization function for unexpected tag storages
+ *
+ * @param ts          tag storage pointer
+ * @param attr        tag storage attributes
+ * @param match_func  match function to be used on individual list elements
+ * @return -FI_EINVAL, if any invalid parameters were given
+ *         FI_SUCCESS, otherwise
+ */
+static inline int _gnix_unexpected_tag_storage_init(
+		struct gnix_tag_storage *ts,
+		struct gnix_tag_storage_attr *attr)
+{
+	return _gnix_tag_storage_init(ts, attr, _gnix_match_unexpected_tag);
+}
+
+/**
+ * @brief destroys a tag storage and releases any held memory
+ *
+ * @param ts
+ * @return -FI_EINVAL, if the tag storage is in a bad state
+ *         -FI_EAGAIN, if there are tags remaining in the tag storage
+ *         FI_SUCCESS, otherwise
+ */
+int _gnix_tag_storage_destroy(struct gnix_tag_storage *ts);
+
+/**
+ * @brief inserts a gnix_fab_req into the tag storage
+ *
+ * @param ts           pointer to the tag storage
+ * @param tag          tag associated with fab request
+ * @param req          gnix fabric request
+ * @param ignore       bits to ignore in tag (only applies to posted)
+ * @param addr_ignore  bits to ignore in addr (only applies to posted)
+ * @return
+ *
+ * @note if ts is a posted tag storage, 'req->ignore_bits' will be set to
+ *         the value of 'ignore'.
+ *
+ * @note if ts is a posted tag storage and ts->attr.use_src_addr_matching
+ *         is enabled, 'req->addr_ignore_bits' will be set to the value
+ *         of 'addr_ignore'.
+ */
+int _gnix_insert_tag(
+		struct gnix_tag_storage *ts,
+		uint64_t tag,
+		struct gnix_fab_req *req,
+		uint64_t ignore);
+
+
+/**
+ * @brief matches at a request from the tag storage by tag and address
+ *
+ * @param ts           pointer to the tag storage
+ * @param tag          tag to remove
+ * @param ignore       bits to ignore in tag
+ * @param flags        fi_tagged flags
+ * @param context      fi_context associated with tag
+ * @param addr         gnix_address associated with tag
+ * @param addr_ignore  bits to ignore in address
+ * @return NULL, if no entry found that matches parameters
+ *         otherwise, a non-null value pointing to a gnix_fab_req
+ *
+ * @note ignore parameter is not used for posted tag storages
+ * @note addr_ignore parameter is not used for posted tag storages
+ * @note if FI_CLAIM is not provided in flags, the call is an implicit removal
+ *       of the tag
+ */
+struct gnix_fab_req *_gnix_match_tag(
+		struct gnix_tag_storage *ts,
+		uint64_t tag,
+		uint64_t ignore,
+		uint64_t flags,
+		void *context,
+		struct gnix_address *addr);
+
+/* external symbols */
+
+
+
+#endif /* PROV_GNI_SRC_GNIX_TAGS_H_ */

--- a/prov/gni/src/gnix_tags.c
+++ b/prov/gni/src/gnix_tags.c
@@ -1,0 +1,571 @@
+/*
+ * Copyright (c) 2015 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "rdma/fabric.h"
+#include "rdma/fi_tagged.h"
+
+#include "gnix_tags.h"
+
+#include "gnix.h"
+#include "gnix_util.h"
+
+struct gnix_tag_storage_ops list_ops;
+struct gnix_tag_storage_ops hlist_ops;
+struct gnix_tag_storage_ops kdtree_ops;
+
+struct gnix_tag_search_element {
+	uint64_t tag;
+	uint64_t ignore;
+	void *context;
+	uint64_t flags;
+	int use_src_addr_matching;
+	struct gnix_address *addr;
+};
+
+/**
+ * @brief converts gnix_tag_list_element to gnix_fab_req
+ *
+ * @param elem  slist element embedded in a gnix_fab_req
+ * @return pointer to gnix_fab_req
+ */
+static inline struct gnix_fab_req *__to_gnix_fab_req(
+		struct gnix_tag_list_element *elem)
+{
+	struct gnix_fab_req *req;
+
+	req = container_of(elem, struct gnix_fab_req, tle);
+
+	return req;
+}
+
+/**
+ * @brief determines if a req matches the address parameters
+ *
+ * @param addr_to_find    address to find in tag storage
+ * @param addr            stored address
+ * @return 0 if the request does not match the parameters, 1 otherwise
+ */
+static inline int __req_matches_addr_params(
+		struct gnix_address *addr_to_find,
+		struct gnix_address *addr)
+{
+	return (GNIX_ADDR_UNSPEC(*addr) ||
+			GNIX_ADDR_EQUAL(*addr_to_find, *addr));
+}
+
+int _gnix_req_matches_params(
+		struct gnix_fab_req *req,
+		uint64_t tag,
+		uint64_t ignore,
+		uint64_t flags,
+		void *context,
+		int use_src_addr_matching,
+		struct gnix_address *addr,
+		int matching_posted)
+{
+	int valid_request;
+
+	/* adding some error checking to the first condition
+	 *
+	 * if the context is null, then FI_PEEK | FI_CLAIM should fail
+	 */
+	if ((flags & FI_CLAIM) && (flags & FI_PEEK))
+		valid_request = (context != NULL &&
+				context != req->tle.context);
+	else if ((flags & FI_CLAIM) && !(flags & FI_PEEK))
+		valid_request = (req->tle.context != NULL &&
+				context == req->tle.context);
+	else
+		valid_request = req->tle.context == NULL;
+
+	/* shortcut */
+	if (!valid_request)
+		return valid_request;
+
+	if (use_src_addr_matching && matching_posted) {
+		/* if matching posted, flip the arguments so that the unspec check
+		 *   is done on the request in the tag store and not the address
+		 *   that was passed into the function
+		 */
+		valid_request &= __req_matches_addr_params(addr, &req->addr);
+	} else if (use_src_addr_matching && !matching_posted) {
+		valid_request &= __req_matches_addr_params(&req->addr, addr);
+	}
+
+	return valid_request && ((req->tag & ~ignore) == (tag & ~ignore));
+}
+
+/* used to match elements in the posted lists */
+int _gnix_match_posted_tag(struct slist_entry *entry, const void *arg)
+{
+	const struct gnix_tag_search_element *s_elem = arg;
+	struct gnix_tag_list_element *tle;
+	struct gnix_fab_req *req;
+
+	tle = (struct gnix_tag_list_element *) entry;
+	req = __to_gnix_fab_req(tle);
+
+	return _gnix_req_matches_params(req, s_elem->tag, req->ignore_bits,
+			s_elem->flags, s_elem->context,
+			s_elem->use_src_addr_matching,
+			s_elem->addr, 1);
+}
+
+/* used to match elements in the unexpected lists */
+int _gnix_match_unexpected_tag(struct slist_entry *entry, const void *arg)
+{
+	const struct gnix_tag_search_element *s_elem = arg;
+	struct gnix_tag_list_element *tle;
+	struct gnix_fab_req *req;
+
+	tle = (struct gnix_tag_list_element *) entry;
+	req = __to_gnix_fab_req(tle);
+
+	return _gnix_req_matches_params(req, s_elem->tag, s_elem->ignore,
+			s_elem->flags, s_elem->context,
+			s_elem->use_src_addr_matching,
+			s_elem->addr, 0);
+}
+
+/* default attributes for tag storage objects */
+static struct gnix_tag_storage_attr default_attr = {
+		.type = GNIX_TAG_AUTOSELECT,
+		.use_src_addr_matching = 0,
+};
+
+/**
+ * @brief peeks into a tag list to find the first match using given parameters
+ *
+ * @param ts           pointer to gnix_tag_storage_object
+ * @param tag          tag to find
+ * @param ignore       bits to ignore in tags
+ * @param list         slist to search
+ * @param flags        fi_tagged flags
+ * @param context      fi_context associated with tag
+ * @param addr         gnix_address to find
+ * @param addr_ignore  bits to ignore in address
+ * @return NULL, if no match is found,
+ *         a non-NULL value, if a match is found
+ */
+static inline struct gnix_tag_list_element *__tag_list_peek_first_match(
+		struct gnix_tag_storage *ts,
+		uint64_t tag,
+		uint64_t ignore,
+		struct slist *list,
+		uint64_t flags,
+		void *context,
+		struct gnix_address *addr)
+{
+	struct slist_entry *current;
+	struct gnix_tag_search_element s_elem = {
+			.tag = tag,
+			.ignore = ignore,
+			.flags = flags,
+			.context = context,
+			.use_src_addr_matching = ts->attr.use_src_addr_matching,
+			.addr = addr,
+	};
+
+	/* search the list for a matching element. stop at the first match */
+	for (current = list->head; current != NULL; current = current->next) {
+		if (ts->match_func(current, &s_elem))
+			return (struct gnix_tag_list_element *) current;
+	}
+
+	return NULL;
+}
+
+/**
+ * @brief finds and removes the first match in a tag list
+ *
+ * @param ts           pointer to gnix_tag_storage_object
+ * @param tag          tag to find
+ * @param ignore       bits to ignore in tags
+ * @param list         slist to search
+ * @param flags        fi_tagged flags
+ * @param context      fi_context associated with tag
+ * @param addr         gnix_address to find
+ * @param addr_ignore  bits to ignore in address
+ * @return NULL, if no match is found,
+ *         a non-NULL value, if a match is found
+ */
+static inline struct gnix_tag_list_element *__tag_list_find_element(
+		struct gnix_tag_storage *ts,
+		uint64_t tag,
+		uint64_t ignore,
+		struct slist *list,
+		uint64_t flags,
+		void *context,
+		struct gnix_address *addr)
+{
+	struct gnix_tag_search_element s_elem = {
+			.tag = tag,
+			.ignore = ignore,
+			.flags = flags,
+			.context = context,
+			.use_src_addr_matching = ts->attr.use_src_addr_matching,
+			.addr = addr,
+	};
+
+	/* search the list for a matching element. stop at the first match */
+	return (struct gnix_tag_list_element *)
+			slist_remove_first_match(list,
+					ts->match_func, &s_elem);
+}
+
+/**
+ * @brief checks attributes for invalid values
+ *
+ * @param attr  attributes to be checked
+ * @return -FI_EINVAL, if attributes contain invalid values
+ *         FI_SUCCESS, otherwise
+ */
+static inline int __check_for_invalid_attributes(
+		struct gnix_tag_storage_attr *attr)
+{
+	if (attr->type < 0 || attr->type >= GNIX_TAG_MAXTYPES)
+		return -FI_EINVAL;
+
+	return FI_SUCCESS;
+}
+
+int _gnix_tag_storage_init(
+		struct gnix_tag_storage *ts,
+		struct gnix_tag_storage_attr *attr,
+		int (*match_func)(struct slist_entry *, const void *))
+{
+	int ret;
+	struct gnix_tag_storage_attr *attributes = &default_attr;
+
+	if (ts->state == GNIX_TS_STATE_INITIALIZED) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+				"attempted to initialize already active tag storage\n");
+		return -FI_EINVAL;
+	}
+
+	if (attr) {
+		if (__check_for_invalid_attributes(attr)) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+					"invalid attributes passed in to init\n");
+			return -FI_EINVAL;
+		}
+
+		attributes = attr;
+	}
+
+
+
+	/* copy attributes */
+	memcpy(&ts->attr, attributes, sizeof(struct gnix_tag_storage_attr));
+
+	switch (ts->attr.type) {
+	case GNIX_TAG_AUTOSELECT:
+	case GNIX_TAG_LIST:
+		ts->ops = &list_ops;
+		break;
+	case GNIX_TAG_HLIST:
+		ts->ops = &hlist_ops;
+		break;
+	case GNIX_TAG_KDTREE:
+		ts->ops = &kdtree_ops;
+		break;
+	default:
+		GNIX_WARN(FI_LOG_EP_CTRL, "failed to find valid tag type\n");
+		assert(0);
+	}
+
+	ret = ts->ops->init(ts);
+	if (ret) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+				"failed to initialize at ops->init\n");
+		return ret;
+	}
+
+	/* a different type of matching behavior is required for unexpected
+	 *   messages
+	 */
+	ts->match_func = match_func;
+
+	atomic_initialize(&ts->seq, 1);
+	ts->gen = 0;
+	ts->state = GNIX_TS_STATE_INITIALIZED;
+
+	return FI_SUCCESS;
+}
+
+int _gnix_tag_storage_destroy(struct gnix_tag_storage *ts)
+{
+	int ret;
+
+	if (ts->state != GNIX_TS_STATE_INITIALIZED)
+		return -FI_EINVAL;
+
+	ret = ts->ops->fini(ts);
+	if (ret)
+		return ret;
+
+	ts->state = GNIX_TS_STATE_DESTROYED;
+
+	return FI_SUCCESS;
+}
+
+/* not implemented operations */
+static int __gnix_tag_no_init(struct gnix_tag_storage *ts)
+{
+	return -FI_ENOSYS;
+}
+
+static int __gnix_tag_no_fini(struct gnix_tag_storage *ts)
+{
+	return -FI_ENOSYS;
+}
+
+static int __gnix_tag_no_insert_tag(
+		struct gnix_tag_storage *ts,
+		uint64_t tag,
+		struct gnix_fab_req *req)
+{
+	return -FI_ENOSYS;
+}
+
+
+static struct gnix_fab_req *__gnix_tag_no_peek_tag(
+		struct gnix_tag_storage *ts,
+		uint64_t tag,
+		uint64_t ignore,
+		uint64_t flags,
+		void *context,
+		struct gnix_address *addr)
+{
+	return NULL;
+}
+
+static struct gnix_fab_req *__gnix_tag_no_remove_tag(
+		struct gnix_tag_storage *ts,
+		uint64_t tag,
+		uint64_t ignore,
+		uint64_t flags,
+		void *context,
+		struct gnix_address *addr)
+{
+	return NULL;
+}
+
+/* list operations */
+
+static int __gnix_tag_list_init(struct gnix_tag_storage *ts)
+{
+	slist_init(&ts->list.list);
+
+	return FI_SUCCESS;
+}
+
+static int __gnix_tag_list_fini(struct gnix_tag_storage *ts)
+{
+	if (!slist_empty(&ts->list.list))
+		return -FI_EAGAIN;
+
+	return FI_SUCCESS;
+}
+
+static int __gnix_tag_list_insert_tag(
+		struct gnix_tag_storage *ts,
+		uint64_t tag,
+		struct gnix_fab_req *req)
+{
+	struct gnix_tag_list_element *element;
+
+	element = &req->tle;
+	element->free.next = NULL;
+	element->context = NULL;
+	slist_insert_tail(&element->free, &ts->list.list);
+
+	return FI_SUCCESS;
+}
+
+static struct gnix_fab_req *__gnix_tag_list_peek_tag(
+		struct gnix_tag_storage *ts,
+		uint64_t tag,
+		uint64_t ignore,
+		uint64_t flags,
+		void *context,
+		struct gnix_address *addr)
+{
+	struct gnix_tag_list_element *element;
+
+	element = __tag_list_peek_first_match(ts, tag, ignore,
+			&ts->list.list, flags, context, addr);
+
+	if (!element)
+		return NULL;
+
+	return __to_gnix_fab_req(element);
+}
+
+static struct gnix_fab_req *__gnix_tag_list_remove_tag(
+		struct gnix_tag_storage *ts,
+		uint64_t tag,
+		uint64_t ignore,
+		uint64_t flags,
+		void *context,
+		struct gnix_address *addr)
+{
+	struct gnix_tag_list_element *element;
+	struct gnix_fab_req *req;
+
+	element = __tag_list_find_element(ts, tag, ignore, &ts->list.list,
+			flags, context, addr);
+	if (!element)
+		return NULL;
+
+	req = __to_gnix_fab_req(element);
+	element->free.next = NULL;
+
+	return req;
+}
+
+/* ignore is only used on inserting into posted tag storages
+ * addr_ignore is only used on inserting into post tag storages with
+ * use_src_addr_matching enabled
+ */
+int _gnix_insert_tag(
+		struct gnix_tag_storage *ts,
+		uint64_t tag,
+		struct gnix_fab_req *req,
+		uint64_t ignore)
+{
+	int ret;
+
+	GNIX_INFO(FI_LOG_EP_CTRL, "inserting a message by tag, "
+				"ts=%p tag=%llx req=%p\n", ts, tag, req);
+	req->tag = tag;
+	if (ts->match_func == _gnix_match_posted_tag) {
+		req->ignore_bits = ignore;
+	}
+
+	ret = ts->ops->insert_tag(ts, tag, req);
+
+	GNIX_INFO(FI_LOG_EP_CTRL, "ret=%i\n", ret);
+
+	return ret;
+}
+
+/*
+ * ignore parameter is not used for posted tag storages
+ */
+static struct gnix_fab_req *__remove_by_tag_and_addr(
+		struct gnix_tag_storage *ts,
+		uint64_t tag,
+		uint64_t ignore,
+		uint64_t flags,
+		void *context,
+		struct gnix_address *addr)
+{
+	struct gnix_fab_req *ret;
+
+	/* assuming that flags and context are correct */
+	GNIX_INFO(FI_LOG_EP_CTRL, "removing a message by tag, "
+			"ts=%p tag=%llx ignore=%llx flags=%llx context=%p "
+			"addr=%p\n",
+			ts, tag, ignore, flags, context, addr);
+	ret = ts->ops->remove_tag(ts, tag, ignore, flags, context, addr);
+	GNIX_INFO(FI_LOG_EP_CTRL, "ret=%p\n", ret);
+
+	return ret;
+}
+
+static struct gnix_fab_req *__peek_by_tag_and_addr(
+		struct gnix_tag_storage *ts,
+		uint64_t tag,
+		uint64_t ignore,
+		uint64_t flags,
+		void *context,
+		struct gnix_address *addr)
+{
+	struct gnix_fab_req *ret;
+
+	/* assuming that flags and context are correct */
+	GNIX_INFO(FI_LOG_EP_CTRL, "peeking a message by tag, "
+			"ts=%p tag=%llx ignore=%llx flags=%llx context=%p "
+			"addr=%p\n",
+			ts, tag, ignore, flags, context, addr);
+
+	ret =  ts->ops->peek_tag(ts, tag, ignore, flags, context, addr);
+
+	if (ret != NULL && (flags & FI_CLAIM)) {
+		ret->tle.context = context;
+	}
+
+	GNIX_INFO(FI_LOG_EP_CTRL, "ret=%p\n", ret);
+
+	return ret;
+}
+
+struct gnix_fab_req *_gnix_match_tag(
+		struct gnix_tag_storage *ts,
+		uint64_t tag,
+		uint64_t ignore,
+		uint64_t flags,
+		void *context,
+		struct gnix_address *addr)
+{
+	if (flags & FI_PEEK)
+		return __peek_by_tag_and_addr(ts, tag, ignore, flags,
+				context, addr);
+	else
+		return __remove_by_tag_and_addr(ts, tag, ignore, flags,
+				context, addr);
+}
+
+struct gnix_tag_storage_ops list_ops = {
+		.init = __gnix_tag_list_init,
+		.fini = __gnix_tag_list_fini,
+		.insert_tag = __gnix_tag_list_insert_tag,
+		.peek_tag = __gnix_tag_list_peek_tag,
+		.remove_tag = __gnix_tag_list_remove_tag,
+};
+
+struct gnix_tag_storage_ops hlist_ops = {
+		.init = __gnix_tag_no_init,
+		.fini = __gnix_tag_no_fini,
+		.insert_tag = __gnix_tag_no_insert_tag,
+		.remove_tag = __gnix_tag_no_remove_tag,
+		.peek_tag = __gnix_tag_no_peek_tag,
+};
+
+struct gnix_tag_storage_ops kdtree_ops = {
+		.init = __gnix_tag_no_init,
+		.fini = __gnix_tag_no_fini,
+		.insert_tag = __gnix_tag_no_insert_tag,
+		.remove_tag = __gnix_tag_no_remove_tag,
+		.peek_tag = __gnix_tag_no_peek_tag,
+};

--- a/prov/gni/test/tags.c
+++ b/prov/gni/test/tags.c
@@ -1,0 +1,1658 @@
+/*
+ * Copyright (c) 2015 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+/*
+ *  Created on: July 17, 2015
+ *      Author: jswaro
+ */
+#include <stdlib.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <sys/time.h>
+
+#include <rdma/fi_errno.h>
+#include <gnix_tags.h>
+#include <gnix.h>
+
+#include <criterion/criterion.h>
+
+static struct fi_info *hints;
+static struct fi_info *fi;
+
+#define DEFAULT_FORMAT  0x00000000FFFFFFFF
+#define SINGLE_FORMAT   0xFFFFFFFFFFFFFFFF
+#define DOUBLE_FORMAT   0xFFFFFFFF00000000
+#define TRIPLE_FORMAT   0xFFFF0000FFFFFFFF
+#define MULTI_FORMAT    0xFF00FFFF0000FFFF
+#define BAD_FORMAT      0xFFFFFFFFFFFFFF00
+#define SIMPLE_FORMAT   0x0000000000FF00FF
+
+#define TEST_TAG        0x00000000DEADBEEF
+
+enum {
+	TEST_ORDER_INORDER = 0,
+	TEST_ORDER_RANDOM,
+	TEST_ORDER_REVERSE,
+};
+
+enum {
+	TEST_OVERLAY_DEF = 0,
+	TEST_OVERLAY_SINGLE,
+	TEST_OVERLAY_DOUBLE,
+	TEST_OVERLAY_TRIPLE,
+	TEST_OVERLAY_MULTI,
+	TEST_OVERLAY_BAD,
+	TEST_OVERLAY_SIMPLE,
+	TEST_OVERLAY_MAX,
+};
+
+struct __test_mask {
+	uint64_t mask;
+	uint64_t format;
+	int type;
+	int fields;
+	int field_width[5];
+	int reserved_bits;
+};
+
+struct gnix_fr_element {
+	struct gnix_fab_req req;
+	int claimed;
+	uint64_t ignore;
+	uint64_t addr_ignore;
+	uint64_t peek_flags;
+	uint64_t remove_flags;
+	void *context;
+};
+
+struct __test_mask test_masks[TEST_OVERLAY_MAX] = {
+		{
+				.mask = DEFAULT_FORMAT,
+				.format = DEFAULT_FORMAT,
+				.type = TEST_OVERLAY_DEF,
+				.fields = 1,
+				.field_width = {32, 0, 0, 0, 0},
+				.reserved_bits = 32,
+		},
+		{
+				.mask = ~0,
+				.format = SINGLE_FORMAT,
+				.type = TEST_OVERLAY_SINGLE,
+				.fields = 1,
+				.field_width = {64, 0, 0, 0, 0},
+				.reserved_bits = 0,
+		},
+		{
+				.mask = ~0,
+				.format = DOUBLE_FORMAT,
+				.type = TEST_OVERLAY_DOUBLE,
+				.fields = 2,
+				.field_width = {32, 32, 0, 0, 0},
+				.reserved_bits = 0,
+		},
+		{
+				.mask = ~0,
+				.format = TRIPLE_FORMAT,
+				.type = TEST_OVERLAY_TRIPLE,
+				.fields = 3,
+				.field_width = {16, 16, 32, 0, 0},
+				.reserved_bits = 0,
+		},
+		{
+				.mask = ~0,
+				.format = MULTI_FORMAT,
+				.type = TEST_OVERLAY_MULTI,
+				.fields = 5,
+				.field_width = {8, 8, 16, 16, 16},
+				.reserved_bits = 0,
+		},
+		{
+				.mask = ~0,
+				.format = BAD_FORMAT,
+				.type = TEST_OVERLAY_BAD,
+				.fields = 5,
+				.field_width = {16, 16, 16, 8, 8},
+				.reserved_bits = 0,
+		},
+		{
+				.mask = 0x0000000000ffffff,
+				.format = SIMPLE_FORMAT,
+				.type = TEST_OVERLAY_SIMPLE,
+				.fields = 3,
+				.field_width = {8, 8, 8, 0, 0},
+				.reserved_bits = 40,
+		}
+};
+
+static struct gnix_tag_storage_attr default_list_attr = {
+	.type = GNIX_TAG_LIST,
+};
+
+static struct gnix_tag_storage_attr default_hlist_attr = {
+	.type = GNIX_TAG_HLIST,
+};
+
+static struct gnix_tag_storage_attr default_kdtree_attr = {
+	.type = GNIX_TAG_KDTREE,
+};
+
+static struct gnix_tag_storage_attr default_auto_attr = {
+	.type = GNIX_TAG_AUTOSELECT,
+};
+
+static struct gnix_fr_element default_reqs[8] = {
+		{
+			.req = {
+				.tag = 0x00005555,
+				.ignore_bits = 0x11111111
+			},
+			.peek_flags = FI_PEEK,
+			.remove_flags = 0,
+			.context = NULL,
+
+		},
+		{
+			.req = {
+				.tag = 0x0000AAAA,
+				.ignore_bits = 0x11111111
+			},
+			.peek_flags = FI_PEEK,
+			.remove_flags = 0,
+			.context = NULL,
+		},
+		{
+			.req = {
+				.tag = 0xAAAA5555,
+				.ignore_bits = 0x11111111
+			},
+			.peek_flags = FI_PEEK,
+			.remove_flags = 0,
+			.context = NULL,
+		},
+		{
+			.req = {
+				.tag = 0x5555AAAA,
+				.ignore_bits = 0x11111111
+			},
+			.peek_flags = FI_PEEK,
+			.remove_flags = 0,
+			.context = NULL,
+		},
+		{
+			.req = {
+				.tag = 0xAAAA5555,
+				.ignore_bits = 0x11111111
+			},
+			.peek_flags = FI_PEEK,
+			.remove_flags = 0,
+			.context = NULL,
+		},
+		{
+			.req = {
+				.tag = 0x00005555,
+				.ignore_bits = 0x11111111
+			},
+			.peek_flags = FI_PEEK,
+			.remove_flags = 0,
+			.context = NULL,
+		},
+		{
+			.req = {
+				.tag = 0x00005555,
+				.ignore_bits = 0x11111111
+			},
+			.peek_flags = FI_PEEK,
+			.remove_flags = 0,
+			.context = NULL,
+		},
+		{
+			.req = {
+				.tag = 0x0000AAAA,
+				.ignore_bits = 0x11111111
+			},
+			.peek_flags = FI_PEEK,
+			.remove_flags = 0,
+			.context = NULL,
+		},
+};
+
+
+static struct gnix_tag_storage *test_tag_storage;
+static int call_destruct;
+static int (*match_func)(
+		struct slist_entry *entry,
+		const void *arg) = _gnix_match_posted_tag;
+
+
+static inline void reset_test_fr_metadata(struct gnix_fr_element *reqs,
+		int requests)
+{
+	int i;
+
+	for (i = 0; i < requests; i++) {
+		reqs[i].claimed = 0;
+		reqs[i].req.tle.context = NULL;
+	}
+}
+static inline void reset_test_tag_storage(
+		struct gnix_tag_storage *ts,
+		struct gnix_tag_storage_attr *attr)
+{
+	int ret;
+
+	ret = _gnix_tag_storage_destroy(ts);
+	cr_assert(ret == FI_SUCCESS,
+			"failed to destroy tag storage on reset");
+
+	ret = _gnix_tag_storage_init(ts, attr, match_func);
+	cr_assert(ret == FI_SUCCESS,
+			"failed to initialize tag storage on reset");
+}
+
+static void __gnix_tags_bare_test_setup(void)
+{
+	int ret = 0;
+
+	hints = fi_allocinfo();
+	cr_assert(hints, "fi_allocinfo");
+
+	hints->domain_attr->cq_data_size = 4;
+	hints->mode = ~0;
+
+	hints->fabric_attr->name = strdup("gni");
+
+	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
+	cr_assert_eq(ret, FI_SUCCESS, "fi_getinfo");
+
+	cr_assert(test_tag_storage == NULL,
+			"test_tag_storage was not freed prior to setup");
+	test_tag_storage = calloc(1, sizeof(*test_tag_storage));
+	cr_assert(test_tag_storage != NULL,
+			"could not allocate test_tag_storage");
+
+	call_destruct = 0;
+
+	srand(0xDEADBEEF);
+}
+
+static void __gnix_tags_bare_test_teardown(void)
+{
+	fi_freeinfo(fi);
+	fi_freeinfo(hints);
+
+	cr_assert(test_tag_storage != NULL,
+			"test_tag_storage pointer "
+			"deallocated or overwritten during test");
+	free(test_tag_storage);
+	test_tag_storage = NULL;
+}
+
+static void __gnix_tags_basic_test_setup(void)
+{
+	__gnix_tags_bare_test_setup();
+}
+
+static void __gnix_tags_basic_test_teardown(void)
+{
+	int ret;
+
+	ret = _gnix_tag_storage_destroy(test_tag_storage);
+	cr_assert(ret == FI_SUCCESS,
+			"failed to destroy tag storage "
+			"during basic teardown");
+
+	__gnix_tags_bare_test_teardown();
+}
+
+static void __gnix_tags_basic_list_test_setup(void)
+{
+	int ret;
+
+	__gnix_tags_basic_test_setup();
+
+	ret = _gnix_tag_storage_init(test_tag_storage, &default_list_attr,
+		match_func);
+	cr_assert(ret == FI_SUCCESS, "failed to initialize tag storage "
+			"during basic list setup");
+}
+
+static void __gnix_tags_basic_hlist_test_setup(void)
+{
+	int ret;
+
+	__gnix_tags_basic_test_setup();
+
+	ret = _gnix_tag_storage_init(test_tag_storage, &default_hlist_attr,
+			match_func);
+	cr_assert(ret == FI_SUCCESS, "failed to initialize tag storage "
+				"during basic hlist setup");
+}
+
+static void __gnix_tags_basic_kdtree_test_setup(void)
+{
+	int ret;
+
+	__gnix_tags_basic_test_setup();
+
+	ret = _gnix_tag_storage_init(test_tag_storage, &default_kdtree_attr,
+			match_func);
+	cr_assert(ret == FI_SUCCESS, "failed to initialize tag storage "
+				"during basic kdtree setup");
+}
+
+static void __gnix_tags_basic_posted_list_test_setup(void)
+{
+	match_func = _gnix_match_posted_tag;
+	__gnix_tags_basic_list_test_setup();
+}
+
+static void __gnix_tags_basic_posted_hlist_test_setup(void)
+{
+	match_func = _gnix_match_posted_tag;
+	__gnix_tags_basic_hlist_test_setup();
+}
+
+static void __gnix_tags_basic_posted_kdtree_test_setup(void)
+{
+	match_func = _gnix_match_posted_tag;
+	__gnix_tags_basic_kdtree_test_setup();
+}
+
+static void __gnix_tags_basic_unexpected_list_test_setup(void)
+{
+	match_func = _gnix_match_unexpected_tag;
+	__gnix_tags_basic_list_test_setup();
+}
+
+static void __gnix_tags_basic_unexpected_hlist_test_setup(void)
+{
+	match_func = _gnix_match_unexpected_tag;
+	__gnix_tags_basic_hlist_test_setup();
+}
+
+static void __gnix_tags_basic_unexpected_kdtree_test_setup(void)
+{
+	match_func = _gnix_match_unexpected_tag;
+	__gnix_tags_basic_kdtree_test_setup();
+}
+
+__attribute__((unused))
+static void __gnix_tags_basic_auto_test_setup(void)
+{
+	int ret;
+
+	__gnix_tags_basic_test_setup();
+
+	ret = _gnix_tag_storage_init(test_tag_storage, &default_auto_attr,
+			match_func);
+	cr_assert(ret == FI_SUCCESS,
+			"failed to initialize tag storage during basic auto setup");
+}
+
+/* multi-mode tests */
+
+static inline uint64_t make_test_tag(struct __test_mask *mask, uint64_t val)
+{
+	return val & mask->mask;
+}
+
+
+static struct gnix_fr_element *make_evenly_distributed_tags(
+		int requests,
+		struct __test_mask *mask)
+{
+	int i, j;
+	uint64_t offset, field_width, tmp;
+	struct gnix_fr_element *reqs;
+
+	reqs = calloc(requests, sizeof(*reqs));
+	cr_assert(reqs);
+
+	offset = 64 - mask->reserved_bits;
+
+	for (i = 0; i < mask->fields; i++) {
+		field_width = 1ull << mask->field_width[i];
+		if (mask->field_width[i] == 64)
+			field_width = ~0ull;
+
+		offset -= mask->field_width[i];
+		for (j = 0; j < requests; j++) {
+			tmp = (j % field_width) << offset;
+			reqs[j].req.tag |= tmp;
+		}
+	}
+
+	for (i = 0; i < requests; i++) {
+		tmp = make_test_tag(mask, reqs[i].req.tag);
+		reqs[i].req.ignore_bits = 0;
+		reqs[i].req.tag = tmp;
+		reqs[i].peek_flags = FI_PEEK;
+	}
+
+	return reqs;
+}
+
+static struct gnix_fr_element *make_random_tags(
+		int requests,
+		struct __test_mask *mask)
+{
+	int i;
+	uint64_t tag;
+	struct gnix_fr_element *reqs;
+
+	reqs = calloc(requests, sizeof(*reqs));
+	cr_assert(reqs, "failed to allocate requests for random tag creation");
+
+	for (i = 0; i < requests; i++) {
+		tag = rand();
+		tag <<= 32;
+		tag += rand();
+		reqs[i].req.tag = make_test_tag(mask, tag);
+		reqs[i].req.ignore_bits = 0;
+		reqs[i].peek_flags = FI_PEEK;
+	}
+
+	return reqs;
+}
+
+static void print_request_lists(
+		struct gnix_fr_element *reqs,
+		int requests,
+		int *correct_order,
+		int *removal_order,
+		int ordering_type)
+{
+	int i;
+	char *type;
+	struct gnix_fr_element *current;
+
+	if (ordering_type == TEST_ORDER_INORDER)
+		type = "INORDER";
+	else if (ordering_type == TEST_ORDER_RANDOM)
+		type = "RANDOM";
+	else if (ordering_type == TEST_ORDER_REVERSE)
+		type = "REVERSE";
+	else
+		type = "UNKNOWN";
+
+
+	fprintf(stderr, "FAILED %s\n", type);
+	fprintf(stderr, "insertion order:\n");
+	for (i = 0; i < requests; i++) {
+		current = &reqs[i];
+		fprintf(stderr, "  req=%p req.tag=0x%.16llx index=%i\n",
+				&current->req,
+				(unsigned long long int) current->req.tag,
+				i);
+	}
+
+	fprintf(stderr, "removal order:\n");
+	for (i = 0; i < requests; i++) {
+		current = &reqs[removal_order[i]];
+		fprintf(stderr,
+				"  req=%p req.tag=0x%.16llx ignore=0x%.16llx index=%i\n",
+				&current->req,
+				(unsigned long long int) current->req.tag,
+				(unsigned long long int) current->ignore,
+				removal_order[i]);
+	}
+
+	fprintf(stderr, "correct order:\n");
+	for (i = 0; i < requests; i++) {
+		current = &reqs[correct_order[i]];
+		fprintf(stderr, "  req=%p req.tag=0x%.16llx index=%i\n",
+				&current->req,
+				(unsigned long long int) current->req.tag,
+				correct_order[i]);
+	}
+}
+
+static void multiple_insert_peek_remove_by_order(
+		struct gnix_tag_storage *ts,
+		struct __test_mask *mask,
+		int requests,
+		struct gnix_fr_element *reqs,
+		int *correct_order,
+		int *removal_order,
+		int ordering_type)
+{
+	int ret;
+	int i, j, ignore_bits;
+	struct gnix_fr_element *to_remove, *current;
+	struct gnix_fab_req *correct, *found;
+	int is_posted = ts->match_func == _gnix_match_posted_tag;
+
+	/* clear claimed flags */
+	for (i = 0; i < requests; i++)
+		reqs[i].claimed = 0;
+
+	/* establish correct removal order based on passed in removal order */
+	for (i = 0; i < requests; i++) {
+		to_remove = &reqs[removal_order[i]];
+
+		for (j = 0; j < requests; j++) {
+			current = &reqs[j];
+
+			if (current->claimed)
+				continue;
+
+			/* when the tag store is a posted tag store,
+			 * always use the ignore bits from the stored request
+			 *
+			 * otherwise, we are attempting to remove from
+			 * a unexpected tag store and we should use the
+			 * provided ignore bits
+			 */
+			if (is_posted)
+				ignore_bits = current->req.ignore_bits;
+			else
+				ignore_bits = to_remove->ignore;
+
+			/* applying peek flags - This assumes the appropriate
+			 * peek was performed prior to removal
+			 */
+			if ((to_remove->peek_flags & FI_PEEK) &&
+					(to_remove->peek_flags & FI_CLAIM)) {
+				to_remove->req.tle.context = to_remove->context;
+			}
+
+			if (_gnix_req_matches_params(&to_remove->req,
+					current->req.tag,
+					ignore_bits,
+					to_remove->remove_flags,
+					to_remove->context,
+					test_tag_storage->attr.use_src_addr_matching,
+					&to_remove->req.addr, is_posted))
+				break;
+
+			to_remove->req.tle.context = NULL;
+		}
+
+		cr_assert(j != requests,
+				"failed to find a match for every entry");
+		correct_order[i] = j;
+		current->claimed = 1;
+	}
+
+	/* clear alterations to the req structure
+	 * during creation of correct list
+	 */
+	for (i = 0; i < requests; i++)
+		reqs[i].req.tle.context = NULL;
+
+	/* clear claimed flags */
+	for (i = 0; i < requests; i++)
+		reqs[i].claimed = 0;
+
+	for (i = 0; i < requests; i++) {
+		ret = _gnix_insert_tag(ts, reqs[i].req.tag, &reqs[i].req,
+				reqs[i].ignore);
+		if (ret) {
+			print_request_lists(reqs, requests, correct_order,
+					removal_order, ordering_type);
+		}
+		cr_assert(ret == FI_SUCCESS,
+				"failed to insert tag into storage");
+	}
+
+	for (i = 0; i < requests; i++) {
+		to_remove = &reqs[removal_order[i]];
+		correct = &reqs[correct_order[i]].req;
+
+		found = _gnix_match_tag(ts,
+				to_remove->req.tag, to_remove->ignore,
+				to_remove->peek_flags | FI_PEEK, to_remove->context,
+				NULL);
+		if (found != correct) {
+			print_request_lists(reqs, requests, correct_order,
+					removal_order, ordering_type);
+			fprintf(stderr,
+					"failed to find request, to_remove=%p "
+					"correct=%p found=%p",
+					&to_remove->req,
+					found,
+					correct);
+		}
+		cr_assert(found == correct,
+				"failed to find tag in storage");
+
+
+		found = _gnix_match_tag(ts,
+				to_remove->req.tag, to_remove->ignore,
+				to_remove->remove_flags, to_remove->context,
+				NULL);
+		if (found != correct) {
+			print_request_lists(reqs, requests, correct_order,
+					removal_order, ordering_type);
+		}
+		cr_assert(found == correct,
+				"failed to remove tag from storage");
+	}
+}
+
+static void multiple_insert_peek_remove_inorder(
+		struct gnix_tag_storage *ts,
+		struct __test_mask *mask,
+		int requests,
+		struct gnix_fr_element *reqs,
+		int *correct_order,
+		int *removal_order)
+{
+	int i;
+
+	for (i = 0; i < requests; i++)
+		removal_order[i] = i;
+
+	multiple_insert_peek_remove_by_order(
+			ts, mask, requests, reqs,
+			correct_order, removal_order,
+			TEST_ORDER_INORDER);
+}
+
+static void multiple_insert_peek_remove_reverse(
+		struct gnix_tag_storage *ts,
+		struct __test_mask *mask,
+		int requests,
+		struct gnix_fr_element *reqs,
+		int *correct_order,
+		int *removal_order)
+{
+	int i;
+
+	for (i = requests - 1; i >= 0; i--)
+		removal_order[requests - 1 - i] = i;
+
+	multiple_insert_peek_remove_by_order(ts,
+			mask, requests, reqs,
+			correct_order, removal_order,
+			TEST_ORDER_REVERSE);
+}
+
+static void multiple_insert_peek_remove_random(
+		struct gnix_tag_storage *ts,
+		struct __test_mask *mask,
+		int requests,
+		struct gnix_fr_element *reqs,
+		int *correct_order,
+		int *removal_order)
+{
+	int i, j, rand_index, rand_j;
+
+	for (i = 0; i < requests; i++) {
+		rand_index = rand() % requests;
+		for (j = 0; j < requests; j++) {
+			rand_j = (rand_index + j) % requests;
+			if (!reqs[rand_j].claimed)
+				break;
+		}
+
+		removal_order[i] = rand_j;
+		reqs[rand_j].claimed = 1;
+	}
+
+	/* clear claimed flags */
+	for (i = 0; i < requests; i++)
+		reqs[i].claimed = 0;
+
+	multiple_insert_peek_remove_by_order(ts,
+			mask, requests, reqs,
+			correct_order, removal_order,
+			TEST_ORDER_RANDOM);
+}
+
+static inline void __test_multiple_ipr_reqs_by_function(
+		int requests,
+		struct gnix_tag_storage_attr *test_attr,
+		void (*order_func)(
+				struct gnix_tag_storage*,
+				struct __test_mask*,
+				int,
+				struct gnix_fr_element*,
+				int*,
+				int*),
+		struct gnix_fr_element *(make_requests)(
+				int,
+				struct __test_mask *),
+		int *correct_order,
+		int *removal_order)
+{
+	int i;
+	struct gnix_fr_element *reqs;
+	struct gnix_tag_storage_attr attr;
+
+	memcpy(&attr, test_attr, sizeof(struct gnix_tag_storage_attr));
+
+	for (i = 0; i < TEST_OVERLAY_MAX; i++) {
+		reqs = make_requests(requests, &test_masks[i]);
+		cr_assert(reqs != NULL, "failed to make random tags");
+
+		order_func(test_tag_storage, &test_masks[i], requests, reqs,
+				correct_order, removal_order);
+
+		/* make necessary alterations to the structure
+		 * for the next test mask
+		 */
+		reset_test_tag_storage(test_tag_storage, &attr);
+
+		free(reqs);
+	}
+}
+
+static inline void __test_multiple_inorder_ipr_reqs(
+		int requests,
+		struct gnix_tag_storage_attr *test_attr,
+		struct gnix_fr_element *(make_requests)(
+				int,
+				struct __test_mask *))
+
+{
+	int *correct_order, *removal_order;
+
+	correct_order = calloc(requests, sizeof(*correct_order));
+	cr_assert(correct_order != NULL);
+
+	removal_order = calloc(requests, sizeof(*removal_order));
+	cr_assert(removal_order != NULL);
+
+	__test_multiple_ipr_reqs_by_function(requests, test_attr,
+			multiple_insert_peek_remove_inorder,
+			make_requests, correct_order, removal_order);
+
+	free(correct_order);
+	free(removal_order);
+}
+
+static inline void __test_multiple_reverse_ipr_reqs(
+		int requests,
+		struct gnix_tag_storage_attr *test_attr,
+		struct gnix_fr_element *(make_requests)(
+				int,
+				struct __test_mask *))
+
+{
+	int *correct_order, *removal_order;
+
+	correct_order = calloc(requests, sizeof(*correct_order));
+	cr_assert(correct_order != NULL);
+
+	removal_order = calloc(requests, sizeof(*removal_order));
+	cr_assert(removal_order != NULL);
+
+	__test_multiple_ipr_reqs_by_function(requests, test_attr,
+			multiple_insert_peek_remove_reverse,
+			make_requests, correct_order, removal_order);
+
+	free(correct_order);
+	free(removal_order);
+}
+
+static inline void __test_multiple_random_ipr_reqs(
+		int requests,
+		struct gnix_tag_storage_attr *test_attr,
+		struct gnix_fr_element *(make_requests)(
+				int,
+				struct __test_mask *))
+
+{
+	int *correct_order, *removal_order;
+
+	correct_order = calloc(requests, sizeof(*correct_order));
+	cr_assert(correct_order != NULL);
+
+	removal_order = calloc(requests, sizeof(*removal_order));
+	cr_assert(removal_order != NULL);
+
+	__test_multiple_ipr_reqs_by_function(requests, test_attr,
+			multiple_insert_peek_remove_random,
+			make_requests, correct_order, removal_order);
+
+	free(correct_order);
+	free(removal_order);
+}
+
+static inline void __test_multiple_type_ipr_reqs(
+		int requests,
+		struct gnix_tag_storage_attr *test_attr,
+		struct gnix_fr_element *(make_requests)(
+				int,
+				struct __test_mask *))
+{
+	__test_multiple_inorder_ipr_reqs(requests, test_attr, make_requests);
+
+	reset_test_tag_storage(test_tag_storage, test_attr);
+
+	__test_multiple_reverse_ipr_reqs(requests, test_attr, make_requests);
+
+	reset_test_tag_storage(test_tag_storage, test_attr);
+
+	__test_multiple_random_ipr_reqs(requests, test_attr, make_requests);
+
+	reset_test_tag_storage(test_tag_storage, test_attr);
+}
+
+static inline void __test_multiple_8_duplicate_tags(
+		struct gnix_tag_storage_attr *test_attr)
+{
+	int i;
+	struct gnix_fr_element reqs[8];
+	int requests = 8;
+	int *correct_order, *removal_order;
+
+	correct_order = calloc(8, sizeof(*correct_order));
+	cr_assert(correct_order != NULL);
+
+	removal_order = calloc(8, sizeof(*removal_order));
+	cr_assert(removal_order != NULL);
+
+	memcpy(reqs, default_reqs, sizeof(struct gnix_fr_element) * requests);
+
+	for (i = 0; i < TEST_OVERLAY_MAX; i++) {
+		multiple_insert_peek_remove_inorder(
+				test_tag_storage, &test_masks[i],
+				requests, reqs, correct_order,
+				removal_order);
+
+		reset_test_tag_storage(test_tag_storage, test_attr);
+		reset_test_fr_metadata(reqs, requests);
+
+		multiple_insert_peek_remove_reverse(
+				test_tag_storage, &test_masks[i],
+				requests, reqs, correct_order, removal_order);
+
+		reset_test_tag_storage(test_tag_storage, test_attr);
+		reset_test_fr_metadata(reqs, requests);
+
+		multiple_insert_peek_remove_random(
+				test_tag_storage, &test_masks[i],
+				requests, reqs, correct_order, removal_order);
+
+		reset_test_tag_storage(test_tag_storage, test_attr);
+		reset_test_fr_metadata(reqs, requests);
+	}
+
+	free(correct_order);
+	free(removal_order);
+}
+
+static inline void __test_not_found_empty(void)
+{
+	struct gnix_fab_req *found;
+
+	found = _gnix_match_tag(
+			test_tag_storage, 0xCAFEBABE, 0, FI_PEEK, NULL, NULL);
+	cr_assert(found == NULL,
+			"something in this storage should not exist");
+}
+
+static inline void __test_not_found_non_empty(void)
+{
+	int ret;
+	int i, requests = 8;
+	struct gnix_fab_req *correct, *found;
+	struct gnix_fr_element *to_remove;
+	struct gnix_fr_element reqs[8];
+
+	memcpy(reqs, default_reqs, sizeof(struct gnix_fr_element) * 8);
+
+	for (i = 0; i < requests; i++) {
+		ret = _gnix_insert_tag(test_tag_storage,
+				reqs[i].req.tag, &reqs[i].req, reqs[i].ignore);
+		cr_assert(ret == FI_SUCCESS,
+				"failed to insert tag into storage");
+	}
+
+	found = _gnix_match_tag(test_tag_storage, 0xCAFEBABE, 0, FI_PEEK,
+			NULL, NULL);
+	cr_assert(found == NULL,
+			"something in this storage should not exist");
+
+	/* only doing in-order removal */
+	for (i = 0; i < requests; i++) {
+		to_remove = &reqs[i];
+		correct = &reqs[i].req;
+
+		found = _gnix_match_tag(
+				test_tag_storage, to_remove->req.tag,
+				to_remove->ignore, to_remove->peek_flags,
+				to_remove->context, NULL);
+		cr_assert(found == correct,
+				"failed to find tag in storage");
+
+		found = _gnix_match_tag(test_tag_storage,
+				to_remove->req.tag, to_remove->ignore,
+				to_remove->remove_flags, to_remove->context,
+				NULL);
+		cr_assert(found == correct,
+				"failed to remove tag from storage");
+	}
+}
+
+static inline void __test_ignore_mask_set(
+		struct gnix_tag_storage_attr *test_attr)
+{
+	int i;
+	struct gnix_fr_element reqs[8];
+	int requests = 8;
+	int correct_order[8], removal_order[8];
+
+	memcpy(reqs, default_reqs, sizeof(struct gnix_fr_element) * requests);
+
+	for (i = requests - 1; i >= 0 ; i--)
+		removal_order[i] = (requests - 1) - i;
+
+	reqs[7].ignore = 0xffff;
+	reqs[6].ignore = 0xffff0000;
+	reqs[5].ignore = 0xffff0000;
+	reqs[4].ignore = 0xffff0000;
+	reqs[3].ignore = 0xffff0000;
+	reqs[2].ignore = 0xffff0000;
+	reqs[1].ignore = 0x0;
+	reqs[0].ignore = 0xffffffff;
+
+	for (i = 0; i < requests; i++)
+		reqs[i].req.ignore_bits = reqs[i].ignore;
+
+	multiple_insert_peek_remove_by_order(test_tag_storage,
+			&test_masks[TEST_OVERLAY_DEF], requests, reqs,
+			correct_order, removal_order, TEST_ORDER_REVERSE);
+}
+
+static inline void __test_claim_pass(
+		struct gnix_tag_storage_attr *test_attr)
+{
+	int ret;
+	struct gnix_fr_element request = {
+		.req = {
+			.tag = 0xA5A5A5A5,
+			.ignore_bits = 0xFFFFFFFF
+		},
+		.peek_flags = FI_PEEK | FI_CLAIM,
+		.remove_flags = FI_CLAIM,
+		.context = (void *) 0xDEADBEEF,
+	};
+	struct gnix_fab_req *found;
+
+	ret = _gnix_insert_tag(
+			test_tag_storage, request.req.tag,
+			&request.req, request.ignore);
+	cr_assert(ret == FI_SUCCESS, "failed to insert tag into storage");
+
+	found = _gnix_match_tag(
+			test_tag_storage, request.req.tag, request.ignore,
+			request.peek_flags, request.context, NULL);
+	cr_assert(found == &request.req, "failed to find tag in storage");
+
+	found = _gnix_match_tag(
+			test_tag_storage, request.req.tag, request.ignore,
+			request.remove_flags, request.context, NULL);
+	cr_assert(found == &request.req, "failed to remove tag from storage");
+}
+
+/* tests to ensure you cannot remove an unclaimed messge when FI_CLAIM is set */
+static inline void __test_fail_no_claimed_tags(
+		struct gnix_tag_storage_attr *test_attr)
+{
+	int ret;
+	struct gnix_fab_req *found;
+	struct gnix_fr_element request = {
+		.req = {
+			.tag = 0xA5A5A5A5,
+			.ignore_bits = 0xFFFFFFFF
+		},
+		.peek_flags = FI_PEEK,
+		.remove_flags = FI_CLAIM,
+		.context = (void *) 0xDEADBEEF,
+	};
+
+	ret = _gnix_insert_tag(
+			test_tag_storage, request.req.tag,
+			&request.req, request.ignore);
+	cr_assert(ret == FI_SUCCESS, "failed to insert tag into storage");
+
+	found = _gnix_match_tag(
+			test_tag_storage, request.req.tag, request.ignore,
+			request.peek_flags, request.context, NULL);
+	cr_assert(found == &request.req, "failed to find tag in storage");
+
+	found = _gnix_match_tag(
+			test_tag_storage, request.req.tag, request.ignore,
+			request.remove_flags, request.context, NULL);
+	cr_assert(found == NULL, "found an unexpected tag in remove");
+
+	/* use the peek tags this time to remove the entry */
+	found = _gnix_match_tag(
+			test_tag_storage, request.req.tag, request.ignore,
+			0, request.context, NULL);
+	cr_assert(found == &request.req, "failed to find tag in storage");
+}
+
+/* test to ensure you cannot remove a message that has been claimed */
+static inline void __test_fail_all_claimed_tags(
+		struct gnix_tag_storage_attr *test_attr)
+{
+	int ret;
+	struct gnix_fr_element request = {
+		.req = {
+			.tag = 0xA5A5A5A5,
+			.ignore_bits = 0xFFFFFFFF
+		},
+		.peek_flags = FI_PEEK | FI_CLAIM,
+		.remove_flags = 0,
+		.context = (void *) 0xDEADBEEF,
+	};
+	struct gnix_fab_req *found;
+
+	ret = _gnix_insert_tag(
+			test_tag_storage, request.req.tag,
+			&request.req, request.ignore);
+	cr_assert(ret == FI_SUCCESS, "failed to insert tag into storage");
+
+	found = _gnix_match_tag(
+			test_tag_storage, request.req.tag, request.ignore,
+			request.peek_flags, request.context, NULL);
+	cr_assert(found == &request.req, "failed to find tag in storage");
+
+	found = _gnix_match_tag(
+			test_tag_storage, request.req.tag, request.ignore,
+			request.remove_flags, request.context, NULL);
+	cr_assert(found == NULL, "found an unexpected tag during remove");
+
+	/* use the peek tags this time to remove the entry */
+	found = _gnix_match_tag(
+			test_tag_storage, request.req.tag, request.ignore,
+			FI_CLAIM, request.context, NULL);
+	cr_assert(found == &request.req, "failed to find tag in storage");
+}
+
+static inline void __test_fail_peek_all_claimed(
+		struct gnix_tag_storage_attr *test_attr)
+{
+	int ret;
+	struct gnix_fr_element request = {
+		.req = {
+			.tag = 0xA5A5A5A5,
+			.ignore_bits = 0xFFFFFFFF
+		},
+		.peek_flags = FI_PEEK,
+		.remove_flags = FI_CLAIM,
+		.context = (void *) 0xDEADBEEF,
+	};
+	struct gnix_fab_req *found;
+
+	ret = _gnix_insert_tag(
+			test_tag_storage, request.req.tag,
+			&request.req, request.ignore);
+	cr_assert(ret == FI_SUCCESS, "failed to insert tag into storage");
+
+	found = _gnix_match_tag(
+			test_tag_storage, request.req.tag, request.ignore,
+				request.peek_flags | FI_CLAIM, request.context, NULL);
+	cr_assert(found == &request.req, "fail to claim tag");
+
+	found = _gnix_match_tag(
+			test_tag_storage, request.req.tag, request.ignore,
+			request.peek_flags, request.context, NULL);
+	cr_assert(found == NULL, "unexpectedly found a tag");
+
+	found = _gnix_match_tag(
+			test_tag_storage, request.req.tag, request.ignore,
+			request.remove_flags, request.context, NULL);
+	cr_assert(found == &request.req, "failed to remove tag from storage");
+}
+
+static inline void __test_src_addr_match(
+		struct gnix_tag_storage_attr *test_attr)
+{
+	int ret;
+	struct gnix_fr_element request = {
+		.req = {
+			.tag = 0xA5A5A5A5,
+			.addr = {
+				.cdm_id = 1,
+				.device_addr = 1,
+			},
+		},
+		.peek_flags = FI_PEEK,
+	};
+	struct gnix_fab_req *found;
+
+	ret = _gnix_insert_tag(
+			test_tag_storage, request.req.tag,
+			&request.req, request.ignore);
+	cr_assert(ret == FI_SUCCESS, "failed to insert tag into storage");
+
+	found = _gnix_match_tag(
+			test_tag_storage, request.req.tag,
+			request.ignore, request.peek_flags,
+			request.context, &request.req.addr);
+	cr_assert(found == &request.req, "failed to find tag in storage");
+
+	found = _gnix_match_tag(
+			test_tag_storage, request.req.tag,
+			request.ignore, request.remove_flags,
+			request.context, &request.req.addr);
+	cr_assert(found == &request.req, "failed to remove tag from storage");
+}
+
+/* tests to ensure you cannot remove an unclaimed messge when FI_CLAIM is set */
+static inline void __test_src_addr_fail_wrong_src_addr(
+		struct gnix_tag_storage_attr *test_attr)
+{
+	int ret;
+	struct gnix_fab_req *found;
+	struct gnix_fr_element request = {
+		.req = {
+			.tag = 0xA5A5A5A5,
+			.addr = {
+				.cdm_id = 1,
+				.device_addr = 1,
+			},
+		},
+		.ignore = 0,
+		.addr_ignore = 0,
+		.peek_flags = FI_PEEK,
+	};
+	struct gnix_address addr_to_find = {
+			.cdm_id = 1,
+			.device_addr = 2,
+	};
+
+	/* hack, don't actually do this */
+	test_tag_storage->attr.use_src_addr_matching = 1;
+
+	ret = _gnix_insert_tag(
+			test_tag_storage, request.req.tag,
+			&request.req, request.ignore);
+	cr_assert(ret == FI_SUCCESS, "failed to insert tag into storage");
+
+	found = _gnix_match_tag(
+			test_tag_storage, request.req.tag,
+			request.ignore, request.peek_flags,
+			request.context, &addr_to_find);
+	cr_assert(found == NULL, "found unexpected tag");
+
+	found = _gnix_match_tag(
+			test_tag_storage, request.req.tag,
+				request.ignore, request.peek_flags,
+				request.context, &request.req.addr);
+	cr_assert(found == &request.req, "failed to find tag in storage");
+
+	found = _gnix_match_tag(
+			test_tag_storage, request.req.tag,
+			request.ignore, request.remove_flags,
+			request.context, &request.req.addr);
+	cr_assert(found == &request.req, "failed to find tag in storage");
+}
+
+/* test to ensure you cannot remove a message that has been claimed */
+static inline void __test_src_addr_match_unspec(
+		struct gnix_tag_storage_attr *test_attr)
+{
+	int ret;
+	struct gnix_fr_element request = {
+		.req = {
+			.tag = 0xA5A5A5A5,
+			.addr = {
+				.cdm_id = 1,
+				.device_addr = 1,
+			},
+		},
+		.peek_flags = FI_PEEK,
+		.ignore = 0,
+		.addr_ignore = 0,
+	};
+	struct gnix_fab_req *found;
+	struct gnix_address to_find = {
+			.cdm_id = -1,
+			.device_addr = -1,
+	};
+
+
+	if (test_tag_storage->match_func == _gnix_match_posted_tag) {
+		/* swap addresses because posted tag receives check
+		 * the address in the request for unspec rather than
+		 * looking at the address in the parameters
+		 */
+		request.req.addr.cdm_id = -1;
+		request.req.addr.device_addr = -1;
+
+		to_find.cdm_id = 1;
+		to_find.device_addr = 1;
+	}
+
+
+
+	/* hack, don't actually do this */
+	test_tag_storage->attr.use_src_addr_matching = 1;
+
+	ret = _gnix_insert_tag(
+			test_tag_storage, request.req.tag,
+			&request.req, request.ignore);
+	cr_assert(ret == FI_SUCCESS, "failed to insert tag into storage");
+
+
+
+	found = _gnix_match_tag(
+			test_tag_storage, request.req.tag,
+			request.ignore, request.peek_flags,
+			request.context, &to_find);
+	cr_assert(found == &request.req, "failed to find tag in storage");
+
+	found = _gnix_match_tag(
+			test_tag_storage, request.req.tag,
+			request.ignore, request.remove_flags,
+			request.context, &to_find);
+	cr_assert(found == &request.req, "failed to find tag in storage");
+}
+
+static void single_insert_peek_remove(
+		struct gnix_tag_storage *ts,
+		struct __test_mask *mask,
+		struct gnix_fr_element *reqs)
+{
+	int correct_order, removal_order;
+
+	multiple_insert_peek_remove_inorder(ts, mask, 1, reqs, &correct_order,
+			&removal_order);
+}
+
+/*
+ * Basic functionality tests for the gnix_bitmap_t object
+ */
+
+TestSuite(gnix_tags_bare,
+		.init = __gnix_tags_bare_test_setup,
+		.fini = __gnix_tags_bare_test_teardown);
+
+TestSuite(gnix_tags_basic_posted_list,
+		.init = __gnix_tags_basic_posted_list_test_setup,
+		.fini = __gnix_tags_basic_test_teardown);
+
+TestSuite(gnix_tags_basic_posted_hlist,
+		.init = __gnix_tags_basic_posted_hlist_test_setup,
+		.fini = __gnix_tags_basic_test_teardown);
+
+TestSuite(gnix_tags_basic_posted_kdtree,
+		.init = __gnix_tags_basic_posted_kdtree_test_setup,
+		.fini = __gnix_tags_basic_test_teardown);
+
+TestSuite(gnix_tags_basic_unexpected_list,
+		.init = __gnix_tags_basic_unexpected_list_test_setup,
+		.fini = __gnix_tags_basic_test_teardown);
+
+TestSuite(gnix_tags_basic_unexpected_hlist,
+		.init = __gnix_tags_basic_unexpected_hlist_test_setup,
+		.fini = __gnix_tags_basic_test_teardown);
+
+TestSuite(gnix_tags_basic_unexpected_kdtree,
+		.init = __gnix_tags_basic_unexpected_kdtree_test_setup,
+		.fini = __gnix_tags_basic_test_teardown);
+
+Test(gnix_tags_bare, uninitialized)
+{
+	cr_assert(test_tag_storage->gen == 0);
+	cr_assert(test_tag_storage->attr.type == GNIX_TAG_AUTOSELECT);
+	cr_assert(test_tag_storage->state == GNIX_TS_STATE_UNINITIALIZED);
+}
+
+Test(gnix_tags_bare, initialize_list)
+{
+	int ret;
+
+	ret = _gnix_tag_storage_init(test_tag_storage, &default_list_attr,
+			match_func);
+	cr_assert(ret == FI_SUCCESS);
+
+	ret = _gnix_tag_storage_destroy(test_tag_storage);
+	cr_assert(ret == FI_SUCCESS);
+}
+
+
+Test(gnix_tags_bare, initialize_hlist)
+{
+	int ret;
+
+	ret = _gnix_tag_storage_init(test_tag_storage, &default_hlist_attr,
+			match_func);
+	cr_assert(ret == -FI_ENOSYS);
+
+	//ret = _gnix_tag_storage_destroy(test_tag_storage);
+	//cr_assert(ret == FI_SUCCESS);
+}
+
+Test(gnix_tags_bare, initialize_kdtree)
+{
+	int ret;
+
+	ret = _gnix_tag_storage_init(test_tag_storage, &default_kdtree_attr,
+			match_func);
+	cr_assert(ret == -FI_ENOSYS);
+
+	//ret = _gnix_tag_storage_destroy(test_tag_storage);
+	//cr_assert(ret == FI_SUCCESS);
+}
+
+
+Test(gnix_tags_bare, initialize_auto)
+{
+	int ret;
+
+	ret = _gnix_tag_storage_init(test_tag_storage, &default_auto_attr,
+			match_func);
+	cr_assert(ret == FI_SUCCESS);
+
+	ret = _gnix_tag_storage_destroy(test_tag_storage);
+	cr_assert(ret == FI_SUCCESS);
+}
+
+Test(gnix_tags_bare, already_initialized)
+{
+	int ret;
+
+	ret = _gnix_tag_storage_init(test_tag_storage, &default_list_attr,
+			match_func);
+	cr_assert(ret == FI_SUCCESS);
+
+	ret = _gnix_tag_storage_init(test_tag_storage, &default_list_attr,
+			match_func);
+	cr_assert(ret == -FI_EINVAL);
+
+	ret = _gnix_tag_storage_destroy(test_tag_storage);
+	cr_assert(ret == FI_SUCCESS);
+}
+
+Test(gnix_tags_basic_posted_list, single_insert_remove)
+{
+	int i;
+	struct gnix_fr_element request = {
+		.req = {
+			.tag = 0xA5A5A5A5,
+			.ignore_bits = 0xFFFFFFFF
+		},
+		.peek_flags = FI_PEEK,
+	};
+	struct gnix_tag_storage_attr attr;
+
+	memcpy(&attr, &default_list_attr, sizeof(struct gnix_tag_storage_attr));
+
+	for (i = 0; i < TEST_OVERLAY_MAX; i++) {
+
+		single_insert_peek_remove(test_tag_storage,
+				&test_masks[i], &request);
+
+		/* make necessary alterations to the structure
+		 * for the next test mask
+		 */
+		reset_test_tag_storage(test_tag_storage, &attr);
+	}
+}
+
+Test(gnix_tags_basic_posted_list, multiple_16_ipr_random_tag)
+{
+	__test_multiple_type_ipr_reqs(16, &default_list_attr,
+			make_random_tags);
+}
+
+Test(gnix_tags_basic_posted_list, multiple_128_ipr_random_tag)
+{
+	__test_multiple_type_ipr_reqs(128, &default_list_attr,
+			make_random_tags);
+}
+
+Test(gnix_tags_basic_posted_list, multiple_1024_ipr_random_tag)
+{
+	__test_multiple_type_ipr_reqs(1024, &default_list_attr,
+			make_random_tags);
+}
+
+Test(gnix_tags_basic_posted_list, multiple_8192_ipr_random_tag)
+{
+	__test_multiple_type_ipr_reqs(8192, &default_list_attr,
+			make_random_tags);
+}
+
+Test(gnix_tags_basic_posted_list, multiple_16_ipr_sequential_tag)
+{
+	__test_multiple_type_ipr_reqs(16, &default_list_attr,
+			make_evenly_distributed_tags);
+}
+
+Test(gnix_tags_basic_posted_list, multiple_128_ipr_sequential_tag)
+{
+	__test_multiple_type_ipr_reqs(128, &default_list_attr,
+			make_evenly_distributed_tags);
+}
+
+Test(gnix_tags_basic_posted_list, multiple_1024_ipr_sequential_tag)
+{
+	__test_multiple_type_ipr_reqs(1024, &default_list_attr,
+			make_evenly_distributed_tags);
+}
+
+Test(gnix_tags_basic_posted_list, multiple_8192_ipr_sequential_tag)
+{
+	__test_multiple_type_ipr_reqs(8192, &default_list_attr,
+			make_evenly_distributed_tags);
+}
+
+Test(gnix_tags_basic_posted_list, multiple_8_duplicate_tags)
+{
+	__test_multiple_8_duplicate_tags(&default_list_attr);
+}
+
+Test(gnix_tags_basic_posted_list, not_found_non_empty)
+{
+	__test_not_found_non_empty();
+}
+
+Test(gnix_tags_basic_posted_list, not_found_empty)
+{
+	__test_not_found_empty();
+}
+
+Test(gnix_tags_basic_posted_list, ignore_mask_set)
+{
+	__test_ignore_mask_set(&default_list_attr);
+}
+
+Test(gnix_tags_basic_posted_list, fi_claim_pass)
+{
+	__test_claim_pass(&default_list_attr);
+}
+
+Test(gnix_tags_basic_posted_list, fi_claim_fail_no_claimed_tags)
+{
+	__test_fail_no_claimed_tags(&default_list_attr);
+}
+
+Test(gnix_tags_basic_posted_list, fi_claim_fail_all_claimed_tags)
+{
+	__test_fail_all_claimed_tags(&default_list_attr);
+}
+
+Test(gnix_tags_basic_posted_list, fi_claim_fail_peek_all_claimed)
+{
+	__test_fail_peek_all_claimed(&default_list_attr);
+}
+
+/* unexpected list src address matching tests */
+Test(gnix_tags_basic_posted_list, src_addr_match_success)
+{
+	__test_src_addr_match(&default_list_attr);
+}
+
+Test(gnix_tags_basic_posted_list, src_addr_no_match_wrong_addr)
+{
+	__test_src_addr_fail_wrong_src_addr(&default_list_attr);
+}
+
+Test(gnix_tags_basic_posted_list, src_addr_match_unspec)
+{
+	__test_src_addr_match_unspec(&default_list_attr);
+}
+
+
+/*
+ * unexpected list tests
+ */
+
+Test(gnix_tags_basic_unexpected_list, single_insert_remove)
+{
+	int i;
+	struct gnix_fr_element request = {
+		.req = {
+			.tag = 0xA5A5A5A5,
+			.ignore_bits = 0xFFFFFFFF
+		},
+		.peek_flags = FI_PEEK,
+	};
+	struct gnix_tag_storage_attr attr;
+
+	memcpy(&attr, &default_list_attr, sizeof(struct gnix_tag_storage_attr));
+
+	for (i = 0; i < TEST_OVERLAY_MAX; i++) {
+
+		single_insert_peek_remove(test_tag_storage,
+				&test_masks[i], &request);
+
+		/* make necessary alterations to the structure
+		 * for the next test mask
+		 */
+		reset_test_tag_storage(test_tag_storage, &attr);
+	}
+}
+
+Test(gnix_tags_basic_unexpected_list, multiple_16_ipr_random_tag)
+{
+	__test_multiple_type_ipr_reqs(16, &default_list_attr,
+			make_random_tags);
+}
+
+Test(gnix_tags_basic_unexpected_list, multiple_128_ipr_random_tag)
+{
+	__test_multiple_type_ipr_reqs(128, &default_list_attr,
+			make_random_tags);
+}
+
+Test(gnix_tags_basic_unexpected_list, multiple_1024_ipr_random_tag)
+{
+	__test_multiple_type_ipr_reqs(1024, &default_list_attr,
+			make_random_tags);
+}
+
+Test(gnix_tags_basic_unexpected_list, multiple_8192_ipr_random_tag)
+{
+	__test_multiple_type_ipr_reqs(8192, &default_list_attr,
+			make_random_tags);
+}
+
+Test(gnix_tags_basic_unexpected_list, multiple_16_ipr_sequential_tag)
+{
+	__test_multiple_type_ipr_reqs(16, &default_list_attr,
+			make_evenly_distributed_tags);
+}
+
+Test(gnix_tags_basic_unexpected_list, multiple_128_ipr_sequential_tag)
+{
+	__test_multiple_type_ipr_reqs(128, &default_list_attr,
+			make_evenly_distributed_tags);
+}
+
+Test(gnix_tags_basic_unexpected_list, multiple_1024_ipr_sequential_tag)
+{
+	__test_multiple_type_ipr_reqs(1024, &default_list_attr,
+			make_evenly_distributed_tags);
+}
+
+Test(gnix_tags_basic_unexpected_list, multiple_8192_ipr_sequential_tag)
+{
+	__test_multiple_type_ipr_reqs(8192, &default_list_attr,
+			make_evenly_distributed_tags);
+}
+
+Test(gnix_tags_basic_unexpected_list, multiple_8_duplicate_tags)
+{
+	__test_multiple_8_duplicate_tags(&default_list_attr);
+}
+
+Test(gnix_tags_basic_unexpected_list, not_found_non_empty)
+{
+	__test_not_found_non_empty();
+}
+
+Test(gnix_tags_basic_unexpected_list, not_found_empty)
+{
+	__test_not_found_empty();
+}
+
+Test(gnix_tags_basic_unexpected_list, ignore_mask_set)
+{
+	__test_ignore_mask_set(&default_list_attr);
+}
+
+Test(gnix_tags_basic_unexpected_list, fi_claim_pass)
+{
+	__test_claim_pass(&default_list_attr);
+}
+
+Test(gnix_tags_basic_unexpected_list, fi_claim_fail_no_claimed_tags)
+{
+	__test_fail_no_claimed_tags(&default_list_attr);
+}
+
+Test(gnix_tags_basic_unexpected_list, fi_claim_fail_all_claimed_tags)
+{
+	__test_fail_all_claimed_tags(&default_list_attr);
+}
+
+Test(gnix_tags_basic_unexpected_list, fi_claim_fail_peek_all_claimed)
+{
+	__test_fail_peek_all_claimed(&default_list_attr);
+}
+
+/* unexpected list src address matching tests */
+Test(gnix_tags_basic_unexpected_list, src_addr_match_success)
+{
+	__test_src_addr_match(&default_list_attr);
+}
+
+Test(gnix_tags_basic_unexpected_list, src_addr_no_match_wrong_addr)
+{
+	__test_src_addr_fail_wrong_src_addr(&default_list_attr);
+}
+
+Test(gnix_tags_basic_unexpected_list, src_addr_match_unspec)
+{
+	__test_src_addr_match_unspec(&default_list_attr);
+}


### PR DESCRIPTION
This commit provides a list based tag matching system that observes the rules for tag matching as specified by the libfabric man pages. This matching system also allows for address matching which seems necessary for FI_DIRECTED_RECV support.

Signed-off-by: James Swaro jswaro@cray.com

Please review @hppritcha  @sungeunchoi  @ztiffany  @jshimek 

closes #281 
