### PR TITLE
Sanitize transaction op flags.

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -135,7 +135,7 @@ extern "C" {
  */
 
 /*
- * see capabilities section in fi_getinfo.3
+ * See capabilities section in fi_getinfo.3.
  */
 #define GNIX_EP_RDM_CAPS                                                       \
 	(FI_MSG | FI_RMA | FI_TAGGED | FI_ATOMICS |                            \
@@ -146,10 +146,25 @@ extern "C" {
 /*
  * see Operations flags in fi_endpoint.3
  */
-#define GNIX_EP_OP_FLAGS                                                       \
-	(FI_MULTI_RECV | FI_COMPLETION |                                       \
-	 FI_TRANSMIT_COMPLETE | FI_READ | FI_WRITE | FI_SEND | FI_RECV |       \
-	 FI_REMOTE_READ | FI_REMOTE_WRITE)
+#define GNIX_EP_OP_FLAGS	(FI_INJECT | FI_MULTI_RECV | FI_COMPLETION | \
+				 FI_INJECT_COMPLETE | FI_TRANSMIT_COMPLETE | \
+				 FI_DELIVERY_COMPLETE)
+
+/*
+ * Valid msg transaction input flags.  See fi_msg.3.
+ */
+#define GNIX_SENDMSG_FLAGS	(FI_REMOTE_CQ_DATA | FI_COMPLETION | \
+				 FI_MORE | FI_INJECT | FI_INJECT_COMPLETE | \
+				 FI_TRANSMIT_COMPLETE | FI_FENCE)
+#define GNIX_RECVMSG_FLAGS	(FI_COMPLETION | FI_MORE | FI_MULTI_RECV)
+
+/*
+ * Valid rma transaction input flags.  See fi_rma.3.
+ */
+#define GNIX_WRITEMSG_FLAGS	(FI_REMOTE_CQ_DATA | FI_COMPLETION | \
+				 FI_MORE | FI_INJECT | FI_INJECT_COMPLETE | \
+				 FI_TRANSMIT_COMPLETE | FI_FENCE)
+#define GNIX_READMSG_FLAGS	(FI_COMPLETION | FI_MORE | FI_FENCE)
 
 /*
  * if this has to be changed, check gnix_getinfo, etc.

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -91,8 +91,9 @@ struct fi_ops_tagged gnix_ep_tagged_ops;
  ******************************************************************************/
 
 static inline ssize_t __ep_recv(struct fid_ep *ep, void *buf, size_t len,
-		void *desc, fi_addr_t src_addr, void *context, uint64_t flags,
-		uint64_t tag, uint64_t ignore) {
+				void *desc, fi_addr_t src_addr, void *context,
+				uint64_t flags, uint64_t tag, uint64_t ignore)
+{
 	struct gnix_fid_ep *ep_priv;
 
 	if (!ep) {
@@ -107,8 +108,8 @@ static inline ssize_t __ep_recv(struct fid_ep *ep, void *buf, size_t len,
 }
 
 static inline ssize_t __ep_recvv(struct fid_ep *ep, const struct iovec *iov,
-			     void **desc, size_t count, fi_addr_t src_addr,
-			     void *context, uint64_t flags, uint64_t tag,
+				 void **desc, size_t count, fi_addr_t src_addr,
+				 void *context, uint64_t flags, uint64_t tag,
 				 uint64_t ignore)
 {
 	struct gnix_fid_ep *ep_priv;
@@ -126,7 +127,8 @@ static inline ssize_t __ep_recvv(struct fid_ep *ep, const struct iovec *iov,
 }
 
 static inline ssize_t __ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
-		uint64_t flags, uint64_t tag, uint64_t ignore)
+				   uint64_t flags, uint64_t tag,
+				   uint64_t ignore)
 {
 	struct gnix_fid_ep *ep_priv;
 
@@ -144,8 +146,8 @@ static inline ssize_t __ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 }
 
 static inline ssize_t __ep_send(struct fid_ep *ep, const void *buf, size_t len,
-	     void *desc, fi_addr_t dest_addr, void *context,
-		 uint64_t flags, uint64_t tag)
+				void *desc, fi_addr_t dest_addr, void *context,
+				uint64_t flags, uint64_t tag)
 {
 	struct gnix_fid_ep *gnix_ep;
 
@@ -161,8 +163,8 @@ static inline ssize_t __ep_send(struct fid_ep *ep, const void *buf, size_t len,
 }
 
 static inline ssize_t __ep_sendv(struct fid_ep *ep, const struct iovec *iov,
-	     void **desc, size_t count, fi_addr_t dest_addr,
-	     void *context, uint64_t flags, uint64_t tag)
+				 void **desc, size_t count, fi_addr_t dest_addr,
+				 void *context, uint64_t flags, uint64_t tag)
 {
 	struct gnix_fid_ep *gnix_ep;
 
@@ -179,7 +181,7 @@ static inline ssize_t __ep_sendv(struct fid_ep *ep, const struct iovec *iov,
 }
 
 static inline ssize_t __ep_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
-		uint64_t flags, uint64_t tag)
+				   uint64_t flags, uint64_t tag)
 {
 	struct gnix_fid_ep *gnix_ep;
 
@@ -197,8 +199,8 @@ static inline ssize_t __ep_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 }
 
 static inline ssize_t __ep_inject(struct fid_ep *ep, const void *buf,
-		  size_t len, fi_addr_t dest_addr, uint64_t flags,
-		  uint64_t tag)
+				  size_t len, fi_addr_t dest_addr,
+				  uint64_t flags, uint64_t tag)
 {
 	struct gnix_fid_ep *gnix_ep;
 	uint64_t inject_flags;
@@ -217,10 +219,10 @@ static inline ssize_t __ep_inject(struct fid_ep *ep, const void *buf,
 			  NULL, inject_flags, 0, tag);
 }
 
-static inline ssize_t __ep_senddata(struct fid_ep *ep,
-		const void *buf, size_t len, void *desc, uint64_t data,
-		fi_addr_t dest_addr, void *context, uint64_t flags,
-		uint64_t tag)
+static inline ssize_t __ep_senddata(struct fid_ep *ep, const void *buf,
+				    size_t len, void *desc, uint64_t data,
+				    fi_addr_t dest_addr, void *context,
+				    uint64_t flags, uint64_t tag)
 {
 	struct gnix_fid_ep *gnix_ep;
 	uint64_t sd_flags;
@@ -256,7 +258,7 @@ static ssize_t gnix_ep_recvv(struct fid_ep *ep, const struct iovec *iov,
 }
 
 static ssize_t gnix_ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
-			uint64_t flags)
+			       uint64_t flags)
 {
 	return __ep_recvmsg(ep, msg, flags, 0, 0);
 }
@@ -339,8 +341,8 @@ static ssize_t gnix_ep_read(struct fid_ep *ep, void *buf, size_t len,
 }
 
 static ssize_t gnix_ep_readv(struct fid_ep *ep, const struct iovec *iov,
-				void **desc, size_t count, fi_addr_t src_addr,
-				uint64_t addr, uint64_t key, void *context)
+			     void **desc, size_t count, fi_addr_t src_addr,
+			     uint64_t addr, uint64_t key, void *context)
 {
 	struct gnix_fid_ep *gnix_ep;
 
@@ -358,7 +360,7 @@ static ssize_t gnix_ep_readv(struct fid_ep *ep, const struct iovec *iov,
 }
 
 static ssize_t gnix_ep_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
-				uint64_t flags)
+			       uint64_t flags)
 {
 	struct gnix_fid_ep *gnix_ep;
 
@@ -379,8 +381,8 @@ static ssize_t gnix_ep_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 }
 
 static ssize_t gnix_ep_write(struct fid_ep *ep, const void *buf, size_t len,
-				void *desc, fi_addr_t dest_addr, uint64_t addr,
-				uint64_t key, void *context)
+			     void *desc, fi_addr_t dest_addr, uint64_t addr,
+			     uint64_t key, void *context)
 {
 	struct gnix_fid_ep *gnix_ep;
 
@@ -398,8 +400,8 @@ static ssize_t gnix_ep_write(struct fid_ep *ep, const void *buf, size_t len,
 }
 
 static ssize_t gnix_ep_writev(struct fid_ep *ep, const struct iovec *iov,
-				void **desc, size_t count, fi_addr_t dest_addr,
-				uint64_t addr, uint64_t key, void *context)
+			      void **desc, size_t count, fi_addr_t dest_addr,
+			      uint64_t addr, uint64_t key, void *context)
 {
 	struct gnix_fid_ep *gnix_ep;
 
@@ -543,7 +545,7 @@ static ssize_t gnix_ep_trecvmsg(struct fid_ep *ep,
 }
 
 static ssize_t gnix_ep_tsend(struct fid_ep *ep, const void *buf, size_t len, void *desc,
-			fi_addr_t dest_addr, uint64_t tag, void *context)
+			     fi_addr_t dest_addr, uint64_t tag, void *context)
 {
 	return __ep_send(ep, buf, len, desc, dest_addr, context,
 			GNIX_MSG_TAGGED, tag);
@@ -573,14 +575,14 @@ static ssize_t gnix_ep_tsendmsg(struct fid_ep *ep,
 }
 
 static ssize_t gnix_ep_tinject(struct fid_ep *ep, const void *buf, size_t len,
-				fi_addr_t dest_addr, uint64_t tag)
+			       fi_addr_t dest_addr, uint64_t tag)
 {
 	return __ep_inject(ep, buf, len, dest_addr, GNIX_MSG_TAGGED, tag);
 }
 
 ssize_t gnix_ep_tsenddata(struct fid_ep *ep, const void *buf, size_t len,
-			void *desc, uint64_t data, fi_addr_t dest_addr,
-			uint64_t tag, void *context)
+			  void *desc, uint64_t data, fi_addr_t dest_addr,
+			  uint64_t tag, void *context)
 {
 	return __ep_senddata(ep, buf, len, desc, data, dest_addr, context,
 			GNIX_MSG_TAGGED, tag);

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -341,9 +341,10 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 	gnix_info->tx_attr->mode = gnix_info->mode;
 
 	if (hints && hints->tx_attr && hints->tx_attr->op_flags) {
-		gnix_info->tx_attr->op_flags = hints->tx_attr->op_flags;
+		gnix_info->tx_attr->op_flags =
+				hints->tx_attr->op_flags & GNIX_EP_OP_FLAGS;
 	} else {
-		gnix_info->tx_attr->op_flags = GNIX_EP_OP_FLAGS;
+		gnix_info->tx_attr->op_flags = 0;
 	}
 
 	gnix_info->tx_attr->msg_order = FI_ORDER_SAS;
@@ -357,9 +358,10 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 	gnix_info->rx_attr->mode = gnix_info->mode;
 
 	if (hints && hints->rx_attr && hints->rx_attr->op_flags) {
-		gnix_info->rx_attr->op_flags = hints->rx_attr->op_flags;
+		gnix_info->rx_attr->op_flags =
+				hints->rx_attr->op_flags & GNIX_EP_OP_FLAGS;
 	} else {
-		gnix_info->rx_attr->op_flags = GNIX_EP_OP_FLAGS;
+		gnix_info->rx_attr->op_flags = 0;
 	}
 
 	gnix_info->rx_attr->msg_order = FI_ORDER_SAS;


### PR DESCRIPTION
-Sanitize writemsg, readmsg, sendmsg, recvmsg, tsendmsg, trecvmsg input flags.
-Sanitize tx/rx_attr->op_flags.
-fi_getinfo() sets tx/rx_attr->op_flags to null when no hints are provided.

@hppritcha @jswaro @jshimek
