### PR TITLE
prov/gni: introduced nic alloc options

### DIFF
--- a/prov/gni/src/gnix_mr.c
+++ b/prov/gni/src/gnix_mr.c
@@ -379,7 +379,7 @@ int gnix_mr_reg(struct fid *fid, const void *buf, size_t len,
 
 	/* If the nic list is empty, create a nic */
 	if (unlikely(dlist_empty(&domain->nic_list))) {
-		rc = gnix_nic_alloc(domain, &nic);
+		rc = gnix_nic_alloc(domain, NULL, &nic);
 		if (rc) {
 			GNIX_WARN(FI_LOG_MR, "could not allocate nic to do mr_reg,"
 					" ret=%i\n", rc);

--- a/prov/gni/test/nic.c
+++ b/prov/gni/test/nic.c
@@ -96,7 +96,9 @@ Test(nic, alloc_free)
 
 	for (i = 0; i < num_nics; i++) {
 		ret = gnix_nic_alloc(container_of(dom, struct gnix_fid_domain,
-						  domain_fid), &nics[i]);
+						  domain_fid),
+						  NULL,
+						  &nics[i]);
 		cr_assert_eq(ret, FI_SUCCESS, "Could not allocate nic");
 	}
 


### PR DESCRIPTION
This is a followup to the recently introduced
option for bound ep's: FI_EP_RDM types where the
user has specified the cdm id for the associated
gnix_cm_nic.

This PR enhances the ways a gnix_nic can be allocated.
If the app has requested a bound ep, rather than
consuming additional CQ's for a gnix nic, this option
allows the cdm/nic handles from the bound ep's cm_nic
to be reused when instantiating a gnix_nic for the ep.

This PR is the first in a step to allocate a single
gnix_cm_nic/domain in the case where the app isn't allocating
bound eps.

Signed-off-by: Howard Pritchard howardp@lanl.gov
