### PR TITLE
prov/gni: fix problem with rdm_rma/inject test

### DIFF
--- a/prov/gni/test/rdm_rma.c
+++ b/prov/gni/test/rdm_rma.c
@@ -457,7 +457,7 @@ void do_inject_write(int len)
 			     gni_addr[1], (uint64_t)target, mr_key);
 	cr_assert_eq(sz, 0);
 
-	for (i = 0; i < INJECT_SIZE; i++) {
+	for (i = 0; i < len; i++) {
 		loops = 0;
 		while (source[i] != target[i]) {
 			ret = fi_cq_read(send_cq, &cqe, 1); /* for progress */


### PR DESCRIPTION
The rdm_rma inject test was sometimes working
sometimes not depending on contents of the source
and target buffers.  The loop over INJECT_SIZE should
instead have just been over the first len elements.

@ztiffany 

Signed-off-by: Howard Pritchard howardp@lanl.gov
