### PR TITLE
prov/gni: swat warning

### DIFF
--- a/prov/gni/src/gnix_mbox_allocator.c
+++ b/prov/gni/src/gnix_mbox_allocator.c
@@ -454,7 +454,7 @@ static int __check_bitmap(struct gnix_mbox_alloc_handle *handle,
 {
 	struct slist_entry *entry;
 	struct gnix_slab *temp;
-	int ret;
+	int ret = FI_SUCCESS;
 
 	*slab = NULL;
 


### PR DESCRIPTION
@sungeunchoi 

not sure why this warning shows up with gcc 4.8.1 but claims `ret` can be used uninitialized.
which it can.

Signed-off-by: Howard Pritchard howardp@lanl.gov
