### PR TITLE
prov/gni: allow FI_SEND or FI_WRITE for ep bind

### DIFF
--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -813,7 +813,7 @@ static int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 			ret = -FI_EINVAL;
 			break;
 		}
-		if (flags & FI_SEND) {
+		if (flags & (FI_SEND | FI_WRITE)) {
 			/* don't allow rebinding */
 			if (ep->send_cq) {
 				ret = -FI_EINVAL;

--- a/prov/gni/test/rdm_rma.c
+++ b/prov/gni/test/rdm_rma.c
@@ -123,7 +123,11 @@ void rdm_rma_setup(void)
 	ret = fi_cq_open(dom, &cq_attr, &send_cq, 0);
 	cr_assert(!ret, "fi_cq_open");
 
-	ret = fi_ep_bind(ep[0], &send_cq->fid, FI_SEND);
+	/*
+	 * imitate shmem, etc. use FI_WRITE for bind
+	 * flag
+	 */
+	ret = fi_ep_bind(ep[0], &send_cq->fid, FI_WRITE);
 	cr_assert(!ret, "fi_ep_bind");
 
 	ret = fi_getname(&ep[0]->fid, NULL, &addrlen);


### PR DESCRIPTION
Allow for use of either FI_SEND or FI_WRITE to bind
a CQ to an EP for send/write.

Fixes #329

@ztiffany 

Signed-off-by: Howard Pritchard howardp@lanl.gov
