### PR TITLE
Fix for MR cache flush.

### DIFF
--- a/prov/gni/include/gnix_mr.h
+++ b/prov/gni/include/gnix_mr.h
@@ -47,7 +47,9 @@
  *             application consistently sends messages from the same buffers
  *             but continually registers and deregisters those regions. The
  *             LRU is implemented as a queue using a doubly linked list for
- *             fast removal/insertion .
+ *             fast removal/insertion.  Note that this is an
+ *             approximate LRU scheme, because the find function may
+ *             return a larger entry in the stale tree.
  *         - By default, there is no limit to the number of 'inuse'
  *             registrations in the cache. This can be changed by passing
  *             in a set of attributes during _gnix_mr_cache_init.

--- a/prov/gni/test/mr.c
+++ b/prov/gni/test/mr.c
@@ -633,7 +633,6 @@ Test(memory_registration_cache, same_addr_incr_size)
 	cr_assert(cache->state == GNIX_MRC_STATE_READY);
 
 	for (i = 2; i <= buf_len; i *= 2) {
-		printf("i=%d\n", i);
 		ret = fi_mr_reg(dom, (void *) buf, i, default_access,
 				default_offset, default_req_key,
 				default_flags, &mr, NULL);


### PR DESCRIPTION
The red-black tree match function returns the "best" match in a
(potentially re-balanced) tree, which may not be the exact match if
one exists.  This may cause a problem in the stale tree when flushing
via LRU, because the LRU entry may match an entry in the tree that is
not an exact match (which is should be).  This results a different
entry being removed from the LRU list than from the stale tree.

This removes the "best" match from the stale tree.  If this match is
not the LRU entry, then remove the match from the LRU list, and put
the original LRU entry back on the LRU list.

The inuse tree can also run into a similar problem during
deregistration which is not being addressed here.

@jswaro 

Fixes #422 and #445 

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com
