### PR TITLE
travis: see if we can use container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo:false
+sudo: false
 
 language: c
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo:false
+
 language: c
 
 compiler:


### PR DESCRIPTION
apparently adding
sudo:false

lets travis know it can run a build in a container,
which apparently is the next greatest thing since
baguettes started being sliced.

Note this travis only tries to build for os-x for now.

@sungeunchoi 

Signed-off-by: Howard Pritchard howardp@lanl.gov
