### PR TITLE
Add a valgrind suppression for the ioctl call in gni_fma_assign.

### DIFF
--- a/prov/gni/contrib/gnitest.supp
+++ b/prov/gni/contrib/gnitest.supp
@@ -23,6 +23,14 @@
    ...
 }
 {
+   ioctl_gni_fma_assign
+   Memcheck:Param
+   ioctl(generic)
+   fun:ioctl
+   fun:gni_fma_assign
+   ...
+}
+{
    GNI_EpPostDataTestById__gnix_dgram_poll
    Memcheck:Addr4
    fun:GNI_EpPostDataTestById


### PR DESCRIPTION
@ztiffany 

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com
