### PR TITLE
prov/gni: refactor connection setup code

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -279,6 +279,7 @@ struct gnix_fid_domain {
 	/* list nics this domain is attached to, TODO: thread safety */
 	struct dlist_entry nic_list;
 	struct gnix_fid_fabric *fabric;
+	struct gnix_cm_nic *cm_nic;
 	uint8_t ptag;
 	uint32_t cookie;
 	uint32_t cdm_id_seed;
@@ -321,7 +322,7 @@ struct gnix_fid_ep {
 	struct gnix_fid_cntr *read_cntr;
 	struct gnix_fid_cntr *write_cntr;
 	struct gnix_fid_av *av;
-	/* cm nic bound to this ep (FID_EP_RDM only) */
+	struct gnix_ep_name my_name;
 	struct gnix_cm_nic *cm_nic;
 	struct gnix_nic *nic;
 	union {
@@ -329,8 +330,6 @@ struct gnix_fid_ep {
 		struct gnix_vc **vc_table;      /* used for FI_AV_TABLE */
 		struct gnix_vc *vc;
 	};
-	fastlock_t vc_list_lock;
-	struct dlist_entry wc_vc_list;
 	/* lock for unexp and posted recv queue */
 	fastlock_t recv_queue_lock;
 	/* used for unexpected receives */

--- a/prov/gni/include/gnix_datagram.h
+++ b/prov/gni/include/gnix_datagram.h
@@ -78,6 +78,7 @@ extern "C" {
  * @var wc_dgram_active_list head of active list of wildcard datagrams
  * @var dgram_base           starting address of memory block from
  *                           which datagram structures are allocated
+ * @var lock                 lock to protect dgram lists
  * @var progress_thread      pthread id of progress thread for this
  *                           datagram allocator
  * @var n_dgrams             number of bound datagrams managed by the
@@ -92,6 +93,7 @@ struct gnix_dgram_hndl {
 	struct dlist_entry wc_dgram_free_list;
 	struct dlist_entry wc_dgram_active_list;
 	struct gnix_datagram *dgram_base;
+	fastlock_t lock;
 	pthread_t progress_thread;
 	int n_dgrams;
 	int n_wc_dgrams;

--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -53,6 +53,7 @@ extern "C" {
 #define GNIX_VC_MODE_IN_HT		(1U << 1)
 #define GNIX_VC_MODE_DG_POSTED		(1U << 2)
 #define GNIX_VC_MODE_PENDING_MSGS	(1U << 3)
+#define GNIX_VC_MODE_PEER_CONNECTED	(1U << 4)
 
 /* VC flags */
 #define GNIX_VC_FLAG_SCHEDULED		0
@@ -71,9 +72,12 @@ enum gnix_vc_conn_state {
 };
 
 enum gnix_vc_conn_req_type {
-	GNIX_VC_CONN_REQ_CONN = 100,
-	GNIX_VC_CONN_REQ_LISTEN
+	GNIX_VC_CONN_REQ = 1,
+	GNIX_VC_CONN_RESP
 };
+
+#define LOCAL_MBOX_SENT (1UL)
+#define REMOTE_MBOX_RCVD (1UL << 1)
 
 /**
  * Virual Connection (VC) struct
@@ -117,6 +121,7 @@ struct gnix_vc {
 	atomic_t outstanding_tx_reqs;
 	atomic_t outstanding_reqs;
 	enum gnix_vc_conn_state conn_state;
+	uint32_t post_state;
 	int vc_id;
 	int modes;
 	struct dlist_entry pending_list;
@@ -241,5 +246,7 @@ int _gnix_vc_queue_req(struct gnix_fab_req *req);
  */
 int _gnix_ep_get_vc(struct gnix_fid_ep *ep, fi_addr_t dest_addr,
 		    struct gnix_vc **vc_ptr);
+
+int _gnix_vc_cm_init(struct gnix_cm_nic *cm_nic);
 
 #endif /* _GNIX_VC_H_ */

--- a/prov/gni/src/gnix_cm.c
+++ b/prov/gni/src/gnix_cm.c
@@ -95,11 +95,7 @@ static int gnix_getname(fid_t fid, void *addr, size_t *addrlen)
 	 */
 
 	if (ep->type == FI_EP_RDM) {
-		name.gnix_addr.cdm_id = ep->cm_nic->cdm_id;
-		name.gnix_addr.device_addr = ep->cm_nic->device_addr;
-		name.cookie = ep->domain->cookie;
-		name.cm_nic_cdm_id = ep->cm_nic->cdm_id;
-		name.name_type = ep->cm_nic->name_type;
+		name = ep->my_name;
 	} else {
 		return -FI_ENOSYS;  /*TODO: something different needed for
 				      FI_EP_MSG */

--- a/prov/gni/src/gnix_cm_nic.c
+++ b/prov/gni/src/gnix_cm_nic.c
@@ -41,7 +41,155 @@
 #include "gnix.h"
 #include "gnix_datagram.h"
 #include "gnix_cm_nic.h"
+#include "gnix_hashtable.h"
 
+
+#define GNIX_CM_NIC_BND_TAG (100)
+#define GNIX_CM_NIC_WC_TAG (99)
+
+/*******************************************************************************
+ * Helper functions
+ ******************************************************************************/
+
+static void __dgram_set_tag(struct gnix_datagram *d, uint8_t tag)
+{
+
+	_gnix_dgram_pack_buf(d, GNIX_DGRAM_IN_BUF,
+				    &tag, sizeof(uint8_t));
+}
+
+/*
+ * we unpack the out tag instead of getting it
+ * since we need to pass the partially advanced
+ * out buf to the receive callback function
+ * associated with the cm_nic instance.
+ */
+static void __dgram_unpack_out_tag(struct gnix_datagram *d, uint8_t *tag)
+{
+
+	_gnix_dgram_rewind_buf(d, GNIX_DGRAM_OUT_BUF);
+	_gnix_dgram_unpack_buf(d, GNIX_DGRAM_OUT_BUF,
+				      tag, sizeof(uint8_t));
+}
+
+static void __dgram_get_in_tag(struct gnix_datagram *d, uint8_t *tag)
+{
+
+	_gnix_dgram_rewind_buf(d, GNIX_DGRAM_IN_BUF);
+	_gnix_dgram_unpack_buf(d, GNIX_DGRAM_IN_BUF,
+				      tag, sizeof(uint8_t));
+	_gnix_dgram_rewind_buf(d, GNIX_DGRAM_IN_BUF);
+
+}
+
+static int __process_dgram_w_error(struct gnix_cm_nic *cm_nic,
+				   struct gnix_datagram *dgram,
+				   struct gnix_address peer_address,
+				   gni_post_state_t state)
+{
+	return -FI_ENOSYS;
+}
+
+static int __process_datagram(struct gnix_datagram *dgram,
+				 struct gnix_address peer_address,
+				 gni_post_state_t state)
+{
+	int ret = FI_SUCCESS;
+	struct gnix_cm_nic *cm_nic = NULL;
+	uint8_t in_tag = 0, out_tag = 0;
+	char rcv_buf[GNIX_CM_NIC_MAX_MSG_SIZE];
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	cm_nic = (struct gnix_cm_nic *)dgram->cache;
+	if (cm_nic == NULL) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			"process_datagram, null cache\n");
+		goto err;
+	}
+
+	if (state != GNI_POST_COMPLETED) {
+		ret = __process_dgram_w_error(cm_nic,
+					      dgram,
+					      peer_address,
+					      state);
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			"process_datagram bad post state %d\n", state);
+		goto err;
+	}
+
+	__dgram_get_in_tag(dgram, &in_tag);
+	if ((in_tag != GNIX_CM_NIC_BND_TAG) &&
+		(in_tag != GNIX_CM_NIC_WC_TAG)) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			"datagram with unknown in tag %d\n", in_tag);
+		assert(0);
+		goto err;
+	}
+
+	 __dgram_unpack_out_tag(dgram, &out_tag);
+	if ((out_tag != GNIX_CM_NIC_BND_TAG) &&
+		(out_tag != GNIX_CM_NIC_WC_TAG)) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			"datagram with unknown out tag %d\n", out_tag);
+		assert(0);
+		goto err;
+	}
+
+	/*
+	 * if out buf actually has data, call consumer's
+	 * receive callback
+	 */
+
+	if (out_tag == GNIX_CM_NIC_BND_TAG) {
+		_gnix_dgram_unpack_buf(dgram,
+					GNIX_DGRAM_OUT_BUF,
+					rcv_buf,
+					GNIX_CM_NIC_MAX_MSG_SIZE);
+		ret = cm_nic->rcv_cb_fn(cm_nic,
+					rcv_buf,
+					peer_address);
+		if (ret != FI_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				"cm_nic->rcv_cb_fn returned %d\n", ret);
+			goto err;
+		}
+	}
+
+	/*
+	 * if we are processing a WC datagram, repost, otherwise
+	 * just put back on the freelist.
+	 */
+	if (in_tag == GNIX_CM_NIC_WC_TAG) {
+		dgram->callback_fn = __process_datagram;
+		dgram->cache = cm_nic;
+		 __dgram_set_tag(dgram, in_tag);
+		ret = _gnix_dgram_wc_post(dgram);
+		if (ret != FI_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				"_gnix_dgram_wc_post returned %d\n",
+				ret);
+			goto err;
+		}
+	} else {
+		ret  = _gnix_dgram_free(dgram);
+		if (ret != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				"_gnix_dgram_free returned %d\n",
+				ret);
+	}
+
+	return ret;
+
+err:
+	if (in_tag == GNIX_CM_NIC_BND_TAG)
+		_gnix_dgram_free(dgram);
+	return ret;
+}
+
+/*******************************************************************************
+ * Internal API functions
+ ******************************************************************************/
 /*
  * generate a cdm_id, use the 16 LSB of base_id from domain
  * with 16 MSBs being obtained from atomic increment of
@@ -72,7 +220,7 @@ int _gnix_cm_nic_progress(struct gnix_cm_nic *cm_nic)
 	 * box...
 	 */
 
-	if (cm_nic->control_progress == FI_PROGRESS_MANUAL) {
+	if (cm_nic->ctrl_progress == FI_PROGRESS_MANUAL) {
 		ret = _gnix_dgram_poll(cm_nic->dgram_hndl,
 					  GNIX_DGRAM_NOBLOCK);
 		if (ret != FI_SUCCESS)
@@ -125,7 +273,7 @@ check_again:
 		goto check_again;
 	} else {
 		fastlock_acquire(&cm_nic->wq_lock);
-		dlist_insert_before(&cm_nic->cm_nic_wq, &p->list);
+		dlist_insert_before(&p->list, &cm_nic->cm_nic_wq);
 		fastlock_release(&cm_nic->wq_lock);
 	}
 
@@ -133,15 +281,11 @@ err:
 	return ret;
 }
 
-int _gnix_cm_nic_free(struct gnix_cm_nic *cm_nic)
+static void  __cm_nic_destruct(void *obj)
 {
-	int ret = FI_SUCCESS;
+	int ret;
 	gni_return_t status;
-
-	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
-
-	if (cm_nic == NULL)
-		return -FI_EINVAL;
+	struct gnix_cm_nic *cm_nic = (struct gnix_cm_nic *)obj;
 
 	if (cm_nic->dgram_hndl != NULL) {
 		ret = _gnix_dgram_hndl_free(cm_nic->dgram_hndl);
@@ -151,18 +295,162 @@ int _gnix_cm_nic_free(struct gnix_cm_nic *cm_nic)
 				  ret);
 	}
 
+	if (cm_nic->addr_to_ep_ht != NULL) {
+		ret = _gnix_ht_destroy(cm_nic->addr_to_ep_ht);
+		if (ret != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "gnix_ht_destroy returned %d\n",
+				  ret);
+		free(cm_nic->addr_to_ep_ht);
+	}
+
 	if (cm_nic->gni_cdm_hndl != NULL) {
 		status = GNI_CdmDestroy(cm_nic->gni_cdm_hndl);
 		if (status != GNI_RC_SUCCESS) {
 			GNIX_WARN(FI_LOG_EP_CTRL,
 				  "cdm destroy failed - %s\n",
 				  gni_err_str[status]);
-			ret = gnixu_to_fi_errno(status);
 		}
 	}
 
 	free(cm_nic);
+}
+
+int _gnix_cm_nic_send(struct gnix_cm_nic *cm_nic,
+		      char *sbuf, size_t len,
+		      struct gnix_address target_addr)
+{
+	int ret = FI_SUCCESS;
+	struct gnix_datagram *dgram = NULL;
+	ssize_t  __attribute__((unused)) plen;
+	uint8_t tag;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	if ((cm_nic == NULL) || (sbuf == NULL))
+		return -FI_EINVAL;
+
+	if (len > GNI_DATAGRAM_MAXSIZE)
+		return -FI_ENOSPC;
+
+	/*
+	 * TODO: verify that target_addr appears to be
+	 * correct - can't fully verify
+	 */
+
+	ret = _gnix_dgram_alloc(cm_nic->dgram_hndl,
+				GNIX_DGRAM_BND,
+				&dgram);
+	if (ret != FI_SUCCESS)
+		goto exit;
+
+	dgram->target_addr = target_addr;
+	dgram->callback_fn = __process_datagram;
+	dgram->cache = cm_nic;
+
+	tag = GNIX_CM_NIC_BND_TAG;
+	 __dgram_set_tag(dgram, tag);
+
+	plen = _gnix_dgram_pack_buf(dgram, GNIX_DGRAM_IN_BUF,
+				   sbuf, len);
+	assert (plen == len);
+
+	ret = _gnix_dgram_bnd_post(dgram);
+	if (ret == -FI_EBUSY) {
+		ret = -FI_EAGAIN;
+		_gnix_dgram_free(dgram);
+	}
+
+exit:
 	return ret;
+}
+
+int _gnix_cm_nic_reg_recv_fn(struct gnix_cm_nic *cm_nic,
+			     gnix_cm_nic_rcv_cb_func *recv_fn,
+			     gnix_cm_nic_rcv_cb_func **prev_fn)
+{
+	int ret = FI_SUCCESS;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	if (cm_nic == NULL)
+		return -FI_EINVAL;
+
+	*prev_fn = cm_nic->rcv_cb_fn;
+	cm_nic->rcv_cb_fn = recv_fn;
+
+	return ret;
+}
+
+int _gnix_cm_nic_enable(struct gnix_cm_nic *cm_nic)
+{
+	int i, ret = FI_SUCCESS;
+	struct gnix_fid_domain *domain;
+	struct gnix_datagram *dg_ptr;
+	uint8_t tag = GNIX_CM_NIC_WC_TAG;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	if (cm_nic == NULL)
+		return -FI_EINVAL;
+
+	domain = cm_nic->domain;
+	assert(domain != NULL);
+
+	assert(cm_nic->dgram_hndl != NULL);
+
+	for (i = 0; i < domain->fabric->n_wc_dgrams; i++) {
+		ret = _gnix_dgram_alloc(cm_nic->dgram_hndl, GNIX_DGRAM_WC,
+					&dg_ptr);
+
+		/*
+ 		 * wildcards may already be posted to the cm_nic,
+ 		 * so just break if -FI_EAGAIN is returned by
+ 		 * _gnix_dgram_alloc
+ 		 */
+
+		if (ret == -FI_EAGAIN) {
+			ret = FI_SUCCESS;
+			break;
+		}
+
+		if (ret != FI_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+			     "_gnix_dgram_alloc call returned %d\n", ret);
+				goto err;
+		}
+
+		dg_ptr->callback_fn = __process_datagram;
+		dg_ptr->cache = cm_nic;
+		 __dgram_set_tag(dg_ptr, tag);
+
+		ret = _gnix_dgram_wc_post(dg_ptr);
+		if (ret != FI_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				"_gnix_dgram_wc_post returned %d\n", ret);
+			_gnix_dgram_free(dg_ptr);
+			goto err;
+		}
+	}
+
+	/*
+	 * TODO: better cleanup in error case
+	 */
+err:
+	return ret;
+}
+
+int _gnix_cm_nic_free(struct gnix_cm_nic *cm_nic)
+{
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	if (cm_nic == NULL)
+		return -FI_EINVAL;
+
+	_gnix_ref_put(cm_nic);
+
+	return FI_SUCCESS;
 }
 
 int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
@@ -171,19 +459,23 @@ int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 {
 	int ret = FI_SUCCESS;
 	struct gnix_cm_nic *cm_nic = NULL;
-	uint32_t device_addr, cdm_id = -1;
+	uint32_t device_addr, cdm_id;
 	gni_return_t status;
+	gnix_hashtable_attr_t gnix_ht_attr = {0};
 	struct gnix_ep_name *name;
+	uint32_t name_type = GNIX_EPN_TYPE_UNBOUND;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
 	*cm_nic_ptr = NULL;
 
-	cm_nic = (struct gnix_cm_nic *)calloc(1, sizeof(*cm_nic));
-	if (cm_nic == NULL) {
-		ret = -FI_ENOMEM;
-		goto err;
-	}
+	/*
+	 * if app has specified a src_addr in the info
+	 * argument and length matches that for gnix_ep_name
+	 * we must allocate a cm_nic, otherwise we first
+	 * check to see if there is a cm_nic already for this domain
+	 * and just use it.
+	 */
 
 	if (info->src_addr &&
 	    info->src_addrlen == sizeof(struct gnix_ep_name)) {
@@ -191,10 +483,11 @@ int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 		if (name->name_type == GNIX_EPN_TYPE_BOUND) {
 			/* EP name includes user specified service/port */
 			cdm_id = name->gnix_addr.cdm_id;
-			cm_nic->name_type = GNIX_EPN_TYPE_BOUND;
+			name_type = name->name_type;
 		}
-	} else {
-		cm_nic->name_type = GNIX_EPN_TYPE_UNBOUND;
+	}
+
+	if (name_type == GNIX_EPN_TYPE_UNBOUND) {
 		ret = _gnix_get_new_cdm_id(domain, &cdm_id);
 		if (ret != FI_SUCCESS)
 			goto err;
@@ -203,48 +496,107 @@ int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 	GNIX_INFO(FI_LOG_EP_CTRL, "creating cm_nic for %u/0x%x/%u\n",
 		      domain->ptag, domain->cookie, cdm_id);
 
-	status = GNI_CdmCreate(cdm_id,
-			       domain->ptag,
-			       domain->cookie,
-			       gnix_cdm_modes,
-			       &cm_nic->gni_cdm_hndl);
-	if (status != GNI_RC_SUCCESS) {
-		GNIX_ERR(FI_LOG_EP_CTRL, "GNI_CdmCreate returned %s\n",
+#if 1
+	if ((name_type == GNIX_EPN_TYPE_BOUND) ||
+	    (domain->cm_nic == NULL)) {
+#endif
+#if 0
+	if ((name_type == GNIX_EPN_TYPE_BOUND) ||
+		(name_type == GNIX_EPN_TYPE_UNBOUND)) {
+#endif
+
+		cm_nic = (struct gnix_cm_nic *)calloc(1, sizeof(*cm_nic));
+		if (cm_nic == NULL) {
+			ret = -FI_ENOMEM;
+			goto err;
+		}
+
+		status = GNI_CdmCreate(cdm_id,
+				       domain->ptag,
+				       domain->cookie,
+				       gnix_cdm_modes,
+				       &cm_nic->gni_cdm_hndl);
+		if (status != GNI_RC_SUCCESS) {
+			GNIX_ERR(FI_LOG_EP_CTRL, "GNI_CdmCreate returned %s\n",
+				       gni_err_str[status]);
+			ret = gnixu_to_fi_errno(status);
+			goto err;
+		}
+
+		/*
+		 * Okay, now go for the attach
+		 */
+		status = GNI_CdmAttach(cm_nic->gni_cdm_hndl, 0, &device_addr,
+				       &cm_nic->gni_nic_hndl);
+		if (status != GNI_RC_SUCCESS) {
+			GNIX_ERR(FI_LOG_EP_CTRL, "GNI_CdmAttach returned %s\n",
 			       gni_err_str[status]);
-		ret = gnixu_to_fi_errno(status);
-		goto err;
+			ret = gnixu_to_fi_errno(status);
+			goto err;
+		}
+
+		cm_nic->my_name.gnix_addr.cdm_id = cdm_id;
+		cm_nic->ptag = domain->ptag;
+		cm_nic->my_name.cookie = domain->cookie;
+		cm_nic->my_name.gnix_addr.device_addr = device_addr;
+		cm_nic->domain = domain;
+		cm_nic->ctrl_progress = domain->control_progress;
+		cm_nic->my_name.name_type = name_type;
+		fastlock_init(&cm_nic->lock);
+		fastlock_init(&cm_nic->wq_lock);
+		dlist_init(&cm_nic->cm_nic_wq);
+
+		/*
+		 * prep the cm nic's dgram component
+		 */
+		ret = _gnix_dgram_hndl_alloc(domain->fabric,
+					     cm_nic,
+					     domain->control_progress,
+					     &cm_nic->dgram_hndl);
+		if (ret != FI_SUCCESS)
+			goto err;
+
+		/*
+		 * allocate hash table for translating ep addresses
+		 * to ep's.
+		 * This table will not be large - how many FI_EP_RDM ep's
+		 * will an app create using one domain?, nor in the critical path
+		 * so just use defaults.
+		 */
+		cm_nic->addr_to_ep_ht = calloc(1, sizeof(struct gnix_hashtable));
+		if (cm_nic->addr_to_ep_ht == NULL)
+			goto err;
+
+		gnix_ht_attr.ht_initial_size = 64;
+		gnix_ht_attr.ht_maximum_size = 1024;
+		gnix_ht_attr.ht_increase_step = 2;
+		gnix_ht_attr.ht_increase_type = GNIX_HT_INCREASE_MULT;
+		gnix_ht_attr.ht_collision_thresh = 500;
+		gnix_ht_attr.ht_hash_seed = 0xdeadbeefbeefdead;
+		gnix_ht_attr.ht_internal_locking = 1;
+
+		ret = _gnix_ht_init(cm_nic->addr_to_ep_ht, &gnix_ht_attr);
+		if (ret != FI_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "gnix_ht_init returned %d\n",
+				  ret);
+			goto err;
+		}
+
+		_gnix_ref_init(&cm_nic->ref_cnt, 1, __cm_nic_destruct);
+		/*
+ 		 * if this is not a bound endpoint, set the domain's cm_nic
+ 		 * field to point to this new cm_nic
+ 		 */
+
+#if 1
+		if (name_type == GNIX_EPN_TYPE_UNBOUND)
+			domain->cm_nic = cm_nic;
+#endif
+	} else  {
+		cm_nic = domain->cm_nic;
+		_gnix_ref_get(cm_nic);
 	}
-
-	/*
-	 * Okay, now go for the attach
-	 */
-	status = GNI_CdmAttach(cm_nic->gni_cdm_hndl, 0, &device_addr,
-			       &cm_nic->gni_nic_hndl);
-	if (status != GNI_RC_SUCCESS) {
-		GNIX_ERR(FI_LOG_EP_CTRL, "GNI_CdmAttach returned %s\n",
-		       gni_err_str[status]);
-		ret = gnixu_to_fi_errno(status);
-		goto err;
-	}
-
-	cm_nic->cdm_id = cdm_id;
-	cm_nic->ptag = domain->ptag;
-	cm_nic->cookie = domain->cookie;
-	cm_nic->device_addr = device_addr;
-	cm_nic->control_progress = domain->control_progress;
-	fastlock_init(&cm_nic->lock);
-	fastlock_init(&cm_nic->wq_lock);
-	dlist_init(&cm_nic->cm_nic_wq);
-
-	/*
-	 * prep the cm nic's dgram component
-	 */
-	ret = _gnix_dgram_hndl_alloc(domain->fabric,
-				     cm_nic,
-				     domain->control_progress,
-				     &cm_nic->dgram_hndl);
-	if (ret != FI_SUCCESS)
-		goto err;
 
 	*cm_nic_ptr = cm_nic;
 	return ret;
@@ -255,6 +607,11 @@ err:
 
 	if (cm_nic->gni_cdm_hndl)
 		GNI_CdmDestroy(cm_nic->gni_cdm_hndl);
+
+	if (cm_nic->addr_to_ep_ht) {
+		_gnix_ht_destroy(cm_nic->addr_to_ep_ht);
+		free(cm_nic->addr_to_ep_ht);
+	}
 
 	if (cm_nic != NULL)
 		free(cm_nic);

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -755,9 +755,14 @@ static void __ep_destruct(void *obj)
 		ret =  _gnix_ht_remove(ep->cm_nic->addr_to_ep_ht,
 				       *key_ptr);
 		if (ep->vc_ht != NULL) {
-			_gnix_ht_destroy(ep->vc_ht);
-			free(ep->vc_ht);
-			ep->vc_ht = NULL;
+			ret = _gnix_ht_destroy(ep->vc_ht);
+			if (ret == FI_SUCCESS) {
+				free(ep->vc_ht);
+				ep->vc_ht = NULL;
+			} else
+				GNIX_WARN(FI_LOG_EP_CTRL,
+					"_gnix_ht_destroy returned %d\n",
+					ret);
 		}
 	}
 

--- a/prov/gni/test/datagram.c
+++ b/prov/gni/test/datagram.c
@@ -152,7 +152,7 @@ Test(dg_allocation, dgram_verify_cdm_id)
 	ep_priv = container_of(ep, struct gnix_fid_ep, ep_fid);
 	cm_nic = ep_priv->cm_nic;
 	cr_assert((cm_nic != NULL), "cm_nic NULL");
-	cr_assert((cm_nic->cdm_id == correct), "cm_nic incorrect cdm_id");
+	cr_assert((cm_nic->my_name.gnix_addr.cdm_id == correct), "cm_nic incorrect cdm_id");
 }
 
 
@@ -376,11 +376,9 @@ Test(dg_allocation,  dgram_wc_post_exchg)
 				&dgram_bnd);
 	cr_assert((ret == 0), "_gnix_dgram_alloc bnd");
 
-	dgram_bnd->target_addr.device_addr = cm_nic->device_addr;
-	dgram_bnd->target_addr.cdm_id = cm_nic->cdm_id;
+	dgram_bnd->target_addr = cm_nic->my_name.gnix_addr;
 
-	local_address.device_addr = cm_nic->device_addr;
-	local_address.cdm_id = cm_nic->cdm_id;
+	local_address = cm_nic->my_name.gnix_addr;
 
 	dgram_bnd->callback_fn = dgram_callback_fn;
 	ret = _gnix_dgram_bnd_post(dgram_bnd);
@@ -413,7 +411,7 @@ Test(dg_allocation,  dgram_wc_post_exchg_manual, .init = dg_setup_prog_manual)
 	cm_nic = ep_priv->cm_nic;
 	cr_assert((cm_nic != NULL), "cm_nic NULL");
 
-	cr_assert(cm_nic->control_progress == FI_PROGRESS_MANUAL);
+	cr_assert(cm_nic->ctrl_progress == FI_PROGRESS_MANUAL);
 
 	cr_assert((cm_nic->dgram_hndl != NULL), "cm_nic dgram_hndl NULL");
 
@@ -429,11 +427,9 @@ Test(dg_allocation,  dgram_wc_post_exchg_manual, .init = dg_setup_prog_manual)
 				&dgram_bnd);
 	cr_assert((ret == 0), "_gnix_dgram_alloc bnd");
 
-	dgram_bnd->target_addr.device_addr = cm_nic->device_addr;
-	dgram_bnd->target_addr.cdm_id = cm_nic->cdm_id;
+	dgram_bnd->target_addr = cm_nic->my_name.gnix_addr;
 
-	local_address.device_addr = cm_nic->device_addr;
-	local_address.cdm_id = cm_nic->cdm_id;
+	local_address = cm_nic->my_name.gnix_addr;
 
 	dgram_bnd->callback_fn = dgram_callback_fn;
 	ret = _gnix_dgram_bnd_post(dgram_bnd);

--- a/prov/gni/test/vc.c
+++ b/prov/gni/test/vc.c
@@ -69,18 +69,39 @@ fi_addr_t gni_addr[2];
 struct gnix_av_addr_entry * gnix_addr[2];
 size_t gnix_addrlen[2];
 
-void vc_setup(void)
+static void vc_setup_common(void);
+
+static void vc_setup_auto(void)
 {
-	int ret = 0;
-	struct fi_av_attr attr;
-	size_t addrlen = 0;
-	struct gnix_fid_av *gnix_av;
 
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 
 	hints->domain_attr->cq_data_size = 4;
+	hints->domain_attr->control_progress = FI_PROGRESS_AUTO;
 	hints->mode = ~0;
+
+	vc_setup_common();
+}
+
+static void vc_setup_manual(void)
+{
+
+	hints = fi_allocinfo();
+	cr_assert(hints, "fi_allocinfo");
+
+	hints->domain_attr->cq_data_size = 4;
+	hints->domain_attr->control_progress = FI_PROGRESS_MANUAL;
+	hints->mode = ~0;
+	vc_setup_common();
+}
+
+static void vc_setup_common(void)
+{
+	int ret = 0;
+	struct fi_av_attr attr;
+	size_t addrlen = 0;
+	struct gnix_fid_av *gnix_av;
 
 	hints->fabric_attr->name = strdup("gni");
 
@@ -139,8 +160,14 @@ void vc_setup(void)
 	ret = fi_ep_bind(ep[0], &av->fid, 0);
 	cr_assert(!ret, "fi_ep_bind");
 
+	ret = fi_enable(ep[0]);
+	cr_assert(!ret, "fi_ep_enable");
+
 	ret = fi_ep_bind(ep[1], &av->fid, 0);
 	cr_assert(!ret, "fi_ep_bind");
+
+	ret = fi_enable(ep[1]);
+	cr_assert(!ret, "fi_ep_enable");
 }
 
 void vc_teardown(void)
@@ -172,10 +199,13 @@ void vc_teardown(void)
  * Test vc functions.
  ******************************************************************************/
 
-TestSuite(vc_management, .init = vc_setup, .fini = vc_teardown,
+TestSuite(vc_management_auto, .init = vc_setup_auto, .fini = vc_teardown,
 	  .disabled = false);
 
-Test(vc_management, vc_alloc_simple)
+TestSuite(vc_management_manual, .init = vc_setup_manual, .fini = vc_teardown,
+	  .disabled = false);
+
+Test(vc_management_auto, vc_alloc_simple)
 {
 	int ret;
 	struct gnix_vc *vc[2];
@@ -202,7 +232,7 @@ Test(vc_management, vc_alloc_simple)
 	cr_assert_eq(ret, FI_SUCCESS);
 }
 
-Test(vc_management, vc_lookup_by_id)
+Test(vc_management_auto, vc_lookup_by_id)
 {
 	int ret;
 	struct gnix_vc *vc[2], *vc_chk;
@@ -230,48 +260,10 @@ Test(vc_management, vc_lookup_by_id)
 
 }
 
-Test(vc_management, vc_accept)
+Test(vc_management_auto, vc_connect)
 {
 	int ret;
-	struct gnix_vc *vc[2];
-	struct gnix_fid_ep *ep_priv;
-
-	ep_priv = container_of(ep[0], struct gnix_fid_ep, ep_fid);
-
-	ret = _gnix_vc_alloc(ep_priv, gnix_addr[0], &vc[0]);
-	cr_assert_eq(ret, FI_SUCCESS);
-
-	ret = _gnix_vc_alloc(ep_priv, NULL, &vc[1]);
-	cr_assert_eq(ret, FI_SUCCESS);
-
-	/*
-	 * this should fail because the vc was allocated with
-	 * an addr other than FI_ADDR_UNSPEC
-	 */
-
-	ret = _gnix_vc_accept(vc[0]);
-	cr_assert_eq(ret, -FI_EINVAL);
-
-	/*
-	 * this should succeed because the vc was allocated with
-	 * FI_ADDR_UNSPEC
-	 */
-
-	ret = _gnix_vc_accept(vc[1]);
-	cr_assert_eq(ret, FI_SUCCESS);
-
-	ret = _gnix_vc_destroy(vc[0]);
-	cr_assert_eq(ret, FI_SUCCESS);
-
-	ret = _gnix_vc_destroy(vc[1]);
-	cr_assert_eq(ret, FI_SUCCESS);
-
-}
-
-Test(vc_management, vc_conn_accept)
-{
-	int ret;
-	struct gnix_vc *vc_conn, *vc_listen;
+	struct gnix_vc *vc_conn;
 	struct gnix_fid_ep *ep_priv[2];
 	struct gnix_cm_nic *cm_nic[2];
 	gnix_ht_key_t key;
@@ -293,40 +285,19 @@ Test(vc_management, vc_conn_accept)
 	cr_assert_eq(ret, FI_SUCCESS);
 	vc_conn->modes |= GNIX_VC_MODE_IN_HT;
 
-	ret = _gnix_vc_alloc(ep_priv[1], NULL, &vc_listen);
-	cr_assert_eq(ret, FI_SUCCESS);
-
-	ret = _gnix_vc_accept(vc_listen);
-	cr_assert_eq(ret, FI_SUCCESS);
-
-	/*
-	 * this is the moral equivalent of fi_enable(ep[0]),
-	 * but we don't want to do that in our prologue since
-	 * the fi_enable would consume all of the available wc datagrams.
-	 */
-	dlist_insert_tail(&vc_listen->entry, &ep_priv[1]->wc_vc_list);
-
 	ret = _gnix_vc_connect(vc_conn);
 	cr_assert_eq(ret, FI_SUCCESS);
 
 	/*
-	 * progress the cm_nic
+	 * since we asked for FI_PROGRESS_AUTO for control
+	 * we can just spin here.  add a yield in case the
+	 * test is only being run on one cpu.
 	 */
 
 	state = GNIX_VC_CONN_NONE;
 	while (state != GNIX_VC_CONNECTED) {
-		ret = _gnix_cm_nic_progress(cm_nic[0]);
-		cr_assert_eq(ret, FI_SUCCESS);
 		pthread_yield();
 		state = _gnix_vc_state(vc_conn);
-	}
-
-	state = GNIX_VC_CONN_NONE;
-	while (state != GNIX_VC_CONNECTED) {
-		ret = _gnix_cm_nic_progress(cm_nic[1]);
-		cr_assert_eq(ret, FI_SUCCESS);
-		pthread_yield();
-		state = _gnix_vc_state(vc_listen);
 	}
 
 	ret = _gnix_vc_disconnect(vc_conn);
@@ -335,15 +306,75 @@ Test(vc_management, vc_conn_accept)
 	ret = _gnix_vc_destroy(vc_conn);
 	cr_assert_eq(ret, FI_SUCCESS);
 
-	/*
-	 * don't disconnect/destroy listening vc no
-	 * as this is part of ep_close op.
-	 */
-#if 0
-	ret = _gnix_vc_disconnect(vc_listen);
+}
+
+Test(vc_management_auto, vc_connect2)
+{
+	int ret;
+	struct gnix_vc *vc_conn0, *vc_conn1;
+	struct gnix_fid_ep *ep_priv[2];
+	gnix_ht_key_t key;
+	enum gnix_vc_conn_state state;
+
+	ep_priv[0] = container_of(ep[0], struct gnix_fid_ep, ep_fid);
+	ep_priv[1] = container_of(ep[1], struct gnix_fid_ep, ep_fid);
+
+	ret = _gnix_vc_alloc(ep_priv[0], gnix_addr[1], &vc_conn0);
 	cr_assert_eq(ret, FI_SUCCESS);
 
-	ret = _gnix_vc_destroy(vc_listen);
+	memcpy(&key, &gni_addr[1],
+		sizeof(gnix_ht_key_t));
+
+	ret = _gnix_ht_insert(ep_priv[0]->vc_ht, key, vc_conn0);
 	cr_assert_eq(ret, FI_SUCCESS);
-#endif
+
+	vc_conn0->modes |= GNIX_VC_MODE_IN_HT;
+
+	ret = _gnix_vc_alloc(ep_priv[1], gnix_addr[0], &vc_conn1);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	memcpy(&key, &gni_addr[0],
+		sizeof(gnix_ht_key_t));
+
+	ret = _gnix_ht_insert(ep_priv[1]->vc_ht, key, vc_conn1);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	vc_conn1->modes |= GNIX_VC_MODE_IN_HT;
+
+	ret = _gnix_vc_connect(vc_conn0);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	ret = _gnix_vc_connect(vc_conn1);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	/*
+	 * since we asked for FI_PROGRESS_AUTO for control
+	 * we can just spin here.  add a yield in case the
+	 * test is only being run on one cpu.
+	 */
+
+	state = GNIX_VC_CONN_NONE;
+	while (state != GNIX_VC_CONNECTED) {
+		pthread_yield();
+		state = _gnix_vc_state(vc_conn0);
+	}
+
+	state = GNIX_VC_CONN_NONE;
+	while (state != GNIX_VC_CONNECTED) {
+		pthread_yield();
+		state = _gnix_vc_state(vc_conn1);
+	}
+
+	ret = _gnix_vc_disconnect(vc_conn0);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	ret = _gnix_vc_destroy(vc_conn0);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	ret = _gnix_vc_disconnect(vc_conn1);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	ret = _gnix_vc_destroy(vc_conn1);
+	cr_assert_eq(ret, FI_SUCCESS);
+
 }

--- a/prov/gni/test/vc.c
+++ b/prov/gni/test/vc.c
@@ -265,15 +265,12 @@ Test(vc_management_auto, vc_connect)
 	int ret;
 	struct gnix_vc *vc_conn;
 	struct gnix_fid_ep *ep_priv[2];
-	struct gnix_cm_nic *cm_nic[2];
 	gnix_ht_key_t key;
 	enum gnix_vc_conn_state state;
 
 	ep_priv[0] = container_of(ep[0], struct gnix_fid_ep, ep_fid);
-	cm_nic[0] = ep_priv[0]->cm_nic;
 
 	ep_priv[1] = container_of(ep[1], struct gnix_fid_ep, ep_fid);
-	cm_nic[1] = ep_priv[1]->cm_nic;
 
 	ret = _gnix_vc_alloc(ep_priv[0], gnix_addr[1], &vc_conn);
 	cr_assert_eq(ret, FI_SUCCESS);


### PR DESCRIPTION
This is a major refactor of the connection
setup path within the GNI provider.  The
underlying driver for this refactor is issue

In the original GNI provider design, each
FI_EP_RDM endpoint had its own gnix_cm_nic
for connection management.  The problem with
this scheme is that after a few 10s or so of
EP rdms are created, a GNI CQ resource limit
is reached.

In this refactor, unless the FI_EP_RDM has a user
specified cdm_id, the EP rdms associated with a
given domain share the same gnix_cm_nic.

In order to do this, the datagram usage had to
be significantly changed.  Now connections are managed
by a two-stage datagram exchange approach.  Wildcard
datagrams no longer have mailboxes associated with them,
they are purely used to sink incoming connection requests
and responses.

This refactor also uncovered some bugs in other parts
of the connection management path.

Some of the criterion tests had to be modified owing
to GNI provider internal changes.

Fixes #230.

Signed-off-by: Howard Pritchard howardp@lanl.gov
