### PR TITLE
Fix assertion error in gnix_domain_close()

### DIFF
--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -67,8 +67,8 @@ typedef int (*smsg_completer_fn_t)(void  *desc);
 /**
  * GNIX nic struct
  *
- * @var list                 list element used for global NIC list
- * @var gnix_nic_list        list element used for nic linked list associated
+ * @var gnix_nic_list        list element used for global NIC list
+ * @var dom_nic_list         list element used for nic linked list associated
  *                           with a given gnix_fid_domain
  * @var lock                 lock used for serializing access to
  *                           gni_nic_hndl, rx_cq, and tx_cq
@@ -117,8 +117,8 @@ typedef int (*smsg_completer_fn_t)(void  *desc);
  *                           messages
  */
 struct gnix_nic {
-	struct dlist_entry list;          /* global NIC list */
-	struct dlist_entry gnix_nic_list; /* domain list */
+	struct dlist_entry gnix_nic_list; /* global NIC list */
+	struct dlist_entry dom_nic_list;  /* domain NIC list */
 	fastlock_t lock;
 	gni_cdm_handle_t gni_cdm_hndl;
 	gni_nic_handle_t gni_nic_hndl;

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -108,9 +108,9 @@ static int gnix_domain_close(fid_t fid)
 	 *  drops to 0, destroy the cdm, remove from
 	 *  the global nic list.
 	 */
-	dlist_for_each_safe(&domain->nic_list, p, next, list)
+	dlist_for_each_safe(&domain->nic_list, p, next, dom_nic_list)
 	{
-		dlist_remove(&p->list);
+		dlist_remove(&p->dom_nic_list);
 		v = atomic_dec(&p->ref_cnt);
 		assert(v >= 0);
 		if (v == 0) {

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -570,7 +570,7 @@ err:
 
 		dlist_remove(&nic->gnix_nic_list);
 		--gnix_nics_per_ptag[nic->ptag];
-		dlist_remove(&nic->list);
+		dlist_remove(&nic->dom_nic_list);
 
 		pthread_mutex_unlock(&gnix_nic_list_lock);
 
@@ -621,9 +621,9 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 		assert(!dlist_empty(&domain->nic_list));
 
 		nic = dlist_first_entry(&domain->nic_list, struct gnix_nic,
-					list);
-		dlist_remove(&nic->list);
-		dlist_insert_tail(&nic->list, &domain->nic_list);
+					dom_nic_list);
+		dlist_remove(&nic->dom_nic_list);
+		dlist_insert_tail(&nic->dom_nic_list, &domain->nic_list);
 		atomic_inc(&nic->ref_cnt);
 
 		GNIX_INFO(FI_LOG_EP_CTRL, "Reusing NIC:%p\n", nic);
@@ -859,7 +859,7 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 
 		dlist_insert_tail(&nic->gnix_nic_list, &gnix_nic_list);
 
-		dlist_insert_tail(&nic->list, &domain->nic_list);
+		dlist_insert_tail(&nic->dom_nic_list, &domain->nic_list);
 		++gnix_nics_per_ptag[domain->ptag];
 
 		GNIX_INFO(FI_LOG_EP_CTRL, "Allocated NIC:%p\n", nic);


### PR DESCRIPTION
Because the memory registration cache clean up can be the last reference to a nic, it must call _gnix_nic_free() rather than simply decrementing the nic's ref count.  Not doing so resulted in a negative
ref count in gnix_domain_close(), because it was not removed from the domain's nic list when the ref count reached 0.  This case is possible, because the endpoint that allocated the nic can be (and
often is) closed before the domain.

Note that I did not similarly change the ref count decrement in fi_gnix_mr_close(), because it seems to assume that it was not holding the last reference to the domain.  I'm not sure if this is correct, especially in the case of eager deregistration (@jswaro should check me on this).  Probably we should enable setting of the deregistration policy and test.

As part of this commit, I renamed the nic's list field to dom_nic_list for clarity (and fixed the documentation for it and gnix_nic_list).

This gets rid of all the assertions in gnix_domain_close() for gnitest.

Fixes #259

@hppritcha @jswaro @ztiffany @jshimek 

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com
