### PR TITLE
Auto-register buffers for RMA and send/recv

### DIFF
--- a/man/fi_gni.7.md
+++ b/man/fi_gni.7.md
@@ -44,7 +44,7 @@ libfabric API:
   *FI_WAIT_NONE*, *FI_WAIT_FD*, and *FI_WAIT_MUTEX_COND*.
 
 *Modes*
-: The GNI provider only requires the *FI_LOCAL_MR* mode.
+: The GNI provider does not require any operation modes.
 
 *Progress*
 : The GNI provider supports both *FI_PROGRESS_AUTO* and

--- a/man/man7/fi_gni.7
+++ b/man/man7/fi_gni.7
@@ -46,7 +46,7 @@ and \f[I]FI_WAIT_MUTEX_COND\f[].
 .RE
 .TP
 .B \f[I]Modes\f[]
-The GNI provider only requires the \f[I]FI_LOCAL_MR\f[] mode.
+The GNI provider does not require any operation modes.
 .RS
 .RE
 .TP

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -188,7 +188,7 @@ extern "C" {
  * Cray gni provider will require the following fabric interface modes (see
  * fi_getinfo.3 man page)
  */
-#define GNIX_FAB_MODES	FI_LOCAL_MR
+#define GNIX_FAB_MODES	0
 
 /*
  * fabric modes that GNI provider doesn't need


### PR DESCRIPTION
Do not require a memory descriptor be passed to RMA/send/recv interfaces.
Automatically register buffers as needed if the necessary memory descriptors
are not provided.

Signed-off-by: Zach Tiffany ztiffany@cray.com

@hppritcha @sungeunchoi @jshimek @jswaro
