### PR TITLE
Free the cm_nic after freeing the nic, since it does a lot of internal freeing itself

### DIFF
--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -765,13 +765,15 @@ static void __ep_destruct(void *obj)
 		}
 	}
 
-	_gnix_cm_nic_free(cm_nic);
-
 	/* There is no other choice here, we need to assert if we can't free */
 	ret = _gnix_nic_free(nic);
 	assert(ret == FI_SUCCESS);
 
 	ep->nic = NULL;
+
+	/* This currently always returns FI_SUCCESS */
+	ret = _gnix_cm_nic_free(cm_nic);
+	assert(ret == FI_SUCCESS);
 
 	/*
 	 * Free fab_reqs


### PR DESCRIPTION
This fixes a valgrind invalid read error when freeing CQs and mbox slabs.

This fix gets rid of some (but not most) of the warnings reported in #484.

@hppritcha @ztiffany @jswaro 

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com
