### PR TITLE
prov/gni: have crtiterion tests call PMI_Init

### DIFF
--- a/prov/gni/Makefile.am
+++ b/prov/gni/Makefile.am
@@ -41,6 +41,7 @@ if HAVE_CRITERION
 bin_PROGRAMS += prov/gni/test/gnitest
 dist_bin_SCRIPTS = prov/gni/test/run_gnitest
 prov_gni_test_gnitest_SOURCES = \
+	prov/gni/test/pmi_utils.c \
 	prov/gni/test/cq.c \
 	prov/gni/test/ep.c \
 	prov/gni/test/nic.c \
@@ -60,8 +61,8 @@ prov_gni_test_gnitest_SOURCES = \
 	prov/gni/test/rdm_sr.c \
 	prov/gni/test/cntr.c
 
-prov_gni_test_gnitest_LDFLAGS = -static
-prov_gni_test_gnitest_CPPFLAGS = $(AM_CPPFLAGS)
+prov_gni_test_gnitest_LDFLAGS = $(CRAY_PMI_LIBS) -static
+prov_gni_test_gnitest_CPPFLAGS = $(AM_CPPFLAGS) $(CRAY_PMI_CFLAGS)
 prov_gni_test_gnitest_LDADD = -lcriterion \
 		$(linkback)
 endif

--- a/prov/gni/configure.m4
+++ b/prov/gni/configure.m4
@@ -142,6 +142,9 @@ m4_include([config/pkg.m4])
 			else
 				have_criterion=false
 			fi
+			PKG_CHECK_MODULES([CRAY_PMI], [cray-pmi],
+					   [],
+					   [have_criterion=false])
 		else
 			AC_MSG_RESULT([no])
 			AC_MSG_ERROR([criterion requested but invalid path given])

--- a/prov/gni/test/pmi_utils.c
+++ b/prov/gni/test/pmi_utils.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include "pmi.h"
+#include "criterion/criterion.h"
+
+static int pmi_initialized;
+
+ReportHook(PRE_ALL)()
+{
+	int rc, spawned;
+
+	rc = PMI_Init(&spawned);
+	if (rc != PMI_SUCCESS) {
+		fprintf(stderr, "PMI_Init failed - returned %d.\n", rc);
+		fprintf(stderr, "Debugging support may not be available\n");
+	} else
+		pmi_initialized = 1;
+}
+
+ReportHook(POST_ALL)()
+{
+	if (pmi_initialized == 1)
+		PMI_Finalize();
+}


### PR DESCRIPTION
To use the lgdb debugger (or at least have a
hope of so doing), the criterion test needs to
call PMI_Init/PMI_Finalize.

Note the libfabric.so itself does not get linked
against the Cray PMI library.

@sungeunchoi 

Fixes #291 

Signed-off-by: Howard Pritchard howardp@lanl.gov
