### PR TITLE
Fix small bug with tagged cq entry returned by fi_cq_read()

### DIFF
--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -943,7 +943,6 @@ ssize_t _gnix_recv(struct gnix_fid_ep *ep, uint64_t buf, size_t len,
 			req->msg.recv_md = md;
 		}
 		req->msg.recv_flags = flags;
-		req->msg.tag = r_tag;
 		req->msg.ignore = r_ignore;
 
 		if (req->msg.send_flags & GNIX_MSG_RENDEZVOUS) {


### PR DESCRIPTION
As pointed out by Jim, we we're returning the tag that is passed into
fi_trecv().  We should instead be returning the actual tag.

Added a test modeled after the original bug report.

Also fixed up the rdm_tagged_sr tests a bit since I was in there (use
FI_CQ_FORMAT_TAGGED, register memory for FI_SEND | FI_RECV).

@jswaro @ztiffany @hppritcha 

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com
