### PR TITLE
prov/gni: remove unnecssary assert in ep enable

### DIFF
--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -669,7 +669,6 @@ static int gnix_ep_control(fid_t fid, int command, void *arg)
 		if (ep->type == FI_EP_RDM) {
 			dom = ep->domain;
 			for (i = 0; i < dom->fabric->n_wc_dgrams; i++) {
-				assert(ep->recv_cq != NULL);
 				ret = _gnix_vc_alloc(ep, FI_ADDR_UNSPEC, &vc);
 				if (ret != FI_SUCCESS) {
 					GNIX_WARN(FI_LOG_EP_CTRL,


### PR DESCRIPTION
We determined that it is not correct to assert
for recv_cq when enabling an ep.

Fixes #292 
@sungeunchoi 

Signed-off-by: Howard Pritchard howardp@lanl.gov
