### PR TITLE
Skip mdh CRC generation during RMA using FMA.

### DIFF
--- a/prov/gni/include/gnix_mr.h
+++ b/prov/gni/include/gnix_mr.h
@@ -193,6 +193,17 @@ typedef struct gnix_mr_cache {
 } gnix_mr_cache_t;
 
 /**
+ * @brief Converts a libfabric key to a gni memory handle, skipping memory
+ *        handle CRC generation.
+ *
+ * @param[in]     key   libfabric memory region key
+ * @param[in,out] mhdl  gni memory handle
+ */
+void _gnix_convert_key_to_mhdl_no_crc(
+		gnix_mr_key_t    *key,
+		gni_mem_handle_t *mhdl);
+
+/**
  * @brief Converts a libfabric key to a gni memory handle
  *
  * @param[in]     key   libfabric memory region key

--- a/prov/gni/src/gnix_mr.c
+++ b/prov/gni/src/gnix_mr.c
@@ -289,26 +289,32 @@ static inline int __mr_cache_entry_put(
 	return grc;
 }
 
-void _gnix_convert_key_to_mhdl(
+void _gnix_convert_key_to_mhdl_no_crc(
 		gnix_mr_key_t *key,
 		gni_mem_handle_t *mhdl)
 {
 	uint64_t va = key->pfn;
 	uint8_t flags = 0;
 
-	va = (uint64_t) __sign_extend(va << GNIX_MR_PAGE_SHIFT, GNIX_MR_VA_BITS);
+	va = (uint64_t) __sign_extend(va << GNIX_MR_PAGE_SHIFT,
+				      GNIX_MR_VA_BITS);
 
 	if (key->flags & GNIX_MR_FLAG_READONLY)
 		flags |= GNI_MEMHNDL_ATTR_READONLY;
 
 	GNI_MEMHNDL_INIT((*mhdl));
-	//if (key->format)
-	//	GNI_MEMHNDL_SET_FLAGS((*mhdl), GNI_MEMHNDL_FLAG_NEW_FRMT);
 	GNI_MEMHNDL_SET_VA((*mhdl), va);
 	GNI_MEMHNDL_SET_MDH((*mhdl), key->mdd);
 	GNI_MEMHNDL_SET_NPAGES((*mhdl), GNI_MEMHNDL_NPGS_MASK);
 	GNI_MEMHNDL_SET_FLAGS((*mhdl), flags);
 	GNI_MEMHNDL_SET_PAGESIZE((*mhdl), GNIX_MR_PAGE_SHIFT);
+}
+
+void _gnix_convert_key_to_mhdl(
+		gnix_mr_key_t *key,
+		gni_mem_handle_t *mhdl)
+{
+	_gnix_convert_key_to_mhdl_no_crc(key, mhdl);
 	compiler_barrier();
 	GNI_MEMHNDL_SET_CRC((*mhdl));
 }

--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -143,8 +143,17 @@ int _gnix_rma_post_req(void *data)
 	txd->desc.completer_fn = __gnix_rma_txd_complete;
 	txd->desc.req = fab_req;
 
-	_gnix_convert_key_to_mhdl((gnix_mr_key_t *)&fab_req->rma.rem_mr_key,
-				  &mdh);
+	if (rdma) {
+		_gnix_convert_key_to_mhdl(
+				(gnix_mr_key_t *)&fab_req->rma.rem_mr_key,
+				&mdh);
+	} else {
+		/* Mem handle CRC is not validated during FMA operations.  Skip
+		 * this costly calculation. */
+		_gnix_convert_key_to_mhdl_no_crc(
+				(gnix_mr_key_t *)&fab_req->rma.rem_mr_key,
+				&mdh);
+	}
 	loc_md = (struct gnix_fid_mem_desc *)fab_req->loc_md;
 
 	//txd->desc.gni_desc.post_id = (uint64_t)fab_req; /* unused */


### PR DESCRIPTION
Generating the CRC field in a memory handle during an RMA operation hurts short
message latency considerably.  uGNI does not validate a mem. handle's CRC field
during FMA.  This mod skips CRC generation in this case.

fixes ofi-cray/libfabric-cray#319.

Signed-off-by: Zach Tiffany ztiffany@cray.com
