### PR TITLE
Remove inject buffer from TXD structure.

### DIFF
--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -183,50 +183,27 @@ struct gnix_smsg_descriptor {
 	uint8_t  tag;
 };
 
-
-/**
- * gnix_tx_descriptor0 - first part of the send side tx desciptor
- *                       used to track GNI SMSG and Post operations
- *
- * @var list             list element
- * @var gni_desc         embedded GNI post descriptor
- * @var gnix_smsg_desc   embedded gnix SMSG descriptor
- * @var req              pointer to fab request associated with this
- *                       descriptor
- * @var completer_fn     pointer to function to be invoked open
- *                       receipt of the GNI CQE associated with
- *                       the GNI Post or Smsg transaction being
- *                       tracked by this descriptor
- * @var id               the id of this descriptor - the value returned
- *                       from GNI_CQ_MSG_ID
- */
-union gnix_tx_descriptor0 {
-	struct {
-		struct dlist_entry          list;
-		gni_post_descriptor_t       gni_desc;
-		struct gnix_smsg_descriptor smsg_desc;
-		struct gnix_fab_req *req;
-		struct gnix_fid_ep *ep;
-		struct fi_context *context;
-		int  (*completer_fn)(void *);
-		int id;
-	};
-	char padding[GNIX_CACHELINE_SIZE];
-} __attribute__ ((aligned (GNIX_CACHELINE_SIZE)));
-
 /**
  * gni_tx_descriptor - full tx descriptor used to to track GNI SMSG
  *                     and Post operations
  *
- * @var desc       embedded gnix_tx_descriptor0
- * @var inject_buf embedded inline injection buffer associated with
- *                 this descriptor
+ * @var list             list element
+ * @var gni_desc         embedded GNI post descriptor
+ * @var gnix_smsg_desc   embedded gnix SMSG descriptor
+ * @var req              pointer to fab request associated with this descriptor
+ * @var id               the id of this descriptor - the value returned
+ *                       from GNI_CQ_MSG_ID
  */
 struct gnix_tx_descriptor {
-	union gnix_tx_descriptor0 desc;
-	char inject_buf[GNIX_CACHELINE_SIZE];
-} __attribute__ ((aligned (GNIX_CACHELINE_SIZE)));
-
+	struct dlist_entry          list;
+	union {
+		gni_post_descriptor_t       gni_desc;
+		struct gnix_smsg_descriptor smsg_desc;
+	};
+	struct gnix_fab_req *req;
+	int  (*completer_fn)(void *);
+	int id;
+};
 
 /*
  * globals

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -218,7 +218,7 @@ try_again:
 			}
 			gnix_tdesc = container_of(gni_desc,
 						struct gnix_tx_descriptor,
-						desc.gni_desc);
+						gni_desc);
 		}  else if (GNI_CQ_GET_TYPE(cqe)
 			    == GNI_CQ_EVENT_TYPE_SMSG) {
 			msg_id = GNI_CQ_GET_MSG_ID(cqe);
@@ -231,9 +231,9 @@ try_again:
 
 		fastlock_release(&nic->lock);
 		if (ret == FI_SUCCESS) {
-			if (gnix_tdesc->desc.completer_fn) {
+			if (gnix_tdesc->completer_fn) {
 				ret =
-				   gnix_tdesc->desc.completer_fn(gnix_tdesc);
+				   gnix_tdesc->completer_fn(gnix_tdesc);
 				if (ret)
 					goto err;
                         }
@@ -258,7 +258,7 @@ try_again:
 		fastlock_release(&nic->lock);
 		gnix_tdesc = container_of(gni_desc,
 					struct gnix_tx_descriptor,
-					desc.gni_desc);
+					gni_desc);
 		if ((status2 != GNI_RC_SUCCESS) &&
 			(status2 != GNI_RC_TRANSACTION_ERROR)) {
 			ret = gnixu_to_fi_errno(status2);
@@ -409,7 +409,7 @@ int _gnix_nic_tx_alloc(struct gnix_nic *nic,
 	entry = nic->tx_desc_free_list.next;
 	dlist_remove_init(entry);
 	dlist_insert_head(entry, &nic->tx_desc_active_list);
-	*desc = dlist_entry(entry, struct gnix_tx_descriptor, desc.list);
+	*desc = dlist_entry(entry, struct gnix_tx_descriptor, list);
 	fastlock_release(&nic->tx_desc_lock);
 
 	return FI_SUCCESS;
@@ -424,8 +424,8 @@ int _gnix_nic_tx_free(struct gnix_nic *nic,
 		      struct gnix_tx_descriptor *desc)
 {
 	fastlock_acquire(&nic->tx_desc_lock);
-	dlist_remove_init(&desc->desc.list);
-	dlist_insert_head(&desc->desc.list, &nic->tx_desc_free_list);
+	dlist_remove_init(&desc->list);
+	dlist_insert_head(&desc->list, &nic->tx_desc_free_list);
 	fastlock_release(&nic->tx_desc_lock);
 
 	return FI_SUCCESS;
@@ -456,8 +456,8 @@ static int __gnix_nic_tx_freelist_init(struct gnix_nic *nic, int n_descs)
 	dlist_init(&nic->tx_desc_active_list);
 
 	for (i = 0, desc_ptr = desc_base; i < n_descs; i++, desc_ptr++) {
-		desc_ptr->desc.id = i;
-		dlist_insert_tail(&desc_ptr->desc.list,
+		desc_ptr->id = i;
+		dlist_insert_tail(&desc_ptr->list,
 				  &nic->tx_desc_free_list);
 	}
 


### PR DESCRIPTION
This removes the inject buffer from the gnix_tx_descriptor structure.  The
inject buffer is associated with a struct gnix_fab_req.

Fixes ofi-cray/libfabric-cray:312.

Signed-off-by: Zach Tiffany ztiffany@cray.com

@hppritcha @sungeunchoi @jswaro @jshimek
