### PR TITLE
prov/gni: add comment explaining symbol visibility

### DIFF
--- a/prov/gni/src/gnix_hashtable.c
+++ b/prov/gni/src/gnix_hashtable.c
@@ -55,6 +55,9 @@
  *   value during initialization
  */
 
+/*
+ * default_attr is global for a criterion test.
+ */
 gnix_hashtable_attr_t default_attr = {
 		.ht_initial_size     = __GNIX_HT_INITIAL_SIZE,
 		.ht_maximum_size     = __GNIX_HT_MAXIMUM_SIZE,


### PR DESCRIPTION
Add comment to clarify why what at first glance
what should be a static variable, needs to be global
owing to its use in a criterion test.

@jswaro 

Signed-off-by: Howard Pritchard howardp@lanl.gov
