### PR TITLE
prov/gni: provide way for app to set cdm_id

### DIFF
--- a/prov/gni/include/gnix_cm_nic.h
+++ b/prov/gni/include/gnix_cm_nic.h
@@ -84,6 +84,8 @@ int _gnix_cm_nic_free(struct gnix_cm_nic *cm_nic);
  * @brief allocates a cm nic structure
  *
  * @param[in]  domain   pointer to a previously allocated gnix_fid_domain struct
+ * @param[in]  cdm_id   cdm id to use when creating cm nic's GNI CDM.  If
+ *                      set to -1, a cdm_id will be generated for the cm nic.
  * @param[out] cm_nic   pointer to address where address of the allocated
  *                      cm nic structure should be returned
  * @return              FI_SUCCESS on success, -EINVAL on invalid argument,
@@ -91,7 +93,8 @@ int _gnix_cm_nic_free(struct gnix_cm_nic *cm_nic);
  *                      the cm nic structure
  */
 int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
-			struct gnix_cm_nic **cm_nic);
+		       uint32_t cdm_id,
+		       struct gnix_cm_nic **cm_nic);
 
 /**
  * @brief poke the cm nic's progress engine

--- a/prov/gni/src/gnix_cm_nic.c
+++ b/prov/gni/src/gnix_cm_nic.c
@@ -165,7 +165,8 @@ int _gnix_cm_nic_free(struct gnix_cm_nic *cm_nic)
 }
 
 int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
-			struct gnix_cm_nic **cm_nic_ptr)
+		       uint32_t cdm_id_arg,
+		       struct gnix_cm_nic **cm_nic_ptr)
 {
 	int ret = FI_SUCCESS;
 	struct gnix_cm_nic *cm_nic = NULL;
@@ -182,9 +183,12 @@ int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 		goto err;
 	}
 
-	ret = _gnix_get_new_cdm_id(domain, &cdm_id);
-	if (ret != FI_SUCCESS)
-		goto err;
+	if (cdm_id_arg == -1U) {
+		ret = _gnix_get_new_cdm_id(domain, &cdm_id);
+		if (ret != FI_SUCCESS)
+			goto err;
+	} else
+		cdm_id = cdm_id_arg;
 
 	GNIX_INFO(FI_LOG_EP_CTRL, "creating cm_nic for %u/0x%x/%u\n",
 		      domain->ptag, domain->cookie, cdm_id);

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -930,9 +930,11 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 {
 	int ret = FI_SUCCESS;
 	int tsret = FI_SUCCESS;
+	uint32_t cdm_id = -1U;
 	struct gnix_fid_domain *domain_priv;
 	struct gnix_fid_ep *ep_priv;
 	gnix_hashtable_attr_t gnix_ht_attr;
+	struct gnix_ep_name *ep_name = NULL;
 	struct gnix_tag_storage_attr untagged_attr = {
 			.type = GNIX_TAG_LIST,
 			.use_src_addr_matching = 1,
@@ -1017,7 +1019,18 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 	 * TODO, initialize vc hash table
 	 */
 	if (ep_priv->type == FI_EP_RDM) {
+
+		/*
+		 * application may have specified the cdm_id for the
+		 * cm_nic using non NULL service argument to fi_getinfo
+		 */
+		if (info->src_addr != NULL) {
+			ep_name = (struct gnix_ep_name *)info->src_addr;
+			cdm_id = ep_name->gnix_addr.cdm_id;
+		}
+
 		ret = _gnix_cm_nic_alloc(domain_priv,
+					 cdm_id,
 					 &ep_priv->cm_nic);
 		if (ret != FI_SUCCESS)
 			goto err;

--- a/prov/gni/src/gnix_nameserver.c
+++ b/prov/gni/src/gnix_nameserver.c
@@ -258,8 +258,10 @@ int gnix_resolve_name(IN const char *node, IN const char *service,
 	memset(resolved_addr, 0, sizeof(struct gnix_ep_name));
 
 	resolved_addr->gnix_addr.device_addr = pe;
-	/* TODO: have to write a nameserver to get this info */
-	resolved_addr->gnix_addr.cdm_id = 0;
+	if (service != NULL) {
+		resolved_addr->gnix_addr.cdm_id = atol(service);
+	} else
+		resolved_addr->gnix_addr.cdm_id = 0;
 	/* TODO: likely depend on service? */
 	resolved_addr->name_type = 0;
 sock_cleanup:


### PR DESCRIPTION
This mod provides a way for an application to
control the cdm_id (and hence the Aries address)
of FI_EP_RDM endpoints it opens.  Specifically,
by providing a non-NULL node and service argument
to fi_getinfo, and setting the flag to FI_SOURCE,
the GNI provider will assign a CDM_ID equal to the
numerical value of the service argument.

Modified one of the datagram criterion tests to
validate this feature.

@ztiffany 
@sungeunchoi 

Signed-off-by: Howard Pritchard howardp@lanl.gov
