### PR TITLE
prov/gni: fix one problem for osu_bibw

### DIFF
--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -149,6 +149,8 @@ static int process_rx_cqe(struct gnix_nic *nic, gni_cq_entry_t cqe)
 					"_gnix_vc_dqueue_smsg returned %d\n",
 					ret);
 		}
+		ret = _gnix_vc_schedule(vc);
+		assert(ret == FI_SUCCESS);
 	}
 #else /* Defer RX processing until after the RX CQ is cleared. */
 	_gnix_set_bit(&vc->flags, GNIX_VC_FLAG_RX_PENDING);

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -1051,8 +1051,6 @@ static int __gnix_vc_conn_ack_comp_fn(void *data)
  */
 static int __gnix_vc_conn_req_comp_fn(void *data)
 {
-	struct gnix_vc *vc = (struct gnix_vc *)data;
-
 	return FI_SUCCESS;
 }
 


### PR DESCRIPTION
The osu_bibw was bringing out an issue with
scheduling of vc's for processing.  Namely,
a vc should be scheduled if its gotten
SMSG notifications on its RX CQ for a mailbox.
This could indicate a return of SMSG credits
which allows for progressing of pending GNI
Smsg sends.

Also minor compiler warning cleanup.

With this commit, osu_bibw works up to the point where
it switches to rendezvous protocol.

Fixes #491 

@ztiffany 

Signed-off-by: Howard Pritchard howardp@lanl.gov
