### PR TITLE
prov/gni: swat malloc - no proto type warning

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -43,6 +43,7 @@ extern "C" {
 #endif /* HAVE_CONFIG_H */
 
 #include <stdbool.h>
+#include <stdlib.h>
 
 #include <rdma/fabric.h>
 #include <rdma/fi_atomic.h>

--- a/prov/gni/src/gnix_tags.c
+++ b/prov/gni/src/gnix_tags.c
@@ -33,10 +33,9 @@
 #include "rdma/fabric.h"
 #include "rdma/fi_tagged.h"
 
-#include "gnix_tags.h"
-
 #include "gnix.h"
 #include "gnix_util.h"
+#include "gnix_tags.h"
 
 struct gnix_tag_storage_ops list_ops;
 struct gnix_tag_storage_ops hlist_ops;

--- a/prov/gni/test/av.c
+++ b/prov/gni/test/av.c
@@ -33,6 +33,7 @@
 
 #include <stdio.h>
 #include <stddef.h>
+#include <stdlib.h>
 
 #include "fi.h"
 #include "rdma/fi_domain.h"

--- a/prov/gni/test/dlist-utils.c
+++ b/prov/gni/test/dlist-utils.c
@@ -31,6 +31,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/time.h>
 #include <fi_list.h>
 

--- a/prov/gni/test/eq.c
+++ b/prov/gni/test/eq.c
@@ -31,8 +31,8 @@
  * SOFTWARE.
  */
 
-#include "gnix_eq.h"
 #include "gnix.h"
+#include "gnix_eq.h"
 
 #include <criterion/criterion.h>
 

--- a/prov/gni/test/queue.c
+++ b/prov/gni/test/queue.c
@@ -31,6 +31,8 @@
  * SOFTWARE.
  */
 
+#include <stdlib.h>
+
 #include "gnix_queue.h"
 
 #include <criterion/criterion.h>


### PR DESCRIPTION
If one configures libfabric with
export CFLAGS="-g"
and compiles with the gcc 5.1.0 compiler,
one gets a bunch of warning about no prototype
for malloc.

This commit suppresses these warnings.

@e-harvey 
@sungeunchoi 

Signed-off-by: Howard Pritchard howardp@lanl.gov
