### PR TITLE
Fix rendezvous send locking

### DIFF
--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -222,6 +222,7 @@ struct gnix_vc *_gnix_nic_next_pending_vc(struct gnix_nic *nic);
 int _gnix_vc_dequeue_smsg(struct gnix_vc *vc);
 int _gnix_vc_progress(struct gnix_vc *vc);
 int _gnix_vc_queue_tx_req(struct gnix_fab_req *req);
+int _gnix_vc_force_queue_req(struct gnix_fab_req *req);
 int _gnix_vc_queue_req(struct gnix_fab_req *req);
 
 /**

--- a/prov/gni/src/gnix_mr.c
+++ b/prov/gni/src/gnix_mr.c
@@ -693,6 +693,8 @@ static int __mr_cache_register(
 
 		__mr_cache_entry_get(cache, entry);
 
+		GNIX_INFO(FI_LOG_MR, "Using existing MR\n");
+
 		/* Done, go to the end */
 		goto success;
 	}

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -1028,8 +1028,8 @@ ssize_t _gnix_recv(struct gnix_fid_ep *ep, uint64_t buf, size_t len,
 			md = container_of(mdesc,
 					struct gnix_fid_mem_desc,
 					mr_fid);
-			req->msg.recv_md = md;
 		}
+		req->msg.recv_md = md;
 		req->msg.recv_flags = flags;
 		req->msg.ignore = r_ignore;
 
@@ -1122,8 +1122,8 @@ ssize_t _gnix_recv(struct gnix_fid_ep *ep, uint64_t buf, size_t len,
 			md = container_of(mdesc,
 					struct gnix_fid_mem_desc,
 					mr_fid);
-			req->msg.recv_md = md;
 		}
+		req->msg.recv_md = md;
 		req->msg.recv_flags = flags;
 		req->msg.tag = r_tag;
 		req->msg.ignore = r_ignore;

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -1365,6 +1365,19 @@ int _gnix_vc_push_tx_reqs(struct gnix_vc *vc)
 	return fi_rc;
 }
 
+/* Force the request to be queued, do not allow an inline send. */
+int _gnix_vc_force_queue_req(struct gnix_fab_req *req)
+{
+	struct gnix_vc *vc = req->vc;
+
+	fastlock_acquire(&vc->req_queue_lock);
+	slist_insert_tail(&req->slist, &vc->req_queue);
+	_gnix_vc_schedule(vc);
+	fastlock_release(&vc->req_queue_lock);
+
+	return FI_SUCCESS;
+}
+
 int _gnix_vc_queue_req(struct gnix_fab_req *req)
 {
 	int rc, queue_req = 0;


### PR DESCRIPTION
Do not allow rendezvous data GET to be initiated in the SMSG RX callback.  The
NIC lock is held at this point, causing deadlock issues.  Instead, queue the
rendezvous request.  A queued request will be processed shortly after in the
same progress iteration.

Fixes ofi-cray/libfabric-cray#352.

Related to ofi-cray/libfabric-cray#437.

Signed-off-by: Zach Tiffany ztiffany@cray.com

@hppritcha @sungeunchoi @jswaro @jshimek 
