### PR TITLE
Add domain open_ops functionality

### DIFF
--- a/prov/gni/Makefile.am
+++ b/prov/gni/Makefile.am
@@ -58,7 +58,8 @@ prov_gni_test_gnitest_SOURCES = \
 	prov/gni/test/vc.c \
 	prov/gni/test/rdm_rma.c \
 	prov/gni/test/rdm_sr.c \
-	prov/gni/test/cntr.c
+	prov/gni/test/cntr.c \
+	prov/gni/test/dom.c
 
 prov_gni_test_gnitest_LDFLAGS = -static
 prov_gni_test_gnitest_CPPFLAGS = $(AM_CPPFLAGS)
@@ -76,3 +77,6 @@ else !HAVE_GNI_DL
 src_libfabric_la_SOURCES += $(_gni_files)
 endif !HAVE_GNI_DL
 endif
+
+rdmainclude_HEADERS += \
+	prov/gni/include/fi_ext_gni.h

--- a/prov/gni/include/fi_ext_gni.h
+++ b/prov/gni/include/fi_ext_gni.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _FI_EXT_GNI_H_
+#define _FI_EXT_GNI_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#define FI_GNI_DOMAIN_OPS "domain ops"
+typedef enum dom_ops_val { GNI_MSG_RENDEZVOUS_THRESHOLD,
+			   GNI_CONN_TABLE_INITIAL_SIZE,
+			   GNI_CONN_TABLE_MAX_SIZE,
+			   GNI_CONN_TABLE_STEP_SIZE,
+			   GNI_VC_ID_TABLE_CAPACITY,
+			   GNI_MBOX_PAGE_SIZE,
+			   GNI_MBOX_NUM_PER_SLAB,
+			   GNI_MBOX_MAX_CREDIT,
+			   GNI_MBOX_MSG_MAX_SIZE,
+			   GNI_NUM_DOM_OPS
+} dom_ops_val_t;
+
+/* per domain gni provider specific ops */
+struct fi_gni_ops_domain {
+	int (*set_val)(struct fid *fid, dom_ops_val_t t, void *val);
+	int (*get_val)(struct fid *fid, dom_ops_val_t t, void *val);
+};
+
+/* per domain parameters */
+struct gnix_ops_domain {
+	uint32_t msg_rendezvous_thresh;
+	uint32_t ct_init_size;
+	uint32_t ct_max_size;
+	uint32_t ct_step;
+	uint32_t vc_id_table_capacity;
+	uint32_t mbox_page_size;
+	uint32_t mbox_num_per_slab;
+	uint32_t mbox_maxcredit;
+	uint32_t mbox_msg_maxsize;
+};
+
+#endif /* _FI_EXT_GNI_H_ */

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -66,8 +66,8 @@ extern "C" {
 #include "gnix_util.h"
 #include "gnix_freelist.h"
 #include "gnix_mr.h"
-
 #include "gnix_cq.h"
+#include "fi_ext_gni.h"
 
 #define GNI_MAJOR_VERSION 0
 #define GNI_MINOR_VERSION 5
@@ -251,6 +251,8 @@ struct gnix_fid_domain {
 	uint8_t ptag;
 	uint32_t cookie;
 	uint32_t cdm_id_seed;
+	/* user tunable parameters accessed via open_ops functions */
+	struct gnix_ops_domain params;
 	/* work queue for domain */
 	struct list_head domain_wq;
 	/* size of gni tx cqs for this domain */

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -1037,9 +1037,9 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 		if (ret != FI_SUCCESS)
 			goto err;
 
-		gnix_ht_attr.ht_initial_size = 64;     /* TODO: get from domain */
-		gnix_ht_attr.ht_maximum_size = 16384;  /* TODO: from domain */
-		gnix_ht_attr.ht_increase_step = 2;
+		gnix_ht_attr.ht_initial_size = domain_priv->params.ct_init_size;
+		gnix_ht_attr.ht_maximum_size = domain_priv->params.ct_max_size;
+		gnix_ht_attr.ht_increase_step = domain_priv->params.ct_step;
 		gnix_ht_attr.ht_increase_type = GNIX_HT_INCREASE_MULT;
 		gnix_ht_attr.ht_collision_thresh = 500;
 		gnix_ht_attr.ht_hash_seed = 0xdeadbeefbeefdead;

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -493,8 +493,6 @@ static int _gnix_send_req(void *data)
 	return gnixu_to_fi_errno(status);
 }
 
-#define GNIX_MSG_RENDEZVOUS_THRESH (16*1024)
-
 ssize_t _gnix_send(struct gnix_fid_ep *ep, uint64_t loc_addr, size_t len,
 		   void *mdesc, uint64_t dest_addr, void *context,
 		   uint64_t flags, uint64_t data)
@@ -516,7 +514,7 @@ ssize_t _gnix_send(struct gnix_fid_ep *ep, uint64_t loc_addr, size_t len,
 		return -FI_EINVAL;
 	}
 
-	rendezvous = len >= GNIX_MSG_RENDEZVOUS_THRESH;
+	rendezvous = len >= ep->domain->params.msg_rendezvous_thresh;
 
 	/* need a memory descriptor for large sends */
 	if (rendezvous && !mdesc) {

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -657,6 +657,7 @@ static int __gnix_vc_connect_prog_fn(void *data, int *complete_ptr)
 	struct gnix_mbox *mbox = NULL;
 	gni_smsg_attr_t smsg_mbox_attr;
 	struct gnix_fid_ep *ep = NULL;
+	struct gnix_fid_domain *dom = NULL;
 	struct gnix_cm_nic *cm_nic = NULL;
 	struct gnix_datagram *dgram = NULL;
 	enum gnix_vc_conn_req_type rtype = GNIX_VC_CONN_REQ_CONN;
@@ -666,6 +667,10 @@ static int __gnix_vc_connect_prog_fn(void *data, int *complete_ptr)
 
 	ep = vc->ep;
 	if (ep == NULL)
+		return -FI_EINVAL;
+
+	dom = ep->domain;
+	if (dom == NULL)
 		return -FI_EINVAL;
 
 	cm_nic = ep->cm_nic;
@@ -739,8 +744,8 @@ static int __gnix_vc_connect_prog_fn(void *data, int *complete_ptr)
 	smsg_mbox_attr.buff_size =  vc->ep->nic->mem_per_mbox;
 	smsg_mbox_attr.mem_hndl = *mbox->memory_handle;
 	smsg_mbox_attr.mbox_offset = (uint64_t)mbox->offset;
-	smsg_mbox_attr.mbox_maxcredit = 64; /* TODO: fix this */
-	smsg_mbox_attr.msg_maxsize =  16384;  /* TODO: definite fix */
+	smsg_mbox_attr.mbox_maxcredit = dom->params.mbox_maxcredit;
+	smsg_mbox_attr.msg_maxsize = dom->params.mbox_msg_maxsize;
 
 	/*
 	 * pack the things we need into the datagram in_box:
@@ -1026,6 +1031,7 @@ int _gnix_vc_accept(struct gnix_vc *vc)
 {
 	int ret = FI_SUCCESS;
 	struct gnix_fid_ep *ep = NULL;
+	struct gnix_fid_domain *dom = NULL;
 	struct gnix_cm_nic *cm_nic = NULL;
 	struct gnix_nic *nic = NULL;
 	struct gnix_mbox *mbox = NULL;
@@ -1038,6 +1044,10 @@ int _gnix_vc_accept(struct gnix_vc *vc)
 
 	ep = vc->ep;
 	if (ep == NULL)
+		return -FI_EINVAL;
+
+	dom = ep->domain;
+	if (dom == NULL)
 		return -FI_EINVAL;
 
 	cm_nic = ep->cm_nic;
@@ -1103,8 +1113,8 @@ int _gnix_vc_accept(struct gnix_vc *vc)
 	smsg_mbox_attr.buff_size =  nic->mem_per_mbox;
 	smsg_mbox_attr.mem_hndl = *mbox->memory_handle;
 	smsg_mbox_attr.mbox_offset = (uint64_t)mbox->offset;
-	smsg_mbox_attr.mbox_maxcredit = 64; /* TODO: fix this */
-	smsg_mbox_attr.msg_maxsize =  16384;  /* TODO: definite fix */
+	smsg_mbox_attr.mbox_maxcredit = dom->params.mbox_maxcredit;
+	smsg_mbox_attr.msg_maxsize =  dom->params.mbox_msg_maxsize;
 
 	/*
 	 * pack the things we need into the datagram in_box:

--- a/prov/gni/test/dom.c
+++ b/prov/gni/test/dom.c
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2015 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <getopt.h>
+#include <poll.h>
+#include <time.h>
+#include <string.h>
+
+#include <rdma/fabric.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_errno.h>
+#include <rdma/fi_endpoint.h>
+
+#include "gnix.h"
+
+#include <criterion/criterion.h>
+
+static struct fid_fabric *fabric;
+static struct fi_info *fi;
+
+static void setup(void)
+{
+	int ret;
+	struct fi_info *hints;
+
+	hints = fi_allocinfo();
+	cr_assert(hints, "fi_allocinfo");
+
+	hints->fabric_attr->name = strdup("gni");
+
+	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
+	cr_assert(ret == FI_SUCCESS, "fi_getinfo");
+
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
+	cr_assert(ret == FI_SUCCESS, "fi_fabric");
+
+	fi_freeinfo(hints);
+}
+
+static void teardown(void)
+{
+	int ret;
+
+	ret = fi_close(&fabric->fid);
+	cr_assert(ret == FI_SUCCESS, "fi_close fabric");
+
+	fi_freeinfo(fi);
+}
+
+TestSuite(domain, .init = setup, .fini = teardown);
+
+Test(domain, many_domains)
+{
+	int i, ret;
+	const int num_doms = 7919;
+	struct fid_domain *doms[num_doms];
+	struct gnix_fid_domain *gdom;
+	struct gnix_fid_fabric *gfab;
+
+	memset(doms, 0, num_doms*sizeof(struct fid_domain *));
+
+	gfab = container_of(fabric, struct gnix_fid_fabric, fab_fid);
+	for (i = 0; i < num_doms; i++) {
+		ret = fi_domain(fabric, fi, &doms[i], NULL);
+		cr_assert(ret == FI_SUCCESS, "fi_domain");
+		gdom = container_of(doms[i], struct gnix_fid_domain,
+				    domain_fid);
+		cr_assert(gdom, "domain not allcoated");
+		cr_assert(gdom->fabric == gfab, "Incorrect fabric");
+		cr_assert(atomic_get(&gdom->ref_cnt) == 0, "Incorrect ref_cnt");
+	}
+
+	for (i = num_doms-1; i >= 0; i--) {
+		ret = fi_close(&doms[i]->fid);
+		cr_assert(ret == FI_SUCCESS, "fi_close domain");
+	}
+
+}
+
+Test(domain, open_ops)
+{
+	int i, ret;
+	const int num_doms = 11;
+	struct fid_domain *doms[num_doms];
+	struct fi_gni_ops_domain *gni_domain_ops;
+	enum dom_ops_val op;
+	uint32_t val;
+
+	memset(doms, 0, num_doms*sizeof(struct fid_domain *));
+
+	for (i = 0; i < num_doms; i++) {
+		ret = fi_domain(fabric, fi, &doms[i], NULL);
+		cr_assert(ret == FI_SUCCESS, "fi_domain");
+		ret = fi_open_ops(&doms[i]->fid, FI_GNI_DOMAIN_OPS,
+				  0, (void **) &gni_domain_ops, NULL);
+		cr_assert(ret == FI_SUCCESS, "fi_open_ops");
+		for (op = 0; op < GNI_NUM_DOM_OPS; op++) {
+			val = i*op+op;
+			ret = gni_domain_ops->set_val(&doms[i]->fid, op, &val);
+			cr_assert(ret == FI_SUCCESS, "set_val");
+		}
+	}
+
+	for (i = num_doms-1; i >= 0; i--) {
+		for (op = 0; op < GNI_NUM_DOM_OPS; op++) {
+			ret = gni_domain_ops->get_val(&doms[i]->fid, op, &val);
+			cr_assert(ret == FI_SUCCESS, "get_val");
+			cr_assert(val == i*op+op, "Incorrect op value");
+		}
+		ret = fi_close(&doms[i]->fid);
+		cr_assert(ret == FI_SUCCESS, "fi_close domain");
+	}
+
+}
+
+Test(domain, invalid_open_ops)
+{
+	int ret;
+	struct fid_domain *dom;
+	struct fi_gni_ops_domain *gni_domain_ops;
+	uint32_t val = 0;
+
+	ret = fi_domain(fabric, fi, &dom, NULL);
+	cr_assert(ret == FI_SUCCESS, "fi_domain");
+	ret = fi_open_ops(&dom->fid, FI_GNI_DOMAIN_OPS,
+			  0, (void **) &gni_domain_ops, NULL);
+	cr_assert(ret == FI_SUCCESS, "fi_open_ops");
+
+	ret = gni_domain_ops->get_val(&dom->fid, GNI_NUM_DOM_OPS, &val);
+	cr_assert(ret == -FI_EINVAL, "get_val");
+
+	ret = gni_domain_ops->set_val(&dom->fid, GNI_NUM_DOM_OPS, &val);
+	cr_assert(ret == -FI_EINVAL, "set_val");
+
+	ret = fi_close(&dom->fid);
+	cr_assert(ret == FI_SUCCESS, "fi_close domain");
+}


### PR DESCRIPTION
Here's the first stab at the fi_open_ops functionality for domains based on Howard's suggestions for tunable domain parameters.

I named the user facing things with a gni/GNI prefix and made them intentionally descriptive (read: long) to be clear.  I'm open to other suggestions.

I added a new domain unit test, with a simple many domain creation test and a couple tests for getting and setting the new open_ops parameters.

Closes #242 

@hppritcha @jswaro @ztiffany @jshimek 

Provide set_val() and get_val() function to tune the following paramters:
- GNI_MSG_RENDEZVOUS_THRESHOLD
- GNI_CONN_TABLE_INITIAL_SIZE
- GNI_CONN_TABLE_MAX_SIZE
- GNI_CONN_TABLE_STEP_SIZE
- GNI_VC_ID_TABLE_CAPACITY
- GNI_MBOX_PAGE_SIZE
- GNI_MBOX_NUM_PER_SLAB
- GNI_MBOX_MAX_CREDIT
- GNI_MBOX_MSG_MAX_SIZE

All are of type uint32_t.

Users include "fi_ext_gni.h" and pass in FI_GNI_DOMAIN_OPS string to fi_open_ops to get access to this functionality.  See the new dom.c unit test for an example.

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com
