### PR TITLE
prov/gni: fix race condition with pending_vcs list

### DIFF
--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -133,7 +133,7 @@ struct gnix_nic {
 	struct gnix_tx_descriptor *tx_desc_base;
 	atomic_t outstanding_fab_reqs_nic;
 	fastlock_t pending_vc_lock;
-	struct slist pending_vcs;
+	struct dlist_entry pending_vcs;
 	uint8_t ptag;
 	uint32_t cookie;
 	uint32_t device_id;

--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -114,7 +114,7 @@ struct gnix_vc {
 	enum gnix_vc_conn_state conn_state;
 	int vc_id;
 	int modes;
-	struct slist_entry pending_list;
+	struct dlist_entry pending_list;
 	gnix_bitmap_t flags; /* We're missing regular bit ops */
 };
 

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -777,7 +777,7 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 			goto err1;
 
 		fastlock_init(&nic->pending_vc_lock);
-		slist_init(&nic->pending_vcs);
+		dlist_init(&nic->pending_vcs);
 
 		_gnix_ref_init(&nic->ref_cnt, 1, __nic_destruct);
 		atomic_initialize(&nic->outstanding_fab_reqs_nic, 0);


### PR DESCRIPTION
There was a problem revealed by the vc_management/vc_accept.
To fix the problem, the pending_vcs list on the nic had to
be switched to a dlist.  During the _gnix_vc_destroy call
a check is now made to see if the vc is in the pending_vcs
list and if so is removed.

Fixes #369

Checked with fabtests and criterion.  Ran criterion numerous times and
did not see the teardown failure.

@ztiffany @sungeunchoi 

Signed-off-by: Howard Pritchard howardp@lanl.gov
