### PR TITLE
prov/gni: switch to using cm_nic_cdm_id for dgrams

### DIFF
--- a/prov/gni/include/gnix_cm_nic.h
+++ b/prov/gni/include/gnix_cm_nic.h
@@ -55,6 +55,8 @@
  *                     This will always be zero unless Cray starts
  *                     selling systems with multiple aries/node.
  * @var device_addr    Aries network address associated with this nic.
+ * @var name_type      name type for ep type this cm_nic is bound to,
+ *                     either GNIX_EPN_TYPE_UNBOUND/GNIX_EPN_TYPE_BOUND
  */
 struct gnix_cm_nic {
 	fastlock_t lock;
@@ -70,6 +72,7 @@ struct gnix_cm_nic {
 	uint32_t cookie;
 	uint32_t device_id;
 	uint32_t device_addr;
+	uint32_t name_type;
 };
 
 /**

--- a/prov/gni/src/gnix_av.c
+++ b/prov/gni/src/gnix_av.c
@@ -160,8 +160,7 @@ static int table_insert(struct gnix_fid_av *int_av, const void *addr,
 		int_av->valid_entry_vec[index] = 1;
 		int_av->table[index].name_type = temp->name_type;
 		int_av->table[index].cookie = temp->cookie;
-		if (temp->name_type == GNIX_EPN_TYPE_UNBOUND)
-			int_av->table[index].cm_nic_cdm_id =
+		int_av->table[index].cm_nic_cdm_id =
 				temp->cm_nic_cdm_id;
 		if (fi_addr)
 			fi_addr[i] = index;

--- a/prov/gni/src/gnix_cm.c
+++ b/prov/gni/src/gnix_cm.c
@@ -98,6 +98,8 @@ static int gnix_getname(fid_t fid, void *addr, size_t *addrlen)
 		name.gnix_addr.cdm_id = ep->cm_nic->cdm_id;
 		name.gnix_addr.device_addr = ep->cm_nic->device_addr;
 		name.cookie = ep->domain->cookie;
+		name.cm_nic_cdm_id = ep->cm_nic->cdm_id;
+		name.name_type = ep->cm_nic->name_type;
 	} else {
 		return -FI_ENOSYS;  /*TODO: something different needed for
 				      FI_EP_MSG */

--- a/prov/gni/src/gnix_cm_nic.c
+++ b/prov/gni/src/gnix_cm_nic.c
@@ -190,10 +190,10 @@ int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 		if (name->name_type == GNIX_EPN_TYPE_BOUND) {
 			/* EP name includes user specified service/port */
 			cdm_id = name->gnix_addr.cdm_id;
+			cm_nic->name_type = GNIX_EPN_TYPE_BOUND;
 		}
-	}
-
-	if (cdm_id == -1) {
+	} else {
+		cm_nic->name_type = GNIX_EPN_TYPE_UNBOUND;
 		ret = _gnix_get_new_cdm_id(domain, &cdm_id);
 		if (ret != FI_SUCCESS)
 			goto err;

--- a/prov/gni/src/gnix_nameserver.c
+++ b/prov/gni/src/gnix_nameserver.c
@@ -268,6 +268,7 @@ int gnix_resolve_name(IN const char *node, IN const char *service,
 		/* use resolved service/port */
 		resolved_addr->gnix_addr.cdm_id = ntohs(sa->sin_port);
 		resolved_addr->name_type = GNIX_EPN_TYPE_BOUND;
+		resolved_addr->cm_nic_cdm_id = resolved_addr->gnix_addr.cdm_id;
 	} else {
 		/* generate port internally */
 		resolved_addr->name_type = GNIX_EPN_TYPE_UNBOUND;

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -728,7 +728,7 @@ static int __gnix_vc_connect_prog_fn(void *data, int *complete_ptr)
 	 * and target address
 	 */
 
-	dgram->target_addr = vc->peer_addr;
+	dgram->target_addr = vc->peer_cm_nic_addr;
 	dgram->callback_fn = __gnix_vc_process_datagram;
 	dgram->pre_post_clbk_fn = __gnix_vc_pre_post_clbk;
 	dgram->post_post_clbk_fn = __gnix_vc_post_post_clbk;


### PR DESCRIPTION
As part of the cm_nic refactor, start using the
cm_nic_cdm_id as the id to supply for GNI postdatagram
exchange.

@ztiffany please review
