### PR TITLE
Revert "Refactored reference counting functions to get/put/destruct f…

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -490,23 +490,6 @@ int gnix_mr_reg(struct fid *fid, const void *buf, size_t len,
 int gnix_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 		 struct fid_cntr **cntr, void *context);
 
-int _gnix_av_get(struct gnix_fid_av *av);
-
-int _gnix_av_put(struct gnix_fid_av *av);
-
-int _gnix_domain_get(struct gnix_fid_domain *domain);
-
-int _gnix_domain_put(struct gnix_fid_domain *domain);
-
-int _gnix_fabric_get(struct gnix_fid_fabric *fab);
-
-int _gnix_fabric_put(struct gnix_fid_fabric *fab);
-
-int _gnix_ep_get(struct gnix_fid_ep *ep);
-
-int _gnix_ep_put(struct gnix_fid_ep *ep);
-
-
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/prov/gni/include/gnix_cntr.h
+++ b/prov/gni/include/gnix_cntr.h
@@ -49,13 +49,6 @@ struct gnix_cntr_poll_nic {
 	struct gnix_nic *nic;
 };
 
-enum {
-	GNIX_CNTR_STATE_UNINITIALIZED = 0,
-	GNIX_CNTR_STATE_READY,
-	GNIX_CNTR_STATE_WAITING_ON_REFS,
-	GNIX_CNTR_STATE_DEAD,
-};
-
 struct gnix_fid_cntr {
 	struct fid_cntr cntr_fid;
 	struct gnix_fid_domain *domain;
@@ -66,7 +59,6 @@ struct gnix_fid_cntr {
 	atomic_t cnt;
 	atomic_t cnt_err;
 	atomic_t ref_cnt;
-	int state;
 };
 
 /**
@@ -102,11 +94,6 @@ int _gnix_cntr_poll_nic_add(struct gnix_fid_cntr *cntr, struct gnix_nic *nic);
  * @return             FI_SUCCESS on success, -FI_EINVAL on invalid argument
  */
 int _gnix_cntr_poll_nic_rem(struct gnix_fid_cntr *cntr, struct gnix_nic *nic);
-
-
-int _gnix_cntr_put(struct gnix_fid_cntr *cntr);
-
-int _gnix_cntr_get(struct gnix_fid_cntr *cntr);
 
 #ifdef __cplusplus
 }

--- a/prov/gni/include/gnix_cq.h
+++ b/prov/gni/include/gnix_cq.h
@@ -92,10 +92,6 @@ ssize_t _gnix_cq_add_error(struct gnix_fid_cq *cq, void *op_context,
 int _gnix_cq_poll_nic_add(struct gnix_fid_cq *cq, struct gnix_nic *nic);
 int _gnix_cq_poll_nic_rem(struct gnix_fid_cq *cq, struct gnix_nic *nic);
 
-int _gnix_cq_get(struct gnix_fid_cq *cq);
-
-int _gnix_cq_put(struct gnix_fid_cq *cq);
-
 #ifdef __cplusplus
 }
 #endif

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -340,11 +340,6 @@ static inline void *__gnix_nic_elem_by_rem_id(struct gnix_nic *nic, int rem_id)
 	return 0;
 }
 
-int _gnix_nic_get(struct gnix_nic *nic);
-
-int _gnix_nic_put(struct gnix_nic *nic);
-
-
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/prov/gni/src/gnix_cntr.c
+++ b/prov/gni/src/gnix_cntr.c
@@ -260,9 +260,21 @@ static int gnix_cntr_wait(struct fid_cntr *cntr, uint64_t threshold,
 	return ret;
 }
 
-static void __cntr_destruct(struct gnix_fid_cntr *cntr)
+static int gnix_cntr_close(fid_t fid)
 {
-	_gnix_domain_put(cntr->domain);
+	struct gnix_fid_cntr *cntr;
+
+	GNIX_TRACE(FI_LOG_CQ, "\n");
+
+	cntr = container_of(fid, struct gnix_fid_cntr, cntr_fid.fid);
+	if (atomic_get(&cntr->ref_cnt) != 0) {
+		GNIX_INFO(FI_LOG_CQ, "CNTR ref count: %d, not closing.\n",
+			  cntr->ref_cnt);
+		return -FI_EBUSY;
+	}
+
+	atomic_dec(&cntr->domain->ref_cnt);
+	assert(atomic_get(&cntr->domain->ref_cnt) >= 0);
 
 	switch (cntr->attr.wait_obj) {
 	case FI_WAIT_NONE:
@@ -283,51 +295,6 @@ static void __cntr_destruct(struct gnix_fid_cntr *cntr)
 	}
 
 	free(cntr);
-}
-
-int _gnix_cntr_put(struct gnix_fid_cntr *cntr)
-{
-	int ret = atomic_dec(&cntr->ref_cnt);
-
-	assert(ret >= 0);
-
-	if (!ret) {
-		__cntr_destruct(cntr);
-	}
-
-	return ret;
-}
-
-int _gnix_cntr_get(struct gnix_fid_cntr *cntr)
-{
-	int ret = atomic_inc(&cntr->ref_cnt);
-
-	assert(ret > 0);
-
-	return ret;
-}
-
-static int gnix_cntr_close(fid_t fid)
-{
-	struct gnix_fid_cntr *cntr;
-	int references_held;
-
-	GNIX_TRACE(FI_LOG_CQ, "\n");
-
-	cntr = container_of(fid, struct gnix_fid_cntr, cntr_fid.fid);
-
-	if (cntr->state == GNIX_CNTR_STATE_UNINITIALIZED)
-		return -FI_EINVAL;
-	if (cntr->state == GNIX_CNTR_STATE_DEAD)
-		return FI_SUCCESS;
-
-	/* applications should never call close more than once. */
-	references_held = _gnix_cntr_put(cntr);
-	if (references_held) {
-		GNIX_INFO(FI_LOG_CQ, "failed to fully close cntr due to lingering "
-						"references. references=%i cntr=%p\n",
-						references_held, cntr);
-	}
 
 	return FI_SUCCESS;
 }
@@ -456,17 +423,14 @@ int gnix_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 		goto err;
 	}
 
-	cntr_priv->state = GNIX_CNTR_STATE_READY;
-
 	cntr_priv->domain = domain_priv;
 	cntr_priv->attr = *attr;
 	/* initialize atomics */
-	/* ref count is initialized to one to show that the counter exists */
-	atomic_initialize(&cntr_priv->ref_cnt, 1);
+	atomic_initialize(&cntr_priv->ref_cnt, 0);
 	atomic_initialize(&cntr_priv->cnt, 0);
 	atomic_initialize(&cntr_priv->cnt_err, 0);
 
-	_gnix_domain_get(cntr_priv->domain);
+	atomic_inc(&cntr_priv->domain->ref_cnt);
 	dlist_init(&cntr_priv->poll_nics);
 	rwlock_init(&cntr_priv->nic_lock);
 

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -57,89 +57,15 @@ static struct fi_ops gnix_domain_fi_ops;
 static struct fi_ops_mr gnix_domain_mr_ops;
 static struct fi_ops_domain gnix_domain_ops;
 
-static void __domain_destruct(struct gnix_fid_domain *domain)
-{
-	int ret = FI_SUCCESS, v;
-	struct gnix_nic *p, *next;
-	gni_return_t status;
-
-	/* if the domain isn't being destructed by close, we need to check the
-	 * cache again. This isn't a likely case. Both the flush and destroy
-	 * must succeed since we are in the destruct path */
-	ret = _gnix_mr_cache_flush(&domain->mr_cache);
-	if (ret != FI_SUCCESS)
-		GNIX_ERR(FI_LOG_DOMAIN, "failed to flush mr cache "
-				"during domain destruct, dom=%p", domain);
-	assert(ret == FI_SUCCESS);
-
-	ret = _gnix_mr_cache_destroy(&domain->mr_cache);
-	if (ret != FI_SUCCESS)
-		GNIX_ERR(FI_LOG_DOMAIN, "failed to destroy mr cache "
-				"during domain destruct, dom=%p", domain);
-	assert(ret == FI_SUCCESS);
-
-	/*
-	 *  remove nics from the domain's nic list,
-	 *  decrement ref_cnt on each nic.  If ref_cnt
-	 *  drops to 0, destroy the cdm, remove from
-	 *  the global nic list.
-	 */
-	dlist_for_each_safe(&domain->nic_list, p, next, dom_nic_list)
-	{
-		dlist_remove(&p->dom_nic_list);
-		v = _gnix_nic_put(p);
-		if (v == 0) {
-			dlist_remove(&p->gnix_nic_list);
-			status = GNI_CdmDestroy(p->gni_cdm_hndl);
-			if (status != GNI_RC_SUCCESS)
-				GNIX_ERR(FI_LOG_DOMAIN,
-					 "oops, cdm destroy failed\n");
-			free(p);
-		}
-	}
-
-	_gnix_fabric_put(domain->fabric);
-
-	/*
-	 * remove from the list of cdms attached to fabric
-	 */
-	gnix_list_del_init(&domain->list);
-
-	memset(domain, 0, sizeof *domain);
-	free(domain);
-
-}
-
-int _gnix_domain_put(struct gnix_fid_domain *domain)
-{
-	int references_held = atomic_dec(&domain->ref_cnt);
-
-	assert(references_held >= 0);
-
-	if (!references_held)
-		__domain_destruct(domain);
-
-	return references_held;
-}
-
-int _gnix_domain_get(struct gnix_fid_domain *domain)
-{
-	int references_held = atomic_inc(&domain->ref_cnt);
-
-	assert(references_held > 0);
-
-	return references_held;
-}
-
-
-
 /*******************************************************************************
  * API function implementations.
  ******************************************************************************/
 static int gnix_domain_close(fid_t fid)
 {
-	int ret = FI_SUCCESS, references_held;
+	int ret = FI_SUCCESS, v;
 	struct gnix_fid_domain *domain;
+	struct gnix_nic *p, *next;
+	gni_return_t status;
 
 	GNIX_TRACE(FI_LOG_DOMAIN, "\n");
 
@@ -162,13 +88,51 @@ static int gnix_domain_close(fid_t fid)
 	 * with this domain which have not been closed.
 	 */
 
-	references_held = _gnix_domain_put(domain);
-
-	if (references_held) {
-		GNIX_WARN(FI_LOG_DOMAIN, "failed to fully close domain due to "
-				"lingering references. references=%i dom=%p\n",
-			  references_held, domain);
+	if (atomic_get(&domain->ref_cnt) != 0) {
+		GNIX_WARN(FI_LOG_DOMAIN, "non zero refcnt %d\n",
+			  atomic_get(&domain->ref_cnt));
+		ret = -FI_EBUSY;
+		goto err;
 	}
+
+	ret = _gnix_mr_cache_destroy(&domain->mr_cache);
+	if (ret != FI_SUCCESS) {
+		GNIX_WARN(FI_LOG_DOMAIN,
+			  "failed to destroy memory cache on domain close\n");
+		goto err;
+	}
+
+	/*
+	 *  remove nics from the domain's nic list,
+	 *  decrement ref_cnt on each nic.  If ref_cnt
+	 *  drops to 0, destroy the cdm, remove from
+	 *  the global nic list.
+	 */
+	dlist_for_each_safe(&domain->nic_list, p, next, dom_nic_list)
+	{
+		dlist_remove(&p->dom_nic_list);
+		v = atomic_dec(&p->ref_cnt);
+		assert(v >= 0);
+		if (v == 0) {
+			dlist_remove(&p->gnix_nic_list);
+			status = GNI_CdmDestroy(p->gni_cdm_hndl);
+			if (status != GNI_RC_SUCCESS)
+				GNIX_ERR(FI_LOG_DOMAIN,
+					 "oops, cdm destroy failed\n");
+			free(p);
+		}
+	}
+
+	v = atomic_dec(&domain->fabric->ref_cnt);
+	assert(v >= 0);
+
+	/*
+	 * remove from the list of cdms attached to fabric
+	 */
+	gnix_list_del_init(&domain->list);
+
+	memset(domain, 0, sizeof *domain);
+	free(domain);
 
 	GNIX_INFO(FI_LOG_DOMAIN, "gnix_domain_close invoked returning %d\n",
 		  ret);
@@ -374,7 +338,7 @@ int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	list_head_init(&domain->domain_wq);
 
 	domain->fabric = fabric_priv;
-	_gnix_fabric_get(domain->fabric);
+	atomic_inc(&fabric_priv->ref_cnt);
 
 	domain->ptag = ptag;
 	domain->cookie = cookie;
@@ -395,7 +359,7 @@ int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	domain->gni_tx_cq_size = gnix_def_gni_tx_cq_size;
 	domain->gni_rx_cq_size = gnix_def_gni_rx_cq_size;
 	domain->gni_cq_modes = gnix_def_gni_cq_modes;
-	atomic_initialize(&domain->ref_cnt, 1);
+	atomic_initialize(&domain->ref_cnt, 0);
 
 	domain->domain_fid.fid.fclass = FI_CLASS_DOMAIN;
 	domain->domain_fid.fid.context = context;

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -642,9 +642,10 @@ err:
 	return ret;
 }
 
-static void __ep_destruct(struct gnix_fid_ep *ep)
+static int gnix_ep_close(fid_t fid)
 {
 	int ret = FI_SUCCESS;
+	struct gnix_fid_ep *ep;
 	struct gnix_fid_domain *domain;
 	struct gnix_nic *nic;
 	struct gnix_vc *vc;
@@ -652,39 +653,45 @@ static void __ep_destruct(struct gnix_fid_ep *ep)
 	struct gnix_cm_nic *cm_nic;
 	struct dlist_entry *p, *head;
 
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	ep = container_of(fid, struct gnix_fid_ep, ep_fid.fid);
+	/* TODO: lots more stuff to do here */
+
 	if (ep->send_cq) {
 		_gnix_cq_poll_nic_rem(ep->send_cq, ep->nic);
-		_gnix_cq_put(ep->send_cq);
+		atomic_dec(&ep->send_cq->ref_cnt);
 	}
 
 	if (ep->recv_cq) {
 		_gnix_cq_poll_nic_rem(ep->recv_cq, ep->nic);
-		_gnix_cq_put(ep->recv_cq);
+		atomic_dec(&ep->recv_cq->ref_cnt);
 	}
 
 	if (ep->send_cntr) {
 		_gnix_cntr_poll_nic_rem(ep->send_cntr, ep->nic);
-		_gnix_cntr_put(ep->send_cntr);
+		atomic_dec(&ep->send_cntr->ref_cnt);
 	}
 
 	if (ep->recv_cntr) {
 		_gnix_cntr_poll_nic_rem(ep->recv_cntr, ep->nic);
-		_gnix_cntr_put(ep->recv_cntr);
+		atomic_dec(&ep->recv_cntr->ref_cnt);
 	}
 
 	if (ep->read_cntr) {
 		_gnix_cntr_poll_nic_rem(ep->read_cntr, ep->nic);
-		_gnix_cntr_put(ep->read_cntr);
+		atomic_dec(&ep->read_cntr->ref_cnt);
 	}
 
 	if (ep->write_cntr) {
 		_gnix_cntr_poll_nic_rem(ep->write_cntr, ep->nic);
-		_gnix_cntr_put(ep->write_cntr);
+		atomic_dec(&ep->write_cntr->ref_cnt);
 	}
 
 	domain = ep->domain;
 	assert(domain != NULL);
-	_gnix_domain_put(domain);
+	atomic_dec(&domain->ref_cnt);
 
 	cm_nic = ep->cm_nic;
 	assert(cm_nic != NULL);
@@ -695,7 +702,7 @@ static void __ep_destruct(struct gnix_fid_ep *ep)
 
 	av = ep->av;
 	if (av != NULL)
-		_gnix_av_put(av);
+		atomic_dec(&av->ref_cnt);
 
 	/*
 	 * destroy any vc's being used by this EP.
@@ -709,28 +716,17 @@ static void __ep_destruct(struct gnix_fid_ep *ep)
 			ret = _gnix_vc_disconnect(vc);
 			if (ret != FI_SUCCESS) {
 				GNIX_WARN(FI_LOG_EP_CTRL,
-					"_gnix_vc_disconnect returned %d\n",
-					 ret);
-
-				/* TODO: previously, this just returned from the
-				 * close function with the vc disconnect error code. Since
-				 * there are no references to this ep left but
-				 * an error was encountered, what is the appropriate action?
-				 */
-				continue;
+				    "_gnix_vc_disconnect returned %d\n",
+				     ret);
+				goto err;
 			}
 		}
 		ret = _gnix_vc_destroy(vc);
 		if (ret != FI_SUCCESS) {
 			GNIX_WARN(FI_LOG_EP_CTRL,
-				"_gnix_vc_destroy returned %d\n",
-				 ret);
-			/* TODO: previously, this just returned from the
-			 * close function with the vc destroy error code. Since
-			 * there are no references to this ep left but
-			 * an error was encountered, what is the appropriate action?
-			 */
-			continue;
+			    "_gnix_vc_destroy returned %d\n",
+			     ret);
+			goto err;
 		}
 	}
 
@@ -749,8 +745,9 @@ static void __ep_destruct(struct gnix_fid_ep *ep)
 	ret = _gnix_nic_free(nic);
 	if (ret != FI_SUCCESS) {
 		GNIX_WARN(FI_LOG_EP_CTRL,
-			"_gnix_nic_free call returned %d\n",
-			 ret);
+		    "_gnix_vc_destroy call returned %d\n",
+		     ret);
+		goto err;
 	}
 
 	ep->nic = NULL;
@@ -766,46 +763,9 @@ static void __ep_destruct(struct gnix_fid_ep *ep)
 	__fr_freelist_destroy(ep);
 
 	free(ep);
-}
 
-int _gnix_ep_get(struct gnix_fid_ep *ep)
-{
-	int references_held = atomic_inc(&ep->ref_cnt);
-
-	assert(references_held > 0);
-
-	return references_held;
-}
-
-int _gnix_ep_put(struct gnix_fid_ep *ep)
-{
-	int references_held = atomic_dec(&ep->ref_cnt);
-
-	assert(references_held >= 0);
-
-	if (!references_held)
-		__ep_destruct(ep);
-
-	return references_held;
-}
-
-static int gnix_ep_close(fid_t fid)
-{
-	struct gnix_fid_ep *ep;
-	int references_held;
-
-	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
-
-	ep = container_of(fid, struct gnix_fid_ep, ep_fid.fid);
-	/* TODO: lots more stuff to do here */
-
-	references_held = _gnix_ep_put(ep);
-	if (references_held)
-		GNIX_INFO(FI_LOG_EP_CTRL, "failed to fully close ep due "
-				"to lingering references. references=%i ep=%p\n",
-				references_held, ep);
-
-	return FI_SUCCESS;
+err:
+	return ret;
 }
 
 static int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
@@ -847,7 +807,7 @@ static int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 			}
 
 			_gnix_cq_poll_nic_add(cq, ep->nic);
-			_gnix_cq_get(cq);
+			atomic_inc(&cq->ref_cnt);
 		}
 		if (flags & FI_RECV) {
 			/* don't allow rebinding */
@@ -862,7 +822,7 @@ static int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 			}
 
 			_gnix_cq_poll_nic_add(cq, ep->nic);
-			_gnix_cq_get(cq);
+			atomic_inc(&cq->ref_cnt);
 		}
 		break;
 	case FI_CLASS_AV:
@@ -872,7 +832,7 @@ static int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 			break;
 		}
 		ep->av = av;
-		_gnix_av_get(ep->av);
+		atomic_inc(&av->ref_cnt);
 		break;
 	case FI_CLASS_CNTR: /* TODO: need to support cntrs someday */
 		cntr = container_of(bfid, struct gnix_fid_cntr, cntr_fid.fid);
@@ -889,7 +849,7 @@ static int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 			}
 			ep->send_cntr = cntr;
 			_gnix_cntr_poll_nic_add(cntr, ep->nic);
-			_gnix_cntr_get(cntr);
+			atomic_inc(&cntr->ref_cnt);
 		}
 
 		if (flags & FI_RECV) {
@@ -900,7 +860,7 @@ static int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 			}
 			ep->recv_cntr = cntr;
 			_gnix_cntr_poll_nic_add(cntr, ep->nic);
-			_gnix_cntr_get(cntr);
+			atomic_inc(&cntr->ref_cnt);
 		}
 
 		if (flags & FI_READ) {
@@ -911,7 +871,7 @@ static int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 			}
 			ep->read_cntr = cntr;
 			_gnix_cntr_poll_nic_add(cntr, ep->nic);
-			_gnix_cntr_get(cntr);
+			atomic_inc(&cntr->ref_cnt);
 		}
 
 		if (flags & FI_WRITE) {
@@ -922,7 +882,7 @@ static int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 			}
 			ep->write_cntr = cntr;
 			_gnix_cntr_poll_nic_add(cntr, ep->nic);
-			_gnix_cntr_get(cntr);
+			atomic_inc(&cntr->ref_cnt);
 		}
 
 		/* TODO: don't support this option right now,
@@ -1006,7 +966,7 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 	fastlock_init(&ep_priv->vc_list_lock);
 	dlist_init(&ep_priv->wc_vc_list);
 	atomic_initialize(&ep_priv->active_fab_reqs, 0);
-	atomic_initialize(&ep_priv->ref_cnt, 1);
+	atomic_initialize(&ep_priv->ref_cnt, 0);
 
 	fastlock_init(&ep_priv->recv_comp_lock);
 	fastlock_init(&ep_priv->recv_queue_lock);
@@ -1084,7 +1044,7 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 	if (ep_priv->nic->smsg_callbacks == NULL)
 		ep_priv->nic->smsg_callbacks = gnix_ep_smsg_callbacks;
 
-	_gnix_domain_get(ep_priv->domain);
+	atomic_inc(&domain_priv->ref_cnt);
 	*ep = &ep_priv->ep_fid;
 	return ret;
 

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -89,47 +89,22 @@ static struct fi_ops_fabric gnix_fab_ops = {
 	.wait_open = gnix_wait_open
 };
 
-static void __fabric_destruct(struct gnix_fid_fabric *fab)
-{
-	_gnix_alps_cleanup();
-
-	free(fab);
-}
-
-int _gnix_fabric_get(struct gnix_fid_fabric *fab)
-{
-	int references_held = atomic_inc(&fab->ref_cnt);
-
-	assert(references_held > 0);
-
-	return references_held;
-}
-
-int _gnix_fabric_put(struct gnix_fid_fabric *fab)
-{
-	int references_held = atomic_dec(&fab->ref_cnt);
-
-	assert(references_held >= 0);
-
-	if (!references_held)
-		__fabric_destruct(fab);
-
-	return references_held;
-}
-
 static int gnix_fabric_close(fid_t fid)
 {
 	struct gnix_fid_fabric *fab;
-	int references_held;
-
 	fab = container_of(fid, struct gnix_fid_fabric, fab_fid);
 
-	references_held = _gnix_fabric_put(fab);
-	if (references_held)
-		GNIX_INFO(FI_LOG_FABRIC, "failed to fully close fabric due "
-				"to lingering references. references=%i fabric=%p\n",
-				references_held, fab);
+	/*
+ 	 * TODO: is this really right thing to do?
+ 	 */
 
+	if (!list_empty(&fab->domain_list)) {
+		return -FI_EBUSY;
+	}
+
+	_gnix_alps_cleanup();
+
+	free(fab);
 	return FI_SUCCESS;
 }
 
@@ -170,7 +145,7 @@ static int gnix_fabric_open(struct fi_fabric_attr *attr,
 	fab->fab_fid.fid.context = context;
 	fab->fab_fid.fid.ops = &gnix_fab_fi_ops;
 	fab->fab_fid.ops = &gnix_fab_ops;
-	atomic_initialize(&fab->ref_cnt, 1);
+	atomic_initialize(&fab->ref_cnt, 0);
 	list_head_init(&fab->domain_list);
 
 	*fabric = &fab->fab_fid;

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -483,143 +483,102 @@ static void __gnix_nic_tx_freelist_destroy(struct gnix_nic *nic)
  * free a gnix nic and associated resources if refcnt drops to 0
  */
 
-static void __nic_destruct(struct gnix_nic *nic)
-{
-	int ret = FI_SUCCESS;
-	gni_return_t status = GNI_RC_SUCCESS;
-
-	if (!nic->gni_cdm_hndl) {
-		GNIX_ERR(FI_LOG_EP_CTRL, "No CDM attached to nic, nic=%p");
-	}
-
-	assert(nic->gni_cdm_hndl != NULL);
-
-	if (nic->rx_cq_blk != NULL) {
-		status = GNI_CqDestroy(nic->rx_cq_blk);
-		if (status != GNI_RC_SUCCESS) {
-			GNIX_WARN(FI_LOG_EP_CTRL,
-				  "GNI_CqDestroy returned %s\n",
-				 gni_err_str[status]);
-			ret = gnixu_to_fi_errno(status);
-			goto err;
-		}
-	}
-
-	if (nic->rx_cq != NULL) {
-		status = GNI_CqDestroy(nic->rx_cq);
-		if (status != GNI_RC_SUCCESS) {
-			GNIX_WARN(FI_LOG_EP_CTRL,
-				  "GNI_CqDestroy returned %s\n",
-				 gni_err_str[status]);
-			ret = gnixu_to_fi_errno(status);
-			goto err;
-		}
-	}
-
-	if (nic->tx_cq_blk != NULL) {
-		status = GNI_CqDestroy(nic->tx_cq_blk);
-		if (status != GNI_RC_SUCCESS) {
-			GNIX_WARN(FI_LOG_EP_CTRL,
-				  "GNI_CqDestroy returned %s\n",
-				 gni_err_str[status]);
-			ret = gnixu_to_fi_errno(status);
-			goto err;
-		}
-	}
-
-	if (nic->tx_cq != NULL) {
-		status = GNI_CqDestroy(nic->tx_cq);
-		if (status != GNI_RC_SUCCESS) {
-			GNIX_WARN(FI_LOG_EP_CTRL,
-				  "GNI_CqDestroy returned %s\n",
-				 gni_err_str[status]);
-			ret = gnixu_to_fi_errno(status);
-			goto err;
-		}
-	}
-
-	status = GNI_CdmDestroy(nic->gni_cdm_hndl);
-	if (status != GNI_RC_SUCCESS) {
-		GNIX_WARN(FI_LOG_EP_CTRL,
-			  "GNI_CdmDestroy returned %s\n",
-			  gni_err_str[status]);
-		ret = gnixu_to_fi_errno(status);
-		goto err;
-	}
-
-	ret = _gnix_mbox_allocator_destroy(nic->mbox_hndl);
-	if (ret != FI_SUCCESS)
-		GNIX_WARN(FI_LOG_EP_CTRL,
-			  "_gnix_mbox_allocator_destroy returned %d\n",
-			  ret);
-
-	ret = _gnix_mbox_allocator_destroy(nic->s_rdma_buf_hndl);
-	if (ret != FI_SUCCESS)
-		GNIX_WARN(FI_LOG_EP_CTRL,
-			  "_gnix_mbox_allocator_destroy returned %d\n",
-			  ret);
-
-	ret = _gnix_mbox_allocator_destroy(nic->r_rdma_buf_hndl);
-	if (ret != FI_SUCCESS)
-		GNIX_WARN(FI_LOG_EP_CTRL,
-			  "_gnix_mbox_allocator_destroy returned %d\n",
-			  ret);
-
-	/*
-	 * remove the nic from the linked lists
-	 * for the domain and the global nic list
-	 */
-
-err:
-	pthread_mutex_lock(&gnix_nic_list_lock);
-
-	dlist_remove(&nic->gnix_nic_list);
-	--gnix_nics_per_ptag[nic->ptag];
-	dlist_remove(&nic->dom_nic_list);
-
-	pthread_mutex_unlock(&gnix_nic_list_lock);
-
-	__gnix_nic_tx_freelist_destroy(nic);
-	free(nic);
-}
-
-int _gnix_nic_get(struct gnix_nic *nic)
-{
-	int references_held = atomic_inc(&nic->ref_cnt);
-
-	assert(references_held > 0);
-
-	return references_held;
-}
-
-int _gnix_nic_put(struct gnix_nic *nic)
-{
-	int references_held = atomic_dec(&nic->ref_cnt);
-
-	assert(references_held >= 0);
-
-	if (!references_held)
-		__nic_destruct(nic);
-
-	return references_held;
-}
-
 int _gnix_nic_free(struct gnix_nic *nic)
 {
-	int references_held;
+	int ret = FI_SUCCESS, v;
+	gni_return_t status = GNI_RC_SUCCESS;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
 	if (nic == NULL)
 		return -FI_EINVAL;
 
-	references_held = _gnix_nic_put(nic);
-	if (references_held)
-		GNIX_INFO(FI_LOG_EP_CTRL, "failed to fully close nic due to "
-				"lingering references. references=%i nic=%p\n",
-				references_held, nic);
+	v = atomic_dec(&nic->ref_cnt);
+	assert(v >= 0);
 
-	return FI_SUCCESS;
+	if ((nic->gni_cdm_hndl != NULL) && (v == 0))  {
+		if (nic->rx_cq_blk != NULL)
+			status = GNI_CqDestroy(nic->rx_cq_blk);
+			if (status != GNI_RC_SUCCESS) {
+				GNIX_WARN(FI_LOG_EP_CTRL,
+					  "GNI_CqDestroy returned %s\n",
+					 gni_err_str[status]);
+				ret = gnixu_to_fi_errno(status);
+				goto err;
+			}
+		if (nic->rx_cq != NULL)
+			status = GNI_CqDestroy(nic->rx_cq);
+			if (status != GNI_RC_SUCCESS) {
+				GNIX_WARN(FI_LOG_EP_CTRL,
+					  "GNI_CqDestroy returned %s\n",
+					 gni_err_str[status]);
+				ret = gnixu_to_fi_errno(status);
+				goto err;
+			}
+		if (nic->tx_cq_blk != NULL)
+			status = GNI_CqDestroy(nic->tx_cq_blk);
+			if (status != GNI_RC_SUCCESS) {
+				GNIX_WARN(FI_LOG_EP_CTRL,
+					  "GNI_CqDestroy returned %s\n",
+					 gni_err_str[status]);
+				ret = gnixu_to_fi_errno(status);
+				goto err;
+			}
+		if (nic->tx_cq != NULL)
+			status = GNI_CqDestroy(nic->tx_cq);
+			if (status != GNI_RC_SUCCESS) {
+				GNIX_WARN(FI_LOG_EP_CTRL,
+					  "GNI_CqDestroy returned %s\n",
+					 gni_err_str[status]);
+				ret = gnixu_to_fi_errno(status);
+				goto err;
+			}
+		status = GNI_CdmDestroy(nic->gni_cdm_hndl);
+		if (status != GNI_RC_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "GNI_CdmDestroy returned %s\n",
+				  gni_err_str[status]);
+			ret = gnixu_to_fi_errno(status);
+			goto err;
+		}
+
+		ret = _gnix_mbox_allocator_destroy(nic->mbox_hndl);
+		if (ret != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "_gnix_mbox_allocator_destroy returned %d\n",
+				  ret);
+
+		ret = _gnix_mbox_allocator_destroy(nic->s_rdma_buf_hndl);
+		if (ret != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "_gnix_mbox_allocator_destroy returned %d\n",
+				  ret);
+
+		ret = _gnix_mbox_allocator_destroy(nic->r_rdma_buf_hndl);
+		if (ret != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "_gnix_mbox_allocator_destroy returned %d\n",
+				  ret);
+
+		/*
+		 * remove the nic from the linked lists
+		 * for the domain and the global nic list
+		 */
+
+err:
+		pthread_mutex_lock(&gnix_nic_list_lock);
+
+		dlist_remove(&nic->gnix_nic_list);
+		--gnix_nics_per_ptag[nic->ptag];
+		dlist_remove(&nic->dom_nic_list);
+
+		pthread_mutex_unlock(&gnix_nic_list_lock);
+
+		__gnix_nic_tx_freelist_destroy(nic);
+		free(nic);
+	}
+
+	return ret;
 }
 
 /*
@@ -665,7 +624,7 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 					dom_nic_list);
 		dlist_remove(&nic->dom_nic_list);
 		dlist_insert_tail(&nic->dom_nic_list, &domain->nic_list);
-		_gnix_nic_get(nic);
+		atomic_inc(&nic->ref_cnt);
 
 		GNIX_INFO(FI_LOG_EP_CTRL, "Reusing NIC:%p\n", nic);
 	}

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -856,11 +856,8 @@ int _gnix_vc_alloc(struct gnix_fid_ep *ep_priv, fi_addr_t dest_addr,
 
 	vc_ptr->conn_state = GNIX_VC_CONN_NONE;
 	memcpy(&vc_ptr->peer_addr, &dest_addr, sizeof(dest_addr));
-
-	/* take reference on ep */
 	vc_ptr->ep = ep_priv;
-	_gnix_ep_get(vc_ptr->ep);
-
+	atomic_inc(&ep_priv->ref_cnt);
 	slist_init(&vc_ptr->tx_queue);
 	fastlock_init(&vc_ptr->tx_queue_lock);
 	atomic_initialize(&vc_ptr->outstanding_tx_reqs, 0);
@@ -962,8 +959,7 @@ int _gnix_vc_destroy(struct gnix_vc *vc)
 		GNIX_WARN(FI_LOG_EP_CTRL,
 		      "__gnix_vc_free_id returned %d\n", ret);
 
-	/* release reference on ep */
-	_gnix_ep_put(vc->ep);
+	atomic_dec(&vc->ep->ref_cnt);
 
 	free(vc);
 

--- a/prov/gni/src/gnix_wait.c
+++ b/prov/gni/src/gnix_wait.c
@@ -267,7 +267,7 @@ int gnix_wait_close(struct fid *wait)
 		close(wait_priv->fd[WAIT_WRITE]);
 	}
 
-	_gnix_fabric_put(wait_priv->fabric);
+	atomic_dec(&wait_priv->fabric->ref_cnt);
 
 	free(wait_priv);
 
@@ -309,7 +309,7 @@ int gnix_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 
 	wait_priv->fabric = fab_priv;
 
-	_gnix_fabric_get(fab_priv);
+	atomic_inc(&fab_priv->ref_cnt);
 	*waitset = &wait_priv->wait;
 
 	return ret;

--- a/prov/gni/test/dom.c
+++ b/prov/gni/test/dom.c
@@ -99,7 +99,7 @@ Test(domain, many_domains)
 				    domain_fid);
 		cr_assert(gdom, "domain not allcoated");
 		cr_assert(gdom->fabric == gfab, "Incorrect fabric");
-		cr_assert(atomic_get(&gdom->ref_cnt) == 1, "Incorrect ref_cnt");
+		cr_assert(atomic_get(&gdom->ref_cnt) == 0, "Incorrect ref_cnt");
 	}
 
 	for (i = num_doms-1; i >= 0; i--) {


### PR DESCRIPTION
…ormat"

This reverts commit cb53656cfd67a8f945c58646c60c6546b7ec016a.

This revert results from a bug found in the reference counting, which occurs during normal shutdown. 
