### PR TITLE
Defer mr_cache_init until first mr_reg, delay closing MR after rendezvous send

### DIFF
--- a/prov/gni/include/fi_ext_gni.h
+++ b/prov/gni/include/fi_ext_gni.h
@@ -56,6 +56,7 @@ typedef enum dom_ops_val { GNI_MSG_RENDEZVOUS_THRESHOLD,
 			   GNI_TX_CQ_SIZE,
 			   GNI_MAX_RETRANSMITS,
 			   GNI_ERR_INJECT_COUNT,
+			   GNI_MR_CACHE_LAZY_DEREG,
 			   GNI_NUM_DOM_OPS
 } dom_ops_val_t;
 
@@ -80,7 +81,7 @@ struct gnix_ops_domain {
 	uint32_t rx_cq_size;
 	uint32_t tx_cq_size;
 	uint32_t max_retransmits;
-	uint32_t err_inject_count;
+	int32_t err_inject_count;
 };
 
 #endif /* _FI_EXT_GNI_H_ */

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -294,7 +294,9 @@ struct gnix_fid_domain {
 	enum fi_progress control_progress;
 	enum fi_progress data_progress;
 	struct gnix_reference ref_cnt;
-	gnix_mr_cache_t mr_cache;
+	gnix_mr_cache_attr_t mr_cache_attr;
+	gnix_mr_cache_t *mr_cache;
+	fastlock_t mr_cache_lock;
 };
 
 #define GNIX_CQS_PER_EP		8

--- a/prov/gni/include/gnix_mr.h
+++ b/prov/gni/include/gnix_mr.h
@@ -167,6 +167,8 @@ typedef struct gnix_mr_cache_attr {
 	int lazy_deregistration;
 } gnix_mr_cache_attr_t;
 
+extern gnix_mr_cache_attr_t __default_mr_cache_attr;
+
 typedef enum {
 	GNIX_MRC_STATE_UNINITIALIZED = 0,
 	GNIX_MRC_STATE_READY,
@@ -191,7 +193,6 @@ typedef struct gnix_mr_cache {
 	atomic_t inuse_elements;
 	atomic_t stale_elements;
 	struct dlist_entry lru_head;
-	fastlock_t lock;
 } gnix_mr_cache_t;
 
 /**
@@ -222,22 +223,6 @@ void _gnix_convert_key_to_mhdl(
  * @return              fi_mr_key to be used by remote EPs.
  */
 uint64_t _gnix_convert_mhdl_to_key(gni_mem_handle_t *mhdl);
-
-/**
- * @brief Initializes a gnix memory registration cache
- *
- * @param[in] cache  a gnix memory registration cache
- * @param[in] attr   a set of attributes to apply to the cache
- *
- * @return           FI_SUCCESS on success
- *                   -FI_EINVAL if an invalid cache pointer, or invalid set of
- *                     attributes has been passed into the function
- *                   -FI_ENOMEM if there wasn't sufficient memory to allocate
- *                     internal data structures
- */
-int _gnix_mr_cache_init(
-		gnix_mr_cache_t      *cache,
-		gnix_mr_cache_attr_t *attr);
 
 /**
  * @brief Destroys a gnix memory registration cache. Flushes stale memory

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -61,19 +61,16 @@ static void __domain_destruct(void *obj)
 	struct gnix_fid_domain *domain = (struct gnix_fid_domain *) obj;
 
 	/* if the domain isn't being destructed by close, we need to check the
-	 * cache again. This isn't a likely case. Both the flush and destroy
-	 * must succeed since we are in the destruct path */
-	ret = _gnix_mr_cache_flush(&domain->mr_cache);
-	if (ret != FI_SUCCESS)
-		GNIX_ERR(FI_LOG_DOMAIN, "failed to flush mr cache "
-				"during domain destruct, dom=%p", domain);
-	assert(ret == FI_SUCCESS);
-
-	ret = _gnix_mr_cache_destroy(&domain->mr_cache);
-	if (ret != FI_SUCCESS)
-		GNIX_ERR(FI_LOG_DOMAIN, "failed to destroy mr cache "
-				"during domain destruct, dom=%p", domain);
-	assert(ret == FI_SUCCESS);
+	 * cache again. This isn't a likely case. Destroy must succeed since we
+	 * are in the destruct path */
+	if (domain->mr_cache) {
+		ret = _gnix_mr_cache_destroy(domain->mr_cache);
+		if (ret != FI_SUCCESS)
+			GNIX_ERR(FI_LOG_DOMAIN, "failed to destroy mr cache "
+					"during domain destruct, dom=%p",
+					domain);
+		assert(ret == FI_SUCCESS);
+	}
 
 	/*
 	 * Drop a reference to each NIC used by this domain.
@@ -113,11 +110,16 @@ static int gnix_domain_close(fid_t fid)
 	}
 
 	/* before checking the refcnt, flush the memory registration cache */
-	ret = _gnix_mr_cache_flush(&domain->mr_cache);
-	if (ret != FI_SUCCESS) {
-		GNIX_WARN(FI_LOG_DOMAIN,
-			  "failed to flush memory cache on domain close\n");
-		goto err;
+	if (domain->mr_cache) {
+		fastlock_acquire(&domain->mr_cache_lock);
+		ret = _gnix_mr_cache_flush(domain->mr_cache);
+		if (ret != FI_SUCCESS) {
+			GNIX_WARN(FI_LOG_DOMAIN,
+				  "failed to flush memory cache on domain close\n");
+			fastlock_release(&domain->mr_cache_lock);
+			goto err;
+		}
+		fastlock_release(&domain->mr_cache_lock);
 	}
 
 	/*
@@ -361,9 +363,9 @@ int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		goto err;
 	}
 
-	ret = _gnix_mr_cache_init(&domain->mr_cache, NULL);
-	if (ret != FI_SUCCESS)
-		goto err;
+	domain->mr_cache_attr = __default_mr_cache_attr;
+	domain->mr_cache = NULL;
+	fastlock_init(&domain->mr_cache_lock);
 
 	dlist_init(&domain->nic_list);
 	dlist_init(&domain->list);

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -222,6 +222,9 @@ __gnix_dom_ops_get_val(struct fid *fid, dom_ops_val_t t, void *val)
 	case GNI_ERR_INJECT_COUNT:
 		*(int32_t *)val = domain->params.err_inject_count;
 		break;
+	case GNI_MR_CACHE_LAZY_DEREG:
+		*(int32_t *)val = domain->mr_cache_attr.lazy_deregistration;
+		break;
 	default:
 		GNIX_WARN(FI_LOG_DOMAIN, ("Invalid dom_ops_val\n"));
 		return -FI_EINVAL;
@@ -287,6 +290,9 @@ __gnix_dom_ops_set_val(struct fid *fid, dom_ops_val_t t, void *val)
 		break;
 	case GNI_ERR_INJECT_COUNT:
 		domain->params.err_inject_count = *(int32_t *)val;
+		break;
+	case GNI_MR_CACHE_LAZY_DEREG:
+		domain->mr_cache_attr.lazy_deregistration = *(int32_t *)val;
 		break;
 	default:
 		GNIX_WARN(FI_LOG_DOMAIN, ("Invalid dom_ops_val\n"));


### PR DESCRIPTION
Delaying mr_cache_init until after a domain is created allows us to tune MR
cache parameters with domain provider ops.

Signed-off-by: Zach Tiffany ztiffany@cray.com

@jswaro @hppritcha @sungeunchoi I am going towards creating a test which uses lazy deregistration.  The first step is allowing us to configure a domain's mr cache attributes.
