### PR TITLE
Refactor functions to hold/put/destruct format for reference counting

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -490,6 +490,23 @@ int gnix_mr_reg(struct fid *fid, const void *buf, size_t len,
 int gnix_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 		 struct fid_cntr **cntr, void *context);
 
+int _gnix_av_get(struct gnix_fid_av *av);
+
+int _gnix_av_put(struct gnix_fid_av *av);
+
+int _gnix_domain_get(struct gnix_fid_domain *domain);
+
+int _gnix_domain_put(struct gnix_fid_domain *domain);
+
+int _gnix_fabric_get(struct gnix_fid_fabric *fab);
+
+int _gnix_fabric_put(struct gnix_fid_fabric *fab);
+
+int _gnix_ep_get(struct gnix_fid_ep *ep);
+
+int _gnix_ep_put(struct gnix_fid_ep *ep);
+
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/prov/gni/include/gnix_cntr.h
+++ b/prov/gni/include/gnix_cntr.h
@@ -49,6 +49,13 @@ struct gnix_cntr_poll_nic {
 	struct gnix_nic *nic;
 };
 
+enum {
+	GNIX_CNTR_STATE_UNINITIALIZED = 0,
+	GNIX_CNTR_STATE_READY,
+	GNIX_CNTR_STATE_WAITING_ON_REFS,
+	GNIX_CNTR_STATE_DEAD,
+};
+
 struct gnix_fid_cntr {
 	struct fid_cntr cntr_fid;
 	struct gnix_fid_domain *domain;
@@ -59,6 +66,7 @@ struct gnix_fid_cntr {
 	atomic_t cnt;
 	atomic_t cnt_err;
 	atomic_t ref_cnt;
+	int state;
 };
 
 /**
@@ -94,6 +102,11 @@ int _gnix_cntr_poll_nic_add(struct gnix_fid_cntr *cntr, struct gnix_nic *nic);
  * @return             FI_SUCCESS on success, -FI_EINVAL on invalid argument
  */
 int _gnix_cntr_poll_nic_rem(struct gnix_fid_cntr *cntr, struct gnix_nic *nic);
+
+
+int _gnix_cntr_put(struct gnix_fid_cntr *cntr);
+
+int _gnix_cntr_get(struct gnix_fid_cntr *cntr);
 
 #ifdef __cplusplus
 }

--- a/prov/gni/include/gnix_cq.h
+++ b/prov/gni/include/gnix_cq.h
@@ -92,6 +92,10 @@ ssize_t _gnix_cq_add_error(struct gnix_fid_cq *cq, void *op_context,
 int _gnix_cq_poll_nic_add(struct gnix_fid_cq *cq, struct gnix_nic *nic);
 int _gnix_cq_poll_nic_rem(struct gnix_fid_cq *cq, struct gnix_nic *nic);
 
+int _gnix_cq_get(struct gnix_fid_cq *cq);
+
+int _gnix_cq_put(struct gnix_fid_cq *cq);
+
 #ifdef __cplusplus
 }
 #endif

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -340,6 +340,11 @@ static inline void *__gnix_nic_elem_by_rem_id(struct gnix_nic *nic, int rem_id)
 	return 0;
 }
 
+int _gnix_nic_get(struct gnix_nic *nic);
+
+int _gnix_nic_put(struct gnix_nic *nic);
+
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/prov/gni/src/gnix_av.c
+++ b/prov/gni/src/gnix_av.c
@@ -445,6 +445,38 @@ static const char *gnix_av_straddr(struct fid_av *av, const void *addr,
 	return buf;
 }
 
+static void __av_destruct(struct gnix_fid_av *av)
+{
+	if (av->table) {
+		free(av->table);
+	}
+	free(av);
+}
+
+int _gnix_av_get(struct gnix_fid_av *av)
+{
+	int ret = atomic_inc(&av->ref_cnt);
+
+	assert(ret > 0);
+
+	return ret;
+}
+
+int _gnix_av_put(struct gnix_fid_av *av)
+{
+	int ret = atomic_dec(&av->ref_cnt);
+
+	assert(ret >= 0);
+
+	if (!ret) {
+		__av_destruct(av);
+	}
+
+	return ret;
+}
+
+
+
 /*
  * TODO: Free memory for data structures when FI_AV_MAP is fully supported.
  */
@@ -452,6 +484,7 @@ static int gnix_av_close(fid_t fid)
 {
 	struct gnix_fid_av *av = NULL;
 	int ret = FI_SUCCESS;
+	int references_held;
 
 	GNIX_TRACE(FI_LOG_AV, "\n");
 
@@ -461,15 +494,12 @@ static int gnix_av_close(fid_t fid)
 	}
 	av = container_of(fid, struct gnix_fid_av, av_fid.fid);
 
-	if (atomic_get(&av->ref_cnt) != 0) {
-		ret = -FI_EBUSY;
-		goto err;
+	references_held = _gnix_av_put(av);
+	if (references_held) {
+		GNIX_INFO(FI_LOG_AV, "failed to fully close av due to lingering "
+				"references. references=%i av=%p\n",
+				references_held, av);
 	}
-
-	if (av->table) {
-		free(av->table);
-	}
-	free(av);
 
 err:
 	return ret;
@@ -532,7 +562,7 @@ int gnix_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	int_av->av_fid.fid.context = context;
 	int_av->av_fid.fid.ops = &gnix_fi_av_ops;
 	int_av->av_fid.ops = &gnix_av_ops;
-	atomic_initialize(&int_av->ref_cnt, 0);
+	atomic_initialize(&int_av->ref_cnt, 1);
 
 	*av = &int_av->av_fid;
 

--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -410,24 +410,9 @@ int _gnix_cq_poll_nic_rem(struct gnix_fid_cq *cq, struct gnix_nic *nic)
 	return -FI_EINVAL;
 }
 
-/*******************************************************************************
- * API functions.
- ******************************************************************************/
-static int gnix_cq_close(fid_t fid)
+static void __cq_destruct(struct gnix_fid_cq *cq)
 {
-	struct gnix_fid_cq *cq;
-
-	GNIX_TRACE(FI_LOG_CQ, "\n");
-
-	cq = container_of(fid, struct gnix_fid_cq, cq_fid);
-	if (atomic_get(&cq->ref_cnt) != 0) {
-		GNIX_INFO(FI_LOG_CQ, "CQ ref count: %d, not closing.\n",
-			  cq->ref_cnt);
-		return -FI_EBUSY;
-	}
-
-	atomic_dec(&cq->domain->ref_cnt);
-	assert(atomic_get(&cq->domain->ref_cnt) >= 0);
+	_gnix_domain_put(cq->domain);
 
 	switch (cq->attr.wait_obj) {
 	case FI_WAIT_NONE:
@@ -454,6 +439,48 @@ static int gnix_cq_close(fid_t fid)
 	free(cq->cq_fid.ops);
 	free(cq->cq_fid.fid.ops);
 	free(cq);
+}
+
+int _gnix_cq_get(struct gnix_fid_cq *cq)
+{
+	int references_held = atomic_inc(&cq->ref_cnt);
+
+	assert(references_held > 0);
+
+	return references_held;
+}
+
+int _gnix_cq_put(struct gnix_fid_cq *cq)
+{
+	int references_held = atomic_dec(&cq->ref_cnt);
+
+	assert(references_held >= 0);
+
+	if (!references_held)
+		__cq_destruct(cq);
+
+	return references_held;
+}
+
+/*******************************************************************************
+ * API functions.
+ ******************************************************************************/
+static int gnix_cq_close(fid_t fid)
+{
+	struct gnix_fid_cq *cq;
+	int references_held;
+
+	GNIX_TRACE(FI_LOG_CQ, "\n");
+
+	cq = container_of(fid, struct gnix_fid_cq, cq_fid);
+
+	references_held = _gnix_cq_put(cq);
+
+	if (references_held) {
+		GNIX_INFO(FI_LOG_CQ, "failed to fully close cq due to lingering "
+				"references. references=%i cq=%p\n",
+				references_held, cq);
+	}
 
 	return FI_SUCCESS;
 }
@@ -634,8 +661,8 @@ int gnix_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 
 	cq_priv->domain = domain_priv;
 	cq_priv->attr = *attr;
-	atomic_initialize(&cq_priv->ref_cnt, 0);
-	atomic_inc(&cq_priv->domain->ref_cnt);
+	atomic_initialize(&cq_priv->ref_cnt, 1);
+	_gnix_domain_get(cq_priv->domain);
 	dlist_init(&cq_priv->poll_nics);
 	rwlock_init(&cq_priv->nic_lock);
 
@@ -676,7 +703,7 @@ int gnix_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 err5:
 	_gnix_queue_destroy(cq_priv->events);
 err4:
-	atomic_dec(&cq_priv->domain->ref_cnt);
+	_gnix_domain_put(cq_priv->domain);
 	fastlock_destroy(&cq_priv->lock);
 err3:
 	free(cq_priv);

--- a/prov/gni/src/gnix_eq.c
+++ b/prov/gni/src/gnix_eq.c
@@ -236,8 +236,9 @@ int gnix_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 	eq_priv->fabric = container_of(fabric, struct gnix_fid_fabric,
 					  fab_fid);
 
-	atomic_initialize(&eq_priv->ref_cnt, 0);
-	atomic_inc(&eq_priv->fabric->ref_cnt);
+	atomic_initialize(&eq_priv->ref_cnt, 1);
+
+	_gnix_fabric_get(eq_priv->fabric);
 
 	eq_priv->eq_fid.fid.fclass = FI_CLASS_EQ;
 	eq_priv->eq_fid.fid.context = context;
@@ -268,32 +269,16 @@ int gnix_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 err2:
 	_gnix_queue_destroy(eq_priv->events);
 err1:
-	atomic_dec(&eq_priv->fabric->ref_cnt);
+	_gnix_fabric_put(eq_priv->fabric);
 	fastlock_destroy(&eq_priv->lock);
 err:
 	free(eq_priv);
 	return ret;
 }
 
-static int gnix_eq_close(struct fid *fid)
+static void __eq_destruct(struct gnix_fid_eq *eq)
 {
-	struct gnix_fid_eq *eq;
-
-	GNIX_TRACE(FI_LOG_EQ, "\n");
-
-	if (!fid)
-		return -FI_EINVAL;
-
-	eq = container_of(fid, struct gnix_fid_eq, eq_fid);
-
-	if (atomic_get(&eq->ref_cnt) != 0) {
-		GNIX_INFO(FI_LOG_EQ, "EQ ref count: %d, not closing.\n",
-			  eq->ref_cnt);
-		return -FI_EBUSY;
-	}
-
-	atomic_dec(&eq->fabric->ref_cnt);
-	assert(atomic_get(&eq->fabric->ref_cnt) >= 0);
+	_gnix_fabric_put(eq->fabric);
 
 	fastlock_destroy(&eq->lock);
 
@@ -319,6 +304,47 @@ static int gnix_eq_close(struct fid *fid)
 	_gnix_queue_destroy(eq->errors);
 
 	free(eq);
+}
+
+int _gnix_eq_hold(struct gnix_fid_eq *eq)
+{
+	int references_held = atomic_inc(&eq->ref_cnt);
+
+	assert(references_held > 0);
+
+	return references_held;
+}
+
+int _gnix_eq_put(struct gnix_fid_eq *eq)
+{
+	int references_held = atomic_dec(&eq->ref_cnt);
+
+	assert(references_held >= 0);
+
+	if (!references_held)
+		__eq_destruct(eq);
+
+	return references_held;
+}
+
+static int gnix_eq_close(struct fid *fid)
+{
+	struct gnix_fid_eq *eq;
+	int references_held;
+
+	GNIX_TRACE(FI_LOG_EQ, "\n");
+
+	if (!fid)
+		return -FI_EINVAL;
+
+	eq = container_of(fid, struct gnix_fid_eq, eq_fid);
+
+	references_held = _gnix_eq_put(eq);
+	if (references_held) {
+		GNIX_INFO(FI_LOG_EQ, "failed to fully close eq due "
+				"to lingering references. references=%i eq=%p\n",
+				references_held, eq);
+	}
 
 	return FI_SUCCESS;
 }

--- a/prov/gni/src/gnix_mr.c
+++ b/prov/gni/src/gnix_mr.c
@@ -211,7 +211,9 @@ static inline int __mr_cache_entry_destroy(
 	ret = GNI_MemDeregister(entry->nic->gni_nic_hndl, &entry->mem_hndl);
 	fastlock_release(&entry->nic->lock);
 	if (ret == GNI_RC_SUCCESS) {
-		atomic_dec(&entry->domain->ref_cnt);
+		/* release reference to domain */
+		_gnix_domain_put(entry->domain);
+
 		/* This may be last ref to nic, so must call _gnix_nic_free */
 		_gnix_nic_free(entry->nic);
 
@@ -392,7 +394,7 @@ int gnix_mr_reg(struct fid *fid, const void *buf, size_t len,
 
 	/* md.domain */
 	mr->domain = domain;
-	atomic_inc(&domain->ref_cnt); /* take reference on domain */
+	_gnix_domain_get(mr->domain); /* take reference on domain */
 
 	/* md.mr_fid */
 	mr->mr_fid.fid.fclass = FI_CLASS_MR;
@@ -400,7 +402,7 @@ int gnix_mr_reg(struct fid *fid, const void *buf, size_t len,
 	mr->mr_fid.fid.ops = &fi_gnix_mr_ops;
 
 	/* nic */
-	atomic_inc(&mr->nic->ref_cnt); /* take reference on nic */
+	_gnix_nic_get(mr->nic); /* take reference on nic */
 
 	/* setup internal key structure */
 	mr->mr_fid.key = _gnix_convert_mhdl_to_key(&mr->mem_hndl);
@@ -445,8 +447,8 @@ static int fi_gnix_mr_close(fid_t fid)
 	/* check retcode */
 	if (likely(ret == FI_SUCCESS)) {
 		/* release references to the domain and nic */
-		atomic_dec(&mr->domain->ref_cnt);
-		atomic_dec(&mr->nic->ref_cnt);
+		_gnix_domain_put(mr->domain);
+		_gnix_nic_put(mr->nic);
 
 		free(mr);
 	} else {
@@ -798,8 +800,9 @@ static int __mr_cache_register(
 	entry->domain = domain;
 	entry->nic = nic;
 
-	atomic_inc(&entry->domain->ref_cnt);
-	atomic_inc(&entry->nic->ref_cnt);
+	/* take references on domain and nic */
+	_gnix_domain_get(entry->domain);
+	_gnix_nic_get(entry->nic);
 
 success:
 	mr->nic = entry->nic;

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -483,102 +483,143 @@ static void __gnix_nic_tx_freelist_destroy(struct gnix_nic *nic)
  * free a gnix nic and associated resources if refcnt drops to 0
  */
 
+static void __nic_destruct(struct gnix_nic *nic)
+{
+	int ret = FI_SUCCESS;
+	gni_return_t status = GNI_RC_SUCCESS;
+
+	if (!nic->gni_cdm_hndl) {
+		GNIX_ERR(FI_LOG_EP_CTRL, "No CDM attached to nic, nic=%p");
+	}
+
+	assert(nic->gni_cdm_hndl != NULL);
+
+	if (nic->rx_cq_blk != NULL) {
+		status = GNI_CqDestroy(nic->rx_cq_blk);
+		if (status != GNI_RC_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "GNI_CqDestroy returned %s\n",
+				 gni_err_str[status]);
+			ret = gnixu_to_fi_errno(status);
+			goto err;
+		}
+	}
+
+	if (nic->rx_cq != NULL) {
+		status = GNI_CqDestroy(nic->rx_cq);
+		if (status != GNI_RC_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "GNI_CqDestroy returned %s\n",
+				 gni_err_str[status]);
+			ret = gnixu_to_fi_errno(status);
+			goto err;
+		}
+	}
+
+	if (nic->tx_cq_blk != NULL) {
+		status = GNI_CqDestroy(nic->tx_cq_blk);
+		if (status != GNI_RC_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "GNI_CqDestroy returned %s\n",
+				 gni_err_str[status]);
+			ret = gnixu_to_fi_errno(status);
+			goto err;
+		}
+	}
+
+	if (nic->tx_cq != NULL) {
+		status = GNI_CqDestroy(nic->tx_cq);
+		if (status != GNI_RC_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "GNI_CqDestroy returned %s\n",
+				 gni_err_str[status]);
+			ret = gnixu_to_fi_errno(status);
+			goto err;
+		}
+	}
+
+	status = GNI_CdmDestroy(nic->gni_cdm_hndl);
+	if (status != GNI_RC_SUCCESS) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "GNI_CdmDestroy returned %s\n",
+			  gni_err_str[status]);
+		ret = gnixu_to_fi_errno(status);
+		goto err;
+	}
+
+	ret = _gnix_mbox_allocator_destroy(nic->mbox_hndl);
+	if (ret != FI_SUCCESS)
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "_gnix_mbox_allocator_destroy returned %d\n",
+			  ret);
+
+	ret = _gnix_mbox_allocator_destroy(nic->s_rdma_buf_hndl);
+	if (ret != FI_SUCCESS)
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "_gnix_mbox_allocator_destroy returned %d\n",
+			  ret);
+
+	ret = _gnix_mbox_allocator_destroy(nic->r_rdma_buf_hndl);
+	if (ret != FI_SUCCESS)
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "_gnix_mbox_allocator_destroy returned %d\n",
+			  ret);
+
+	/*
+	 * remove the nic from the linked lists
+	 * for the domain and the global nic list
+	 */
+
+err:
+	pthread_mutex_lock(&gnix_nic_list_lock);
+
+	dlist_remove(&nic->gnix_nic_list);
+	--gnix_nics_per_ptag[nic->ptag];
+	dlist_remove(&nic->dom_nic_list);
+
+	pthread_mutex_unlock(&gnix_nic_list_lock);
+
+	__gnix_nic_tx_freelist_destroy(nic);
+	free(nic);
+}
+
+int _gnix_nic_get(struct gnix_nic *nic)
+{
+	int references_held = atomic_inc(&nic->ref_cnt);
+
+	assert(references_held > 0);
+
+	return references_held;
+}
+
+int _gnix_nic_put(struct gnix_nic *nic)
+{
+	int references_held = atomic_dec(&nic->ref_cnt);
+
+	assert(references_held >= 0);
+
+	if (!references_held)
+		__nic_destruct(nic);
+
+	return references_held;
+}
+
 int _gnix_nic_free(struct gnix_nic *nic)
 {
-	int ret = FI_SUCCESS, v;
-	gni_return_t status = GNI_RC_SUCCESS;
+	int references_held;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
 	if (nic == NULL)
 		return -FI_EINVAL;
 
-	v = atomic_dec(&nic->ref_cnt);
-	assert(v >= 0);
+	references_held = _gnix_nic_put(nic);
+	if (references_held)
+		GNIX_INFO(FI_LOG_EP_CTRL, "failed to fully close nic due to "
+				"lingering references. references=%i nic=%p\n",
+				references_held, nic);
 
-	if ((nic->gni_cdm_hndl != NULL) && (v == 0))  {
-		if (nic->rx_cq_blk != NULL)
-			status = GNI_CqDestroy(nic->rx_cq_blk);
-			if (status != GNI_RC_SUCCESS) {
-				GNIX_WARN(FI_LOG_EP_CTRL,
-					  "GNI_CqDestroy returned %s\n",
-					 gni_err_str[status]);
-				ret = gnixu_to_fi_errno(status);
-				goto err;
-			}
-		if (nic->rx_cq != NULL)
-			status = GNI_CqDestroy(nic->rx_cq);
-			if (status != GNI_RC_SUCCESS) {
-				GNIX_WARN(FI_LOG_EP_CTRL,
-					  "GNI_CqDestroy returned %s\n",
-					 gni_err_str[status]);
-				ret = gnixu_to_fi_errno(status);
-				goto err;
-			}
-		if (nic->tx_cq_blk != NULL)
-			status = GNI_CqDestroy(nic->tx_cq_blk);
-			if (status != GNI_RC_SUCCESS) {
-				GNIX_WARN(FI_LOG_EP_CTRL,
-					  "GNI_CqDestroy returned %s\n",
-					 gni_err_str[status]);
-				ret = gnixu_to_fi_errno(status);
-				goto err;
-			}
-		if (nic->tx_cq != NULL)
-			status = GNI_CqDestroy(nic->tx_cq);
-			if (status != GNI_RC_SUCCESS) {
-				GNIX_WARN(FI_LOG_EP_CTRL,
-					  "GNI_CqDestroy returned %s\n",
-					 gni_err_str[status]);
-				ret = gnixu_to_fi_errno(status);
-				goto err;
-			}
-		status = GNI_CdmDestroy(nic->gni_cdm_hndl);
-		if (status != GNI_RC_SUCCESS) {
-			GNIX_WARN(FI_LOG_EP_CTRL,
-				  "GNI_CdmDestroy returned %s\n",
-				  gni_err_str[status]);
-			ret = gnixu_to_fi_errno(status);
-			goto err;
-		}
-
-		ret = _gnix_mbox_allocator_destroy(nic->mbox_hndl);
-		if (ret != FI_SUCCESS)
-			GNIX_WARN(FI_LOG_EP_CTRL,
-				  "_gnix_mbox_allocator_destroy returned %d\n",
-				  ret);
-
-		ret = _gnix_mbox_allocator_destroy(nic->s_rdma_buf_hndl);
-		if (ret != FI_SUCCESS)
-			GNIX_WARN(FI_LOG_EP_CTRL,
-				  "_gnix_mbox_allocator_destroy returned %d\n",
-				  ret);
-
-		ret = _gnix_mbox_allocator_destroy(nic->r_rdma_buf_hndl);
-		if (ret != FI_SUCCESS)
-			GNIX_WARN(FI_LOG_EP_CTRL,
-				  "_gnix_mbox_allocator_destroy returned %d\n",
-				  ret);
-
-		/*
-		 * remove the nic from the linked lists
-		 * for the domain and the global nic list
-		 */
-
-err:
-		pthread_mutex_lock(&gnix_nic_list_lock);
-
-		dlist_remove(&nic->gnix_nic_list);
-		--gnix_nics_per_ptag[nic->ptag];
-		dlist_remove(&nic->dom_nic_list);
-
-		pthread_mutex_unlock(&gnix_nic_list_lock);
-
-		__gnix_nic_tx_freelist_destroy(nic);
-		free(nic);
-	}
-
-	return ret;
+	return FI_SUCCESS;
 }
 
 /*
@@ -624,7 +665,7 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 					dom_nic_list);
 		dlist_remove(&nic->dom_nic_list);
 		dlist_insert_tail(&nic->dom_nic_list, &domain->nic_list);
-		atomic_inc(&nic->ref_cnt);
+		_gnix_nic_get(nic);
 
 		GNIX_INFO(FI_LOG_EP_CTRL, "Reusing NIC:%p\n", nic);
 	}

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -856,8 +856,11 @@ int _gnix_vc_alloc(struct gnix_fid_ep *ep_priv, fi_addr_t dest_addr,
 
 	vc_ptr->conn_state = GNIX_VC_CONN_NONE;
 	memcpy(&vc_ptr->peer_addr, &dest_addr, sizeof(dest_addr));
+
+	/* take reference on ep */
 	vc_ptr->ep = ep_priv;
-	atomic_inc(&ep_priv->ref_cnt);
+	_gnix_ep_get(vc_ptr->ep);
+
 	slist_init(&vc_ptr->tx_queue);
 	fastlock_init(&vc_ptr->tx_queue_lock);
 	atomic_initialize(&vc_ptr->outstanding_tx_reqs, 0);
@@ -959,7 +962,8 @@ int _gnix_vc_destroy(struct gnix_vc *vc)
 		GNIX_WARN(FI_LOG_EP_CTRL,
 		      "__gnix_vc_free_id returned %d\n", ret);
 
-	atomic_dec(&vc->ep->ref_cnt);
+	/* release reference on ep */
+	_gnix_ep_put(vc->ep);
 
 	free(vc);
 

--- a/prov/gni/src/gnix_wait.c
+++ b/prov/gni/src/gnix_wait.c
@@ -267,7 +267,7 @@ int gnix_wait_close(struct fid *wait)
 		close(wait_priv->fd[WAIT_WRITE]);
 	}
 
-	atomic_dec(&wait_priv->fabric->ref_cnt);
+	_gnix_fabric_put(wait_priv->fabric);
 
 	free(wait_priv);
 
@@ -309,7 +309,7 @@ int gnix_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 
 	wait_priv->fabric = fab_priv;
 
-	atomic_inc(&fab_priv->ref_cnt);
+	_gnix_fabric_get(fab_priv);
 	*waitset = &wait_priv->wait;
 
 	return ret;

--- a/prov/gni/test/dom.c
+++ b/prov/gni/test/dom.c
@@ -99,7 +99,7 @@ Test(domain, many_domains)
 				    domain_fid);
 		cr_assert(gdom, "domain not allcoated");
 		cr_assert(gdom->fabric == gfab, "Incorrect fabric");
-		cr_assert(atomic_get(&gdom->ref_cnt) == 0, "Incorrect ref_cnt");
+		cr_assert(atomic_get(&gdom->ref_cnt) == 1, "Incorrect ref_cnt");
 	}
 
 	for (i = num_doms-1; i >= 0; i--) {


### PR DESCRIPTION
Reference counting with hold/put/destuct allows objects to dangle until they are no longer in use. Once a object is no longer in use, it becomes freed when the last reference is dropped. This raises the risk of dangling pointers and unfreed memory, but allows objects to be freed by the application without impacting on-going actions. 

A hold/put/destruct style of reference counting relies on atomics to handle the reference counting and all object destruction code should be self-contained within the destruct function. 
