### PR TITLE
Cleanup gnix_tx_descriptor.

### DIFF
--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -177,49 +177,27 @@ struct gnix_smsg_descriptor {
 	uint8_t  tag;
 };
 
-
-/**
- * gnix_tx_descriptor0 - first part of the send side tx desciptor
- *                       used to track GNI SMSG and Post operations
- *
- * @var list             list element
- * @var gni_desc         embedded GNI post descriptor
- * @var gnix_smsg_desc   embedded gnix SMSG descriptor
- * @var req              pointer to fab request associated with this
- *                       descriptor
- * @var completer_fn     pointer to function to be invoked open
- *                       receipt of the GNI CQE associated with
- *                       the GNI Post or Smsg transaction being
- *                       tracked by this descriptor
- * @var id               the id of this descriptor - the value returned
- *                       from GNI_CQ_MSG_ID
- */
-union gnix_tx_descriptor0 {
-	struct {
-		struct dlist_entry          list;
-		gni_post_descriptor_t       gni_desc;
-		struct gnix_smsg_descriptor smsg_desc;
-		struct gnix_fab_req *req;
-		struct gnix_fid_ep *ep;
-		struct fi_context *context;
-		int  (*completer_fn)(void *);
-		int id;
-	};
-	char padding[GNIX_CACHELINE_SIZE];
-} __attribute__ ((aligned (GNIX_CACHELINE_SIZE)));
-
 /**
  * gni_tx_descriptor - full tx descriptor used to to track GNI SMSG
  *                     and Post operations
  *
- * @var desc       embedded gnix_tx_descriptor0
- * @var inject_buf embedded inline injection buffer associated with
- *                 this descriptor
+ * @var list             list element
+ * @var gni_desc         embedded GNI post descriptor
+ * @var gnix_smsg_desc   embedded gnix SMSG descriptor
+ * @var req              pointer to fab request associated with this descriptor
+ * @var id               the id of this descriptor - the value returned
+ *                       from GNI_CQ_MSG_ID
  */
 struct gnix_tx_descriptor {
-	union gnix_tx_descriptor0 desc;
-	char inject_buf[GNIX_CACHELINE_SIZE];
-} __attribute__ ((aligned (GNIX_CACHELINE_SIZE)));
+	struct dlist_entry          list;
+	union {
+		gni_post_descriptor_t       gni_desc;
+		struct gnix_smsg_descriptor smsg_desc;
+	};
+	struct gnix_fab_req *req;
+	int  (*completer_fn)(void *);
+	int id;
+};
 
 
 /*

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -244,7 +244,7 @@ try_again:
 			}
 			gnix_tdesc = container_of(gni_desc,
 						struct gnix_tx_descriptor,
-						desc.gni_desc);
+						gni_desc);
 		}  else if (GNI_CQ_GET_TYPE(cqe)
 			    == GNI_CQ_EVENT_TYPE_SMSG) {
 			msg_id = GNI_CQ_GET_MSG_ID(cqe);
@@ -257,9 +257,9 @@ try_again:
 
 		fastlock_release(&nic->lock);
 		if (ret == FI_SUCCESS) {
-			if (gnix_tdesc->desc.completer_fn) {
+			if (gnix_tdesc->completer_fn) {
 				ret =
-				   gnix_tdesc->desc.completer_fn(gnix_tdesc);
+				   gnix_tdesc->completer_fn(gnix_tdesc);
 				if (ret)
 					goto err;
                         }
@@ -284,7 +284,7 @@ try_again:
 		fastlock_release(&nic->lock);
 		gnix_tdesc = container_of(gni_desc,
 					struct gnix_tx_descriptor,
-					desc.gni_desc);
+					gni_desc);
 		if ((status2 != GNI_RC_SUCCESS) &&
 			(status2 != GNI_RC_TRANSACTION_ERROR)) {
 			ret = gnixu_to_fi_errno(status2);
@@ -458,7 +458,7 @@ int _gnix_nic_tx_alloc(struct gnix_nic *nic,
 	entry = nic->tx_desc_free_list.next;
 	dlist_remove_init(entry);
 	dlist_insert_head(entry, &nic->tx_desc_active_list);
-	*desc = dlist_entry(entry, struct gnix_tx_descriptor, desc.list);
+	*desc = dlist_entry(entry, struct gnix_tx_descriptor, list);
 	fastlock_release(&nic->tx_desc_lock);
 
 	return FI_SUCCESS;
@@ -473,8 +473,8 @@ int _gnix_nic_tx_free(struct gnix_nic *nic,
 		      struct gnix_tx_descriptor *desc)
 {
 	fastlock_acquire(&nic->tx_desc_lock);
-	dlist_remove_init(&desc->desc.list);
-	dlist_insert_head(&desc->desc.list, &nic->tx_desc_free_list);
+	dlist_remove_init(&desc->list);
+	dlist_insert_head(&desc->list, &nic->tx_desc_free_list);
 	fastlock_release(&nic->tx_desc_lock);
 
 	return FI_SUCCESS;
@@ -505,8 +505,8 @@ static int __gnix_nic_tx_freelist_init(struct gnix_nic *nic, int n_descs)
 	dlist_init(&nic->tx_desc_active_list);
 
 	for (i = 0, desc_ptr = desc_base; i < n_descs; i++, desc_ptr++) {
-		desc_ptr->desc.id = i;
-		dlist_insert_tail(&desc_ptr->desc.list,
+		desc_ptr->id = i;
+		dlist_insert_tail(&desc_ptr->list,
 				  &nic->tx_desc_free_list);
 	}
 

--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -79,7 +79,7 @@ static int __gnix_rma_txd_complete(void *arg)
 
 	/* Progress fabric operation in the fab_req completer.  Can we call
 	 * fab_req->completer_fn directly from __gnix_tx_progress? */
-	return txd->desc.req->completer_fn(txd->desc.req->completer_data);
+	return txd->req->completer_fn(txd->req->completer_data);
 }
 
 static gni_post_type_t __gnix_fr_post_type(int fr_type, int rdma)
@@ -122,33 +122,33 @@ int _gnix_rma_post_req(void *data)
 		return -FI_EAGAIN;
 	}
 
-	txd->desc.completer_fn = __gnix_rma_txd_complete;
-	txd->desc.req = fab_req;
+	txd->completer_fn = __gnix_rma_txd_complete;
+	txd->req = fab_req;
 
 	_gnix_convert_key_to_mhdl((gnix_mr_key_t *)&fab_req->rma.rem_mr_key,
 				  &mdh);
 	loc_md = (struct gnix_fid_mem_desc *)fab_req->rma.loc_md;
 
-	//txd->desc.gni_desc.post_id = (uint64_t)fab_req; /* unused */
-	txd->desc.gni_desc.type = __gnix_fr_post_type(fab_req->type, rdma);
-	txd->desc.gni_desc.cq_mode = GNI_CQMODE_GLOBAL_EVENT; /* check flags */
-	txd->desc.gni_desc.dlvr_mode = GNI_DLVMODE_PERFORMANCE; /* check flags */
-	txd->desc.gni_desc.local_addr = (uint64_t)fab_req->loc_addr;
+	//txd->gni_desc.post_id = (uint64_t)fab_req; /* unused */
+	txd->gni_desc.type = __gnix_fr_post_type(fab_req->type, rdma);
+	txd->gni_desc.cq_mode = GNI_CQMODE_GLOBAL_EVENT; /* check flags */
+	txd->gni_desc.dlvr_mode = GNI_DLVMODE_PERFORMANCE; /* check flags */
+	txd->gni_desc.local_addr = (uint64_t)fab_req->loc_addr;
 	if (loc_md) {
-		txd->desc.gni_desc.local_mem_hndl = loc_md->mem_hndl;
+		txd->gni_desc.local_mem_hndl = loc_md->mem_hndl;
 	}
-	txd->desc.gni_desc.remote_addr = (uint64_t)fab_req->rma.rem_addr;
-	txd->desc.gni_desc.remote_mem_hndl = mdh;
-	txd->desc.gni_desc.length = fab_req->len;
-	txd->desc.gni_desc.rdma_mode = 0; /* check flags */
-	txd->desc.gni_desc.src_cq_hndl = nic->tx_cq; /* check flags */
+	txd->gni_desc.remote_addr = (uint64_t)fab_req->rma.rem_addr;
+	txd->gni_desc.remote_mem_hndl = mdh;
+	txd->gni_desc.length = fab_req->len;
+	txd->gni_desc.rdma_mode = 0; /* check flags */
+	txd->gni_desc.src_cq_hndl = nic->tx_cq; /* check flags */
 
 	{
-		gni_mem_handle_t *tl_mdh = &txd->desc.gni_desc.local_mem_hndl;
-		gni_mem_handle_t *tr_mdh = &txd->desc.gni_desc.remote_mem_hndl;
+		gni_mem_handle_t *tl_mdh = &txd->gni_desc.local_mem_hndl;
+		gni_mem_handle_t *tr_mdh = &txd->gni_desc.remote_mem_hndl;
 		GNIX_INFO(FI_LOG_EP_DATA, "la: %llx ra: %llx len: %d\n",
-			  txd->desc.gni_desc.local_addr, txd->desc.gni_desc.remote_addr,
-			  txd->desc.gni_desc.length);
+			  txd->gni_desc.local_addr, txd->gni_desc.remote_addr,
+			  txd->gni_desc.length);
 		GNIX_INFO(FI_LOG_EP_DATA, "lmdh: %llx:%llx rmdh: %llx:%llx key: %llx\n",
 			  *(uint64_t *)tl_mdh, *(((uint64_t *)tl_mdh) + 1),
 			  *(uint64_t *)tr_mdh, *(((uint64_t *)tr_mdh) + 1),
@@ -156,9 +156,9 @@ int _gnix_rma_post_req(void *data)
 	}
 
 	if (rdma) {
-		status = GNI_PostRdma(fab_req->vc->gni_ep, &txd->desc.gni_desc);
+		status = GNI_PostRdma(fab_req->vc->gni_ep, &txd->gni_desc);
 	} else {
-		status = GNI_PostFma(fab_req->vc->gni_ep, &txd->desc.gni_desc);
+		status = GNI_PostFma(fab_req->vc->gni_ep, &txd->gni_desc);
 	}
 
 	if (status != GNI_RC_SUCCESS) {


### PR DESCRIPTION
Remove inject buffer and other unused fields from gnix_tx_descriptor.

Fixes ofi-cray/libfabric-cray#312.

Signed-off-by: Zach Tiffany ztiffany@cray.com
