### PR TITLE
Call _gnix_cm_nic_free() after we're done using it to clear out addr_to_ep_ht

### DIFF
--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -735,7 +735,6 @@ static void __ep_destruct(void *obj)
 
 	cm_nic = ep->cm_nic;
 	assert(cm_nic != NULL);
-	_gnix_cm_nic_free(cm_nic);
 
 	nic = ep->nic;
 	assert(nic != NULL);
@@ -765,6 +764,8 @@ static void __ep_destruct(void *obj)
 					ret);
 		}
 	}
+
+	_gnix_cm_nic_free(cm_nic);
 
 	/* There is no other choice here, we need to assert if we can't free */
 	ret = _gnix_nic_free(nic);


### PR DESCRIPTION
ep->cm_nic was being used after the cm_nic had been freed.

@hppritcha @ztiffany @jswaro 

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com
