### PR TITLE
Clean up teardown sequence to get rid of warnings.

### DIFF
--- a/prov/gni/test/rdm_atomic.c
+++ b/prov/gni/test/rdm_atomic.c
@@ -226,13 +226,19 @@ void rdm_atomic_teardown(void)
 {
 	int ret = 0;
 
-	fi_close(&read_cntr->fid);
-	fi_close(&write_cntr->fid);
+	ret = fi_close(&read_cntr->fid);
+	cr_assert(!ret, "failure in closing read counter.");
+
+	ret = fi_close(&write_cntr->fid);
+	cr_assert(!ret, "failure in closing write counter.");
 
 	free(uc_source);
 
-	fi_close(&loc_mr->fid);
-	fi_close(&rem_mr->fid);
+	ret = fi_close(&loc_mr->fid);
+	cr_assert(!ret, "failure in closing av.");
+
+	ret = fi_close(&rem_mr->fid);
+	cr_assert(!ret, "failure in closing av.");
 
 	free(target);
 	free(source);
@@ -242,6 +248,9 @@ void rdm_atomic_teardown(void)
 
 	ret = fi_close(&ep[1]->fid);
 	cr_assert(!ret, "failure in closing ep.");
+
+	ret = fi_close(&recv_cq->fid);
+	cr_assert(!ret, "failure in recv cq.");
 
 	ret = fi_close(&send_cq->fid);
 	cr_assert(!ret, "failure in send cq.");

--- a/prov/gni/test/rdm_rma.c
+++ b/prov/gni/test/rdm_rma.c
@@ -226,13 +226,19 @@ void rdm_rma_teardown(void)
 {
 	int ret = 0;
 
-	fi_close(&read_cntr->fid);
-	fi_close(&write_cntr->fid);
+	ret = fi_close(&read_cntr->fid);
+	cr_assert(!ret, "failure in closing read counter.");
+
+	ret = fi_close(&write_cntr->fid);
+	cr_assert(!ret, "failure in closing write counter.");
 
 	free(uc_source);
 
-	fi_close(&loc_mr->fid);
-	fi_close(&rem_mr->fid);
+	ret = fi_close(&loc_mr->fid);
+	cr_assert(!ret, "failure in closing av.");
+
+	ret = fi_close(&rem_mr->fid);
+	cr_assert(!ret, "failure in closing av.");
 
 	free(target);
 	free(source);
@@ -242,6 +248,9 @@ void rdm_rma_teardown(void)
 
 	ret = fi_close(&ep[1]->fid);
 	cr_assert(!ret, "failure in closing ep.");
+
+	ret = fi_close(&recv_cq->fid);
+	cr_assert(!ret, "failure in recv cq.");
 
 	ret = fi_close(&send_cq->fid);
 	cr_assert(!ret, "failure in send cq.");


### PR DESCRIPTION
- Close recv_cq
- Add additional error checking of ret value

Fixes #496 

@jswaro @ztiffany @hppritcha 

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com
