### PR TITLE
prov/gni: move fi_register_provider up above sock

### DIFF
--- a/src/fabric.c
+++ b/src/fabric.c
@@ -395,11 +395,11 @@ libdl_done:
 	fi_register_provider(USNIC_INIT, NULL);
 	fi_register_provider(MXM_INIT, NULL);
 	fi_register_provider(VERBS_INIT, NULL);
+	fi_register_provider(GNI_INIT, NULL);
         /* Initialize the sockets provider last.  This will result in
            it being the least preferred provider. */
 	fi_register_provider(SOCKETS_INIT, NULL);
 
-	fi_register_provider(GNI_INIT, NULL);
 	init = 1;
 
 unlock:


### PR DESCRIPTION
per feedback from PR ofiwg/libfabric#1439
the GNI_INIT takes a little trip up in the fabric.c file.

@sungeunchoi 

Signed-off-by: Howard Pritchard howardp@lanl.gov
