### PR TITLE
Fix memory leaks and warning messages during endpoint destruction.

### DIFF
--- a/prov/gni/include/gnix_hashtable.h
+++ b/prov/gni/include/gnix_hashtable.h
@@ -94,6 +94,9 @@ enum gnix_ht_increase {
  *                           results.
  * @var ht_internal_locking  if non-zero, uses a version of the hash table with
  *                           internal locking implemented
+ *
+ * @var destructor           if non-NULL, will be called with value when
+ *                           destroying the hash table
  */
 typedef struct gnix_hashtable_attr {
 	int ht_initial_size;
@@ -103,6 +106,7 @@ typedef struct gnix_hashtable_attr {
 	int ht_collision_thresh;
 	uint64_t ht_hash_seed;
 	int ht_internal_locking;
+	void  (*destructor)(void *);
 } gnix_hashtable_attr_t;
 
 struct gnix_hashtable;
@@ -206,5 +210,15 @@ void *_gnix_ht_lookup(gnix_hashtable_t *ht, gnix_ht_key_t key);
  * @return        true if the hash table is empty, false if not
  */
 int _gnix_ht_empty(gnix_hashtable_t *ht);
+
+/* Hastable iteration macros */
+#define ht_lf_for_each(ht, ht_entry)				\
+	dlist_for_each(ht->ht_lf_tbl->head, ht_entry, entry)	\
+
+#define ht_lk_for_each(ht, ht_entry)				\
+	dlist_for_each(ht.ht_lk_tbl->head, ht_entry, entry)
+
+#define ht_entry_value(ht_entry)		\
+	ht_entry->value
 
 #endif /* GNIX_HASHTABLE_H_ */

--- a/prov/gni/src/gnix_av.c
+++ b/prov/gni/src/gnix_av.c
@@ -552,6 +552,7 @@ static void __av_destruct(void *obj)
 			GNIX_WARN(FI_LOG_AV,
 				  "_gnix_ht_destroy failed %d\n",
 				  ret);
+		free(av->map_ht);
 	}
 	if (av->valid_entry_vec) {
 		free(av->valid_entry_vec);
@@ -562,9 +563,6 @@ static void __av_destruct(void *obj)
 	free(av);
 }
 
-/*
- * TODO: Free memory for data structures when FI_AV_MAP is fully supported.
- */
 static int gnix_av_close(fid_t fid)
 {
 	struct gnix_fid_av *av = NULL;
@@ -675,6 +673,7 @@ int gnix_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 		ht_attr.ht_collision_thresh = 500;
 		ht_attr.ht_hash_seed = 0xdeadbeefbeefdead;
 		ht_attr.ht_internal_locking = 1;
+		ht_attr.destructor = NULL;
 
 		ret = _gnix_ht_init(int_av->map_ht,
 				    &ht_attr);

--- a/prov/gni/src/gnix_cm_nic.c
+++ b/prov/gni/src/gnix_cm_nic.c
@@ -574,6 +574,7 @@ int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 		gnix_ht_attr.ht_collision_thresh = 500;
 		gnix_ht_attr.ht_hash_seed = 0xdeadbeefbeefdead;
 		gnix_ht_attr.ht_internal_locking = 1;
+		gnix_ht_attr.destructor = NULL;
 
 		ret = _gnix_ht_init(cm_nic->addr_to_ep_ht, &gnix_ht_attr);
 		if (ret != FI_SUCCESS) {

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -942,10 +942,11 @@ static void __ep_destruct(void *obj)
 			if (ret == FI_SUCCESS) {
 				free(ep->vc_ht);
 				ep->vc_ht = NULL;
-			} else
+			} else {
 				GNIX_WARN(FI_LOG_EP_CTRL,
-					"_gnix_ht_destroy returned %d\n",
-					ret);
+					"_gnix_ht_destroy returned %s\n",
+					  fi_strerror(-ret));
+			}
 		}
 	}
 
@@ -1129,6 +1130,13 @@ err:
 	return ret;
 }
 
+static void __gnix_vc_destroy_ht_entry(void *val)
+{
+	struct gnix_vc *vc = (struct gnix_vc *) val;
+
+	_gnix_vc_destroy(vc);
+}
+
 int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 		 struct fid_ep **ep, void *context)
 {
@@ -1279,6 +1287,7 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 		gnix_ht_attr.ht_collision_thresh = 500;
 		gnix_ht_attr.ht_hash_seed = 0xdeadbeefbeefdead;
 		gnix_ht_attr.ht_internal_locking = 0;
+		gnix_ht_attr.destructor = __gnix_vc_destroy_ht_entry;
 
 		ep_priv->vc_ht = calloc(1, sizeof(struct gnix_hashtable));
 		if (ep_priv->vc_ht == NULL)

--- a/prov/gni/src/gnix_mbox_allocator.c
+++ b/prov/gni/src/gnix_mbox_allocator.c
@@ -709,7 +709,7 @@ int _gnix_mbox_alloc(struct gnix_mbox_alloc_handle *alloc_handle,
 		position = ret;
 	}
 
-	ret = __fill_mbox(alloc_handle, slab, position, ptr);
+	ret = __fill_mbox(alloc_handle, slab, (size_t) position, ptr);
 	if (ret)
 		GNIX_WARN(FI_LOG_EP_CTRL, "Creating mbox failed.\n");
 


### PR DESCRIPTION
- Added support in the hashtable for an entry destructor function.
  Call this function in __gnix_ht_destroy_list().
- Register VC destructor function for the vc_ht in the endpoint.  Add
  wrapper for VC destructor function to support this.
- Update av and cm_nic hashtables to initialize NULL destructor.
- Check to see if VC's smsg_mbox has already been allocated before
  allocating another one.

Fixes #432 
Fixes #484 
Fixes #486 

@hppritcha @jswaro @ztiffany 

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com
