### PR TITLE
Fix valgrind errors in _gnix_send

### DIFF
--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -940,8 +940,9 @@ ssize_t _gnix_send(struct gnix_fid_ep *ep, uint64_t loc_addr, size_t len,
 	req->msg.send_md = md;
 	req->msg.send_len = len;
 	req->msg.send_flags = flags;
+	req->flags = 0;
 
-	if (req->flags & FI_INJECT) {
+	if (flags & FI_INJECT) {
 		memcpy(req->inject_buf, (void *)loc_addr, len);
 		req->msg.send_addr = (uint64_t)req->inject_buf;
 	} else {


### PR DESCRIPTION
- Set req->flags = 0.  Valgrind complained, but is it possible this is
  a false positive?
- Compare with flags (not req->flags) when looking for FI_INJECT

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com

@hppritcha @ztiffany 
