### PR TITLE
Rename FI_PRINT to GNIX_FI_PRINT

### DIFF
--- a/prov/gni/include/gnix_util.h
+++ b/prov/gni/include/gnix_util.h
@@ -52,7 +52,7 @@ extern struct fi_provider gnix_prov;
 #define GNIX_LOG_INTERNAL(FI_LOG_FN, subsystem, fmt, ...)	\
 	FI_LOG_FN(&gnix_prov, subsystem, fmt, ##__VA_ARGS__)
 
-#define FI_PRINT(prov, subsystem, ...)
+#define GNIX_FI_PRINT(prov, subsystem, ...)
 
 #else
 
@@ -62,7 +62,7 @@ extern __thread pid_t gnix_debug_pid;
 extern __thread uint32_t gnix_debug_tid;
 extern atomic_t gnix_debug_next_tid;
 
-#define FI_PRINT(prov, subsystem, ...)				\
+#define GNIX_FI_PRINT(prov, subsystem, ...)				\
 	do {								\
 		fi_log(prov, FI_LOG_WARN, subsystem,			\
 				__func__, __LINE__, __VA_ARGS__);	\
@@ -100,7 +100,7 @@ extern atomic_t gnix_debug_next_tid;
 	GNIX_LOG_INTERNAL(FI_DBG, subsystem, __VA_ARGS__)
 #define GNIX_ERR(subsystem, ...)                                               \
 	do { \
-		GNIX_LOG_INTERNAL(FI_PRINT, subsystem, __VA_ARGS__); \
+		GNIX_LOG_INTERNAL(GNIX_FI_PRINT, subsystem, __VA_ARGS__); \
 		abort(); \
 	} while (0)
 


### PR DESCRIPTION
@hppritcha 

In response to comment on https://github.com/ofiwg/libfabric/pull/1439

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com
