### PR TITLE
VC progress refactor

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -457,7 +457,7 @@ struct gnix_fab_req {
 	struct gnix_fid_ep        *gnix_ep;
 	void                      *user_context;
 	struct gnix_vc            *vc;
-	int                       (*send_fn)(void *);
+	int                       (*work_fn)(void *);
 	int                       modes;
 	int                       retries;
 	uint64_t                  flags;

--- a/prov/gni/include/gnix_hashtable.h
+++ b/prov/gni/include/gnix_hashtable.h
@@ -110,6 +110,7 @@ typedef struct gnix_hashtable_attr {
 } gnix_hashtable_attr_t;
 
 struct gnix_hashtable;
+struct gnix_hashtable_iter;
 
 typedef struct gnix_hashtable_ops {
 	int   (*init)(struct gnix_hashtable *);
@@ -119,6 +120,7 @@ typedef struct gnix_hashtable_ops {
 	void *(*lookup)(struct gnix_hashtable *, gnix_ht_key_t);
 	int   (*resize)(struct gnix_hashtable *, int, int);
 	struct dlist_entry *(*retrieve_list)(struct gnix_hashtable *, int bucket);
+	void *(*iter_next)(struct gnix_hashtable_iter *);
 } gnix_hashtable_ops_t;
 
 /**
@@ -150,6 +152,19 @@ typedef struct gnix_hashtable {
 		gnix_ht_lk_lh_t *ht_lk_tbl;
 	};
 } gnix_hashtable_t;
+
+struct gnix_hashtable_iter {
+	struct gnix_hashtable *ht;
+	int cur_idx;
+	struct dlist_entry *cur_entry;
+};
+
+#define GNIX_HASHTABLE_ITERATOR(_ht, _iter)	\
+	struct gnix_hashtable_iter _iter = {	\
+		.ht = (_ht),			\
+		.cur_idx = 0,			\
+		.cur_entry = NULL		\
+	}
 
 /**
  * Initializes the hash table with provided attributes, if any
@@ -210,6 +225,14 @@ void *_gnix_ht_lookup(gnix_hashtable_t *ht, gnix_ht_key_t key);
  * @return        true if the hash table is empty, false if not
  */
 int _gnix_ht_empty(gnix_hashtable_t *ht);
+
+/**
+ * Return next element in the hashtable
+ *
+ * @param iter    pointer to the hashtable iterator
+ * @return        pointer to next element in the hashtable
+ */
+void *_gnix_ht_iterator_next(struct gnix_hashtable_iter *iter);
 
 /* Hastable iteration macros */
 #define ht_lf_for_each(ht, ht_entry)				\

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -158,8 +158,12 @@ struct gnix_nic {
 	struct dlist_entry tx_desc_free_list;
 	struct gnix_tx_descriptor *tx_desc_base;
 	atomic_t outstanding_fab_reqs_nic;
-	fastlock_t pending_vc_lock;
-	struct dlist_entry pending_vcs;
+	fastlock_t rx_vc_lock;
+	struct dlist_entry rx_vcs;
+	fastlock_t work_vc_lock;
+	struct dlist_entry work_vcs;
+	fastlock_t tx_vc_lock;
+	struct dlist_entry tx_vcs;
 	uint8_t ptag;
 	uint32_t cookie;
 	uint32_t device_id;

--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -83,12 +83,13 @@ enum gnix_vc_conn_req_type {
 /**
  * Virual Connection (VC) struct
  *
- * @var rx_queue             List of VCs scheduled for RX processing.
- * @var rx_queue_lock        Lock for serializing access to the VC's rx_queue
- * @var work_queue           List of VCs scheduled for deferred work processing.
- * @var work_queue_lock      Lock for serializing access to VC's work_queue
- * @var tx_queue             List of VCs scheduled for TX processing.
- * @var tx_queue_lock        Lock for serializing access to the VC's tx_queue
+ * @var rx_list              NIC RX VC list
+ * @var work_queue           Deferred work request queue
+ * @var work_queue_lock      Deferred work request queue lock
+ * @var work_list            NIC work VC list
+ * @var tx_queue             TX request queue
+ * @var tx_queue_lock        TX request queue lock
+ * @var tx_list              NIC TX VC list
  * @var entry                used internally for managing linked lists
  *                           of vc structs that require O(1) insertion/removal
  * @var peer_addr            address of peer with which this VC is connected

--- a/prov/gni/src/gnix_atomic.c
+++ b/prov/gni/src/gnix_atomic.c
@@ -121,12 +121,10 @@ static void __gnix_amo_fr_complete(struct gnix_fab_req *req,
 	}
 
 	atomic_dec(&req->vc->outstanding_tx_reqs);
-
 	_gnix_nic_tx_free(req->vc->ep->nic, txd);
 
-	/* We could have requests waiting for TXDs or FI_FENCE operations.
-	 * Schedule this VC to push any such requests. */
-	_gnix_vc_schedule_reqs(req->vc);
+	/* Schedule VC TX queue in case the VC is 'fenced'. */
+	_gnix_vc_tx_schedule(req->vc);
 
 	_gnix_fr_free(req->vc->ep, req);
 }
@@ -140,7 +138,7 @@ static int __gnix_amo_post_err(struct gnix_tx_descriptor *txd)
 	if (req->tx_failures < req->gnix_ep->domain->params.max_retransmits) {
 		GNIX_INFO(FI_LOG_EP_DATA,
 			  "Requeueing failed request: %p\n", req);
-		return _gnix_vc_queue_req(req);
+		return _gnix_vc_queue_work_req(req);
 	}
 
 	GNIX_INFO(FI_LOG_EP_DATA, "Failed %d transmits: %p\n",
@@ -196,7 +194,7 @@ static int __gnix_amo_send_data_req(void *arg)
 			GNIX_INFO(FI_LOG_EP_DATA,
 				  "_gnix_nic_tx_alloc() failed: %d\n",
 				  rc);
-			return -FI_EAGAIN;
+			return -FI_ENOSPC;
 		}
 		req->txd = txd;
 	}
@@ -281,8 +279,8 @@ static int __gnix_amo_txd_complete(void *arg, gni_return_t tx_status)
 		/* initiate immediate data transfer */
 		req->tx_failures = 0;
 		req->txd = (void *)txd;
-		req->send_fn = __gnix_amo_send_data_req;
-		_gnix_vc_queue_req(req);
+		req->work_fn = __gnix_amo_send_data_req;
+		_gnix_vc_queue_work_req(req);
 	} else {
 		/* complete request */
 		rc = __gnix_amo_send_completion(req->vc->ep, req);
@@ -387,7 +385,7 @@ int _gnix_amo_post_req(void *data)
 	if (rc) {
 		GNIX_INFO(FI_LOG_EP_DATA, "_gnix_nic_tx_alloc() failed: %d\n",
 			 rc);
-		return -FI_EAGAIN;
+		return -FI_ENOSPC;
 	}
 
 	txd->completer_fn = __gnix_amo_txd_complete;
@@ -530,7 +528,7 @@ ssize_t _gnix_atomic(struct gnix_fid_ep *ep,
 	req->gnix_ep = ep;
 	req->vc = vc;
 	req->user_context = msg->context;
-	req->send_fn = _gnix_amo_post_req;
+	req->work_fn = _gnix_amo_post_req;
 
 	if (mdesc) {
 		md = container_of(mdesc, struct gnix_fid_mem_desc, mr_fid);

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -1343,6 +1343,7 @@ err:
 
 }
 
+#if 0
 static int __match_context(struct slist_entry *item, const void *arg)
 {
 	struct gnix_fab_req *req;
@@ -1351,12 +1352,14 @@ static int __match_context(struct slist_entry *item, const void *arg)
 
 	return req->user_context == arg;
 }
+#endif
 
 static inline struct gnix_fab_req *__find_tx_req(
 		struct gnix_fid_ep *ep,
 		void *context)
 {
 	struct gnix_fab_req *req = NULL;
+#if 0
 	struct slist_entry *entry;
 	struct gnix_vc *vc;
 
@@ -1368,12 +1371,12 @@ static inline struct gnix_fab_req *__find_tx_req(
 		entry = slist_remove_first_match(&vc->tx_queue,
 				__match_context, context);
 		fastlock_release(&vc->tx_queue_lock);
-		_gnix_vc_schedule(vc);
 		if (entry) {
 			req = container_of(entry, struct gnix_fab_req, slist);
 			break;
 		}
 	}
+#endif
 
 	return req;
 }

--- a/prov/gni/src/gnix_hashtable.c
+++ b/prov/gni/src/gnix_hashtable.c
@@ -726,6 +726,102 @@ int _gnix_ht_empty(gnix_hashtable_t *ht)
 	return atomic_get(&ht->ht_elements) == 0;
 }
 
+void *__gnix_ht_lf_iter_next(struct gnix_hashtable_iter *iter)
+{
+	gnix_ht_entry_t *ht_entry;
+	struct dlist_entry *head, *next;
+	int i;
+
+	/* take next entry in bin */
+	if (iter->cur_entry) {
+		head = &iter->ht->ht_lf_tbl[iter->cur_idx].head;
+		next = iter->cur_entry->next;
+		if (next != head) {
+			iter->cur_entry = next;
+			ht_entry = dlist_entry(next, gnix_ht_entry_t, entry);
+			return ht_entry->value;
+		}
+		iter->cur_idx++;
+	}
+
+	/* look for next bin with an entry */
+	for (i = iter->cur_idx; i < iter->ht->ht_size; i++) {
+		head = &iter->ht->ht_lf_tbl[i].head;
+		if (dlist_empty(head))
+			continue;
+
+		ht_entry = dlist_first_entry(head, gnix_ht_entry_t, entry);
+		iter->cur_idx = i;
+		iter->cur_entry = &ht_entry->entry;
+		return ht_entry->value;
+	}
+
+	return NULL;
+}
+
+void *__gnix_ht_lk_iter_next(struct gnix_hashtable_iter *iter)
+{
+	gnix_ht_lk_lh_t *lh;
+	gnix_ht_entry_t *ht_entry;
+	struct dlist_entry *head, *next;
+	int i;
+	void *value;
+
+	rwlock_rdlock(&iter->ht->ht_lock);
+
+	/* take next entry in bin */
+	if (iter->cur_entry) {
+		lh = &iter->ht->ht_lk_tbl[iter->cur_idx];
+
+		rwlock_rdlock(&lh->lh_lock);
+		head = &lh->head;
+		next = iter->cur_entry->next;
+		if (next != head) {
+			iter->cur_entry = next;
+			ht_entry = dlist_entry(next, gnix_ht_entry_t, entry);
+			value = ht_entry->value;
+			rwlock_unlock(&lh->lh_lock);
+
+			rwlock_unlock(&iter->ht->ht_lock);
+			return value;
+		}
+		rwlock_unlock(&lh->lh_lock);
+
+		iter->cur_idx++;
+	}
+
+	/* look for next bin with an entry */
+	for (i = iter->cur_idx; i < iter->ht->ht_size; i++) {
+		lh = &iter->ht->ht_lk_tbl[i];
+
+		rwlock_rdlock(&lh->lh_lock);
+		head = &lh->head;
+		if (dlist_empty(head)) {
+			rwlock_unlock(&lh->lh_lock);
+			continue;
+		}
+
+		ht_entry = dlist_first_entry(head, gnix_ht_entry_t, entry);
+		value = ht_entry->value;
+		rwlock_unlock(&lh->lh_lock);
+
+		iter->cur_idx = i;
+		iter->cur_entry = &ht_entry->entry;
+
+		rwlock_unlock(&iter->ht->ht_lock);
+		return value;
+	}
+
+	rwlock_unlock(&iter->ht->ht_lock);
+
+	return NULL;
+}
+
+void *_gnix_ht_iterator_next(struct gnix_hashtable_iter *iter)
+{
+	return iter->ht->ht_ops->iter_next(iter);
+}
+
 static gnix_hashtable_ops_t __gnix_lockless_ht_ops = {
 		.init          = __gnix_ht_lf_init,
 		.destroy       = __gnix_ht_lf_destroy,
@@ -733,7 +829,8 @@ static gnix_hashtable_ops_t __gnix_lockless_ht_ops = {
 		.remove        = __gnix_ht_lf_remove,
 		.lookup        = __gnix_ht_lf_lookup,
 		.resize        = __gnix_ht_lf_resize,
-		.retrieve_list = __gnix_ht_lf_retrieve_list
+		.retrieve_list = __gnix_ht_lf_retrieve_list,
+		.iter_next     = __gnix_ht_lf_iter_next
 };
 
 static gnix_hashtable_ops_t __gnix_locked_ht_ops = {
@@ -743,5 +840,6 @@ static gnix_hashtable_ops_t __gnix_locked_ht_ops = {
 		.remove        = __gnix_ht_lk_remove,
 		.lookup        = __gnix_ht_lk_lookup,
 		.resize        = __gnix_ht_lk_resize,
-		.retrieve_list = __gnix_ht_lk_retrieve_list
+		.retrieve_list = __gnix_ht_lk_retrieve_list,
+		.iter_next     = __gnix_ht_lk_iter_next
 };

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -233,6 +233,8 @@ static int __gnix_rndzv_req_send_fin(void *arg)
 	gni_return_t status;
 	int rc;
 
+	GNIX_TRACE(FI_LOG_EP_DATA, "\n");
+
 	ep = req->gnix_ep;
 	assert(ep != NULL);
 

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -69,16 +69,14 @@ static void __gnix_msg_queues(struct gnix_fid_ep *ep,
 	}
 }
 
-static void __gnix_msg_fr_complete(struct gnix_fab_req *req,
-				   struct gnix_tx_descriptor *txd)
+static void __gnix_msg_send_fr_complete(struct gnix_fab_req *req,
+					struct gnix_tx_descriptor *txd)
 {
 	atomic_dec(&req->vc->outstanding_tx_reqs);
-
 	_gnix_nic_tx_free(req->gnix_ep->nic, txd);
 
-	/* We could have requests waiting for TXDs or FI_FENCE operations.
-	 * Schedule this VC to push any such requests. */
-	_gnix_vc_schedule_reqs(req->vc);
+	/* Schedule VC TX queue in case the VC is 'fenced'. */
+	_gnix_vc_tx_schedule(req->vc);
 
 	_gnix_fr_free(req->gnix_ep, req);
 }
@@ -206,7 +204,7 @@ static int __gnix_send_smsg_err(struct gnix_tx_descriptor *txd)
 			  "__gnix_send_err() failed: %d\n",
 			  rc);
 
-	__gnix_msg_fr_complete(req, txd);
+	__gnix_msg_send_fr_complete(req, txd);
 	return FI_SUCCESS;
 }
 
@@ -218,7 +216,7 @@ static int __gnix_send_post_err(struct gnix_tx_descriptor *txd)
 	if (req->tx_failures < req->gnix_ep->domain->params.max_retransmits) {
 		GNIX_INFO(FI_LOG_EP_DATA,
 			  "Requeueing failed request: %p\n", req);
-		return _gnix_vc_queue_req(req);
+		return _gnix_vc_queue_work_req(req);
 	}
 
 	/* TODO should this be fatal? A request will sit waiting at the
@@ -248,7 +246,7 @@ static int __gnix_rndzv_req_send_fin(void *arg)
 			GNIX_INFO(FI_LOG_EP_DATA,
 				  "_gnix_nic_tx_alloc() failed: %d\n",
 				  rc);
-			return -FI_EAGAIN;
+			return -FI_ENOSPC;
 		}
 		req->txd = txd;
 	}
@@ -302,9 +300,9 @@ static int __gnix_rndzv_req_complete(void *arg, gni_return_t tx_status)
 	}
 
 	req->txd = txd;
-	req->send_fn = __gnix_rndzv_req_send_fin;
+	req->work_fn = __gnix_rndzv_req_send_fin;
 
-	ret = _gnix_vc_queue_req(req);
+	ret = _gnix_vc_queue_work_req(req);
 
 	return ret;
 }
@@ -341,7 +339,7 @@ static int __gnix_rndzv_req(void *arg)
 	if (rc) {
 		GNIX_INFO(FI_LOG_EP_DATA, "_gnix_nic_tx_alloc() failed: %d\n",
 			 rc);
-		return -FI_EAGAIN;
+		return -FI_ENOSPC;
 	}
 
 	txd->completer_fn = __gnix_rndzv_req_complete;
@@ -399,7 +397,7 @@ static int __comp_eager_msg_w_data(void *data, gni_return_t tx_status)
 			  "__gnix_send_completion() failed: %d\n",
 			  ret);
 
-	__gnix_msg_fr_complete(req, tdesc);
+	__gnix_msg_send_fr_complete(req, tdesc);
 
 	return FI_SUCCESS;
 }
@@ -458,10 +456,6 @@ static int __comp_rndzv_start(void *data, gni_return_t tx_status)
 	 * buffer. */
 	_gnix_nic_tx_free(txd->req->gnix_ep->nic, txd);
 
-	/* We could have requests waiting for TXDs.  Schedule this VC to push
-	 * any such requests. */
-	_gnix_vc_schedule_reqs(txd->req->vc);
-
 	GNIX_INFO(FI_LOG_EP_DATA, "Completed RNDZV_START, req: %p\n", txd->req);
 
 	return FI_SUCCESS;
@@ -478,18 +472,25 @@ static int __comp_rndzv_fin(void *data, gni_return_t tx_status)
 	if (tx_status != GNI_RC_SUCCESS) {
 		/* TODO should this be fatal? A request will sit waiting at the
 		 * peer. */
-		return __gnix_send_smsg_err(tdesc);
+		GNIX_WARN(FI_LOG_EP_DATA, "Failed transaction: %p\n", req);
+		ret = __gnix_send_err(req->gnix_ep, req);
+		if (ret != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_EP_DATA,
+					"__gnix_send_err() failed: %d\n",
+					ret);
+	} else {
+		GNIX_INFO(FI_LOG_EP_DATA, "Completed RNDZV_FIN, req: %p\n",
+			  req);
+
+		ret = __gnix_recv_completion(req->gnix_ep, req);
+		if (ret != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_EP_DATA,
+				  "__gnix_recv_completion() failed: %d\n",
+				  ret);
 	}
 
-	GNIX_INFO(FI_LOG_EP_DATA, "Completed RNDZV_FIN, req: %p\n", req);
-
-	ret = __gnix_recv_completion(req->gnix_ep, req);
-	if (ret != FI_SUCCESS)
-		GNIX_WARN(FI_LOG_EP_DATA,
-			  "__gnix_recv_completion() failed: %d\n",
-			  ret);
-
-	__gnix_msg_fr_complete(req, tdesc);
+	_gnix_nic_tx_free(req->gnix_ep->nic, tdesc);
+	_gnix_fr_free(req->gnix_ep, req);
 
 	return FI_SUCCESS;
 }
@@ -577,7 +578,7 @@ static int __smsg_eager_msg_w_data(void *data, void *msg)
 		if (unlikely(req->msg.recv_addr == 0ULL)) {
 			fastlock_release(queue_lock);
 			_gnix_fr_free(ep, req);
-			return -FI_EAGAIN;
+			return -FI_ENOMEM;
 		}
 
 		GNIX_INFO(FI_LOG_EP_DATA, "New req: %p\n",
@@ -710,11 +711,9 @@ static int __smsg_rndzv_start(void *data, void *msg)
 		req->msg.rma_mdh = hdr->mdh;
 		req->msg.rma_id = hdr->req_addr;
 
-		/* Initiate pull of source data.  We already hold the NIC lock
-		 * here in the SMSG RX callback.  Force this operation to be
-		 * queued to avoid locking issues. */
-		req->send_fn = __gnix_rndzv_req;
-		ret = _gnix_vc_force_queue_req(req);
+		/* Queue request to initiate pull of source data. */
+		req->work_fn = __gnix_rndzv_req;
+		ret = _gnix_vc_queue_work_req(req);
 	} else {
 		/* Add new unexpected receive request. */
 		req = _gnix_fr_alloc(ep);
@@ -794,16 +793,13 @@ static int __smsg_rndzv_fin(void *data, void *msg)
 
 	atomic_dec(&req->vc->outstanding_tx_reqs);
 
-	/* We could have requests waiting for TXDs or FI_FENCE operations.
-	 * Schedule this VC to push any such requests. */
-	_gnix_vc_schedule_reqs(req->vc);
+	/* Schedule VC TX queue in case the VC is 'fenced'. */
+	_gnix_vc_tx_schedule(req->vc);
 
 	if (req->msg.send_flags & FI_LOCAL_MR) {
-		/* We cannot close the auto-MR here in the SMSG RX completer,
-		 * with the NIC lock held.  Queue the request to be freed
-		 * immediately after SMSG processing */
-		req->send_fn = __gnix_rndzv_fin_cleanup;
-		ret = _gnix_vc_force_queue_req(req);
+		/* Defer freeing the MR and request. */
+		req->work_fn = __gnix_rndzv_fin_cleanup;
+		ret = _gnix_vc_queue_work_req(req);
 	} else {
 		_gnix_fr_free(ep, req);
 	}
@@ -942,8 +938,8 @@ static int  __gnix_discard_request(struct gnix_fid_ep *ep,
 
 		/* Complete rendezvous request, skipping data transfer. */
 		req->txd = NULL;
-		req->send_fn = __gnix_rndzv_req_send_fin;
-		ret = _gnix_vc_queue_req(req);
+		req->work_fn = __gnix_rndzv_req_send_fin;
+		ret = _gnix_vc_queue_work_req(req);
 	} else {
 		/* data has already been delivered, so just discard it and
 		 * generate cqe
@@ -1082,8 +1078,8 @@ ssize_t _gnix_recv(struct gnix_fid_ep *ep, uint64_t buf, size_t len,
 			}
 
 			/* Initiate pull of source data. */
-			req->send_fn = __gnix_rndzv_req;
-			ret = _gnix_vc_queue_req(req);
+			req->work_fn = __gnix_rndzv_req;
+			ret = _gnix_vc_queue_work_req(req);
 		} else {
 			/* Matched eager request.  Copy data and generate
 			 * completions. */
@@ -1200,7 +1196,7 @@ static int _gnix_send_req(void *arg)
 	if (rc != FI_SUCCESS) {
 		GNIX_INFO(FI_LOG_EP_DATA, "_gnix_nic_tx_alloc() failed: %d\n",
 			  rc);
-		return -FI_EAGAIN;
+		return -FI_ENOSPC;
 	}
 	assert(rc == FI_SUCCESS);
 
@@ -1317,7 +1313,7 @@ ssize_t _gnix_send(struct gnix_fid_ep *ep, uint64_t loc_addr, size_t len,
 	req->gnix_ep = ep;
 	req->vc = vc;
 	req->user_context = context;
-	req->send_fn = _gnix_send_req;
+	req->work_fn = _gnix_send_req;
 
 	if (flags & FI_TAGGED) {
 		req->msg.tag = tag;

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -131,7 +131,7 @@ static int process_rx_cqe(struct gnix_nic *nic, gni_cq_entry_t cqe)
 	vc_id =  GNI_CQ_GET_INST_ID(cqe);
 	vc = __gnix_nic_elem_by_rem_id(nic, vc_id);
 
-#if 1 /* Process RX inline with arrival of an RX CQE. */
+#if 0 /* Process RX inline with arrival of an RX CQE. */
 	if (unlikely(vc->conn_state != GNIX_VC_CONNECTED)) {
 		GNIX_INFO(FI_LOG_EP_DATA,
 			  "Scheduling VC for RX processing (%p)\n",
@@ -149,6 +149,9 @@ static int process_rx_cqe(struct gnix_nic *nic, gni_cq_entry_t cqe)
 					"_gnix_vc_dqueue_smsg returned %d\n",
 					ret);
 		}
+
+		/* The RX CQE could be associated with an SMSG credit return.
+		 * Schedule the VC just in case. */
 		ret = _gnix_vc_schedule(vc);
 		assert(ret == FI_SUCCESS);
 	}

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -108,9 +108,6 @@ static int __nic_rx_overrun(struct gnix_nic *nic)
 		ret = _gnix_test_bit(&nic->vc_id_bitmap, i);
 		if (ret) {
 			vc = __gnix_nic_elem_by_rem_id(nic, i);
-			if (unlikely(vc->conn_state != GNIX_VC_CONNECTED))
-				_gnix_set_bit(&vc->flags,
-					      GNIX_VC_FLAG_RX_PENDING);
 			ret = _gnix_vc_dequeue_smsg(vc);
 			if (ret != FI_SUCCESS) {
 				GNIX_WARN(FI_LOG_EP_DATA,
@@ -131,13 +128,12 @@ static int process_rx_cqe(struct gnix_nic *nic, gni_cq_entry_t cqe)
 	vc_id =  GNI_CQ_GET_INST_ID(cqe);
 	vc = __gnix_nic_elem_by_rem_id(nic, vc_id);
 
-#if 0 /* Process RX inline with arrival of an RX CQE. */
+#if 1 /* Process RX inline with arrival of an RX CQE. */
 	if (unlikely(vc->conn_state != GNIX_VC_CONNECTED)) {
 		GNIX_INFO(FI_LOG_EP_DATA,
 			  "Scheduling VC for RX processing (%p)\n",
 			  vc);
-		_gnix_set_bit(&vc->flags, GNIX_VC_FLAG_RX_PENDING);
-		ret = _gnix_vc_schedule(vc);
+		ret = _gnix_vc_rx_schedule(vc);
 		assert(ret == FI_SUCCESS);
 	} else {
 		GNIX_INFO(FI_LOG_EP_DATA,
@@ -149,15 +145,9 @@ static int process_rx_cqe(struct gnix_nic *nic, gni_cq_entry_t cqe)
 					"_gnix_vc_dqueue_smsg returned %d\n",
 					ret);
 		}
-
-		/* The RX CQE could be associated with an SMSG credit return.
-		 * Schedule the VC just in case. */
-		ret = _gnix_vc_schedule(vc);
-		assert(ret == FI_SUCCESS);
 	}
 #else /* Defer RX processing until after the RX CQ is cleared. */
-	_gnix_set_bit(&vc->flags, GNIX_VC_FLAG_RX_PENDING);
-	ret = _gnix_vc_schedule(vc);
+	ret = _gnix_vc_rx_schedule(vc);
 	assert(ret == FI_SUCCESS);
 #endif
 
@@ -329,24 +319,6 @@ static int __nic_tx_progress(struct gnix_nic *nic)
 	return ret;
 }
 
-int __nic_vc_progress(struct gnix_nic *nic)
-{
-	struct gnix_vc *vc;
-	int ret;
-
-	while ((vc = _gnix_nic_next_pending_vc(nic))) {
-		ret = _gnix_vc_progress(vc);
-		if (ret != FI_SUCCESS) {
-			GNIX_INFO(FI_LOG_EP_DATA,
-				  "Rescheduling VC (%p)\n", vc);
-			ret = _gnix_vc_schedule(vc);
-			assert(ret == FI_SUCCESS);
-		}
-	}
-
-	return FI_SUCCESS;
-}
-
 int _gnix_nic_progress(struct gnix_nic *nic)
 {
 	int ret = FI_SUCCESS;
@@ -359,7 +331,7 @@ int _gnix_nic_progress(struct gnix_nic *nic)
 	if (unlikely(ret != FI_SUCCESS))
 		return ret;
 
-	ret = __nic_vc_progress(nic);
+	ret = _gnix_nic_vc_progress(nic);
 	if (unlikely(ret != FI_SUCCESS))
 		return ret;
 
@@ -843,8 +815,12 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 		if (ret != FI_SUCCESS)
 			goto err1;
 
-		fastlock_init(&nic->pending_vc_lock);
-		dlist_init(&nic->pending_vcs);
+		fastlock_init(&nic->rx_vc_lock);
+		dlist_init(&nic->rx_vcs);
+		fastlock_init(&nic->work_vc_lock);
+		dlist_init(&nic->work_vcs);
+		fastlock_init(&nic->tx_vc_lock);
+		dlist_init(&nic->tx_vcs);
 
 		_gnix_ref_init(&nic->ref_cnt, 1, __nic_destruct);
 		atomic_initialize(&nic->outstanding_fab_reqs_nic, 0);

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -564,7 +564,7 @@ static int __gnix_vc_hndl_conn_resp(struct gnix_cm_nic *cm_nic,
 		ret = _gnix_nic_progress(ep->nic);
 	else
 		GNIX_WARN(FI_LOG_EP_CTRL,
-			"__gnix_vc_schedule returned %s\n",
+			"_gnix_vc_schedule returned %s\n",
 			fi_strerror(-ret));
 
 	return ret;
@@ -761,7 +761,7 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 			ret = _gnix_nic_progress(ep->nic);
 		else
 			GNIX_WARN(FI_LOG_EP_CTRL,
-				"__gnix_vc_schedule returned %s\n",
+				"_gnix_vc_schedule returned %s\n",
 				fi_strerror(-ret));
 	}
 err:
@@ -1107,12 +1107,13 @@ int _gnix_vc_alloc(struct gnix_fid_ep *ep_priv,
 		vc_ptr->peer_cm_nic_addr.cdm_id = -1;
 	}
 	vc_ptr->ep = ep_priv;
+
+	slist_init(&vc_ptr->work_queue);
+	fastlock_init(&vc_ptr->work_queue_lock);
 	slist_init(&vc_ptr->tx_queue);
 	fastlock_init(&vc_ptr->tx_queue_lock);
+
 	atomic_initialize(&vc_ptr->outstanding_tx_reqs, 0);
-	slist_init(&vc_ptr->req_queue);
-	fastlock_init(&vc_ptr->req_queue_lock);
-	atomic_initialize(&vc_ptr->outstanding_reqs, 0);
 	ret = _gnix_alloc_bitmap(&vc_ptr->flags, 1);
 	assert(!ret);
 
@@ -1159,6 +1160,7 @@ int _gnix_vc_destroy(struct gnix_vc *vc)
 	 * if the vc is in a nic's work queue, remove it
 	 */
 
+#if 0
 	if (_gnix_test_and_clear_bit(&vc->flags, GNIX_VC_FLAG_SCHEDULED)) {
 		fastlock_acquire(&nic->pending_vc_lock);
 		dlist_remove(&vc->pending_list);
@@ -1166,6 +1168,7 @@ int _gnix_vc_destroy(struct gnix_vc *vc)
 		GNIX_INFO(FI_LOG_EP_CTRL, "Removed VC (%p) from pending_list\n",
 			  vc);
 	}
+#endif
 
 
 	/*
@@ -1326,51 +1329,49 @@ int _gnix_vc_disconnect(struct gnix_vc *vc)
 	return FI_SUCCESS;
 }
 
-int _gnix_vc_schedule(struct gnix_vc *vc)
+/* Return 0 if VC is connected.  Progress VC CM if not. */
+static int __gnix_vc_connected(struct gnix_vc *vc)
+{
+	struct gnix_cm_nic *cm_nic;
+	int ret;
+
+	if (unlikely(vc->conn_state < GNIX_VC_CONNECTED)) {
+		cm_nic = vc->ep->cm_nic;
+		ret = _gnix_cm_nic_progress(cm_nic);
+		if ((ret != FI_SUCCESS) && (ret != -FI_EAGAIN))
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "_gnix_cm_nic_progress() failed: %s\n",
+				   fi_strerror(-ret));
+		/* waiting to connect, check back later */
+		return -FI_EAGAIN;
+	}
+
+	return 0;
+}
+
+
+/******************************************************************************
+ *
+ * VC RX progress
+ *
+ *****************************************************************************/
+
+/* Schedule the VC for RX progress. */
+int _gnix_vc_rx_schedule(struct gnix_vc *vc)
 {
 	struct gnix_nic *nic = vc->ep->nic;
 
-	if (!_gnix_test_and_set_bit(&vc->flags, GNIX_VC_FLAG_SCHEDULED)) {
-		fastlock_acquire(&nic->pending_vc_lock);
-		dlist_insert_tail(&vc->pending_list, &nic->pending_vcs);
-		fastlock_release(&nic->pending_vc_lock);
-		GNIX_INFO(FI_LOG_EP_CTRL, "Scheduled VC (%p)\n", vc);
+	if (!_gnix_test_and_set_bit(&vc->flags, GNIX_VC_FLAG_RX_SCHEDULED)) {
+		fastlock_acquire(&nic->rx_vc_lock);
+		dlist_insert_tail(&vc->rx_list, &nic->rx_vcs);
+		fastlock_release(&nic->rx_vc_lock);
+		GNIX_INFO(FI_LOG_EP_CTRL, "Scheduled RX VC (%p)\n", vc);
 	}
 
 	return FI_SUCCESS;
 }
 
-int _gnix_vc_schedule_reqs(struct gnix_vc *vc)
-{
-	int ret __attribute__((unused));
-
-	if (!slist_empty(&vc->tx_queue) || !slist_empty(&vc->req_queue)) {
-		ret = _gnix_vc_schedule(vc);
-		assert(ret == FI_SUCCESS);
-	}
-
-	return FI_SUCCESS;
-}
-
-struct gnix_vc *_gnix_nic_next_pending_vc(struct gnix_nic *nic)
-{
-	struct gnix_vc *vc = NULL;
-
-	fastlock_acquire(&nic->pending_vc_lock);
-	vc = dlist_first_entry(&nic->pending_vcs, struct gnix_vc,
-				  pending_list);
-	if (vc)
-		dlist_remove(&vc->pending_list);
-	fastlock_release(&nic->pending_vc_lock);
-
-	if (vc) {
-		GNIX_INFO(FI_LOG_EP_CTRL, "Dequeued VC (%p)\n", vc);
-		_gnix_clear_bit(&vc->flags, GNIX_VC_FLAG_SCHEDULED);
-	}
-
-	return vc;
-}
-
+/* Process a VC's SMSG mailbox. */
 int _gnix_vc_dequeue_smsg(struct gnix_vc *vc)
 {
 	int ret = FI_SUCCESS;
@@ -1396,26 +1397,256 @@ int _gnix_vc_dequeue_smsg(struct gnix_vc *vc)
 		if (status == GNI_RC_SUCCESS) {
 			GNIX_INFO(FI_LOG_EP_DATA, "Found RX (%p)\n", vc);
 			ret = nic->smsg_callbacks[tag](vc, msg_ptr);
-			assert(ret == FI_SUCCESS);
+			if (ret != FI_SUCCESS) {
+				/* Stalled, reschedule */
+				break;
+			}
 		} else if (status == GNI_RC_NOT_DONE) {
+			/* No more work. */
+			ret = FI_SUCCESS;
 			break;
 		} else {
 			GNIX_WARN(FI_LOG_EP_DATA,
 				"GNI_SmsgGetNextWTag returned %s\n",
 				gni_err_str[status]);
 			ret = gnixu_to_fi_errno(status);
-			assert(0);
 			break;
 		}
-	} while (status != GNI_RC_NOT_DONE);
+	} while (1);
 
 	return ret;
 }
 
+/* Progress VC RXs.  Reschedule VC if more there is more work. */
+static int __gnix_vc_rx_progress(struct gnix_vc *vc)
+{
+	int ret;
+
+	ret = __gnix_vc_connected(vc);
+	if (ret) {
+		/* The CM will schedule the VC when the connection is complete.
+		 * Return success to allow continued VC RX processing. */
+		_gnix_vc_rx_schedule(vc);
+		return FI_SUCCESS;
+	}
+
+	/* Process pending RXs */
+	fastlock_acquire(&vc->ep->nic->lock);
+	ret = _gnix_vc_dequeue_smsg(vc);
+	fastlock_release(&vc->ep->nic->lock);
+
+	if (ret != FI_SUCCESS) {
+		/* We didn't finish processing RXs.  Low memory likely.
+		 * Try again later.  Return error to abort processing
+		 * other VCs. */
+		_gnix_vc_rx_schedule(vc);
+		return -FI_EAGAIN;
+	}
+
+	/* Return success to continue processing other VCs */
+	return FI_SUCCESS;
+}
+
+static struct gnix_vc *__gnix_nic_next_pending_rx_vc(struct gnix_nic *nic)
+{
+	struct gnix_vc *vc = NULL;
+
+	fastlock_acquire(&nic->rx_vc_lock);
+	vc = dlist_first_entry(&nic->rx_vcs, struct gnix_vc, rx_list);
+	if (vc)
+		dlist_remove(&vc->rx_list);
+	fastlock_release(&nic->rx_vc_lock);
+
+	if (vc) {
+		GNIX_INFO(FI_LOG_EP_CTRL, "Dequeued RX VC (%p)\n", vc);
+		_gnix_clear_bit(&vc->flags, GNIX_VC_FLAG_RX_SCHEDULED);
+	}
+
+	return vc;
+}
+
+/* Progress VC RXs.  Exit when all VCs are empty or if an error is encountered
+ * during progress.  Failure to process an RX on any VC likely indicates an
+ * inability to progress other VCs (due to low memory). */
+static int __gnix_nic_vc_rx_progress(struct gnix_nic *nic)
+{
+	struct gnix_vc *vc;
+	int ret;
+
+	while ((vc = __gnix_nic_next_pending_rx_vc(nic))) {
+		ret = __gnix_vc_rx_progress(vc);
+		if (ret != FI_SUCCESS)
+			break;
+	}
+
+	return FI_SUCCESS;
+}
+
+
+/******************************************************************************
+ *
+ * VC work progress
+ *
+ *****************************************************************************/
+
+/* Schedule the VC for work progress. */
+static int __gnix_vc_work_schedule(struct gnix_vc *vc)
+{
+	struct gnix_nic *nic = vc->ep->nic;
+
+	/* Don't bother scheduling if there's no work to do. */
+	if (slist_empty(&vc->work_queue))
+		return FI_SUCCESS;
+
+	if (!_gnix_test_and_set_bit(&vc->flags, GNIX_VC_FLAG_WORK_SCHEDULED)) {
+		fastlock_acquire(&nic->work_vc_lock);
+		dlist_insert_tail(&vc->work_list, &nic->work_vcs);
+		fastlock_release(&nic->work_vc_lock);
+		GNIX_INFO(FI_LOG_EP_CTRL, "Scheduled work VC (%p)\n", vc);
+	}
+
+	return FI_SUCCESS;
+}
+
+/* Schedule deferred request processing.  Usually used in RX completers. */
+int _gnix_vc_queue_work_req(struct gnix_fab_req *req)
+{
+	struct gnix_vc *vc = req->vc;
+
+	fastlock_acquire(&vc->work_queue_lock);
+	slist_insert_tail(&req->slist, &vc->work_queue);
+	__gnix_vc_work_schedule(vc);
+	fastlock_release(&vc->work_queue_lock);
+
+	return FI_SUCCESS;
+}
+
+/* Process deferred request work on the VC. */
+static int __gnix_vc_push_work_reqs(struct gnix_vc *vc)
+{
+	int ret, fi_rc = FI_SUCCESS;
+	struct slist *list;
+	struct slist_entry *item;
+	struct gnix_fab_req *req;
+
+	fastlock_acquire(&vc->work_queue_lock);
+
+	list = &vc->work_queue;
+	item = list->head;
+	while (item != NULL) {
+		req = (struct gnix_fab_req *)container_of(item,
+							  struct gnix_fab_req,
+							  slist);
+		ret = req->work_fn(req);
+		if (ret == FI_SUCCESS) {
+			GNIX_INFO(FI_LOG_EP_DATA,
+				  "Request processed: %p\n", req);
+		} else {
+			/* Work failed.  Reschedule to put this VC back on the
+			 * end of the list. */
+			__gnix_vc_work_schedule(vc);
+
+			/* FI_ENOSPC is reserved to indicate a lack of TXDs,
+			 * which are shared by all VCs on the NIC.  Return
+			 * error to stall processing of VCs in this case.  The
+			 * other likely error is a lack of SMSG credits, which
+			 * only halts this VC. */
+			if (ret == -FI_ENOSPC) {
+				fi_rc = -FI_EAGAIN;
+			} else if (ret != -FI_EAGAIN) {
+				/* TODO report error? */
+				GNIX_WARN(FI_LOG_EP_DATA,
+					  "Failed to push request %p: %s\n",
+					  req, fi_strerror(-ret));
+			} /* else return success to keep processing TX VCs */
+			break;
+		}
+
+		slist_remove_head(&vc->work_queue);
+		item = list->head;
+	}
+
+	fastlock_release(&vc->work_queue_lock);
+
+	return fi_rc;
+}
+
+static struct gnix_vc *__gnix_nic_next_pending_work_vc(struct gnix_nic *nic)
+{
+	struct gnix_vc *vc = NULL;
+
+	fastlock_acquire(&nic->work_vc_lock);
+	vc = dlist_first_entry(&nic->work_vcs, struct gnix_vc, work_list);
+	if (vc)
+		dlist_remove(&vc->work_list);
+	fastlock_release(&nic->work_vc_lock);
+
+	if (vc) {
+		GNIX_INFO(FI_LOG_EP_CTRL, "Dequeued work VC (%p)\n", vc);
+		_gnix_clear_bit(&vc->flags, GNIX_VC_FLAG_WORK_SCHEDULED);
+	}
+
+	return vc;
+}
+
+/* Progress VCs with deferred request work. */
+static int __gnix_nic_vc_work_progress(struct gnix_nic *nic)
+{
+	int ret;
+	struct gnix_vc *first_vc = NULL, *vc;
+
+	while ((vc = __gnix_nic_next_pending_work_vc(nic))) {
+		ret = __gnix_vc_push_work_reqs(vc);
+		if (ret != FI_SUCCESS)
+			break;
+
+		if (!first_vc) {
+			/* Record first VC processed. */
+			first_vc = vc;
+		} else if (vc == first_vc) {
+			/* VCs can self reschedule or be rescheduled in other
+			 * threads.  Exit if we loop back to the first VC. */
+			break;
+		}
+	}
+
+	return FI_SUCCESS;
+}
+
+/******************************************************************************
+ *
+ * VC TX progress
+ *
+ *****************************************************************************/
+
+/* Schedule the VC for TX progress. */
+int _gnix_vc_tx_schedule(struct gnix_vc *vc)
+{
+	struct gnix_nic *nic = vc->ep->nic;
+
+	/* Don't bother scheduling if there's no work to do. */
+	if (slist_empty(&vc->tx_queue))
+		return FI_SUCCESS;
+
+	if (!_gnix_test_and_set_bit(&vc->flags, GNIX_VC_FLAG_TX_SCHEDULED)) {
+		fastlock_acquire(&nic->tx_vc_lock);
+		dlist_insert_tail(&vc->tx_list, &nic->tx_vcs);
+		fastlock_release(&nic->tx_vc_lock);
+		GNIX_INFO(FI_LOG_EP_CTRL, "Scheduled TX VC (%p)\n", vc);
+	}
+
+	return FI_SUCCESS;
+}
+
+/* Attempt to initiate a TX request.  If the TX queue is blocked (due to low
+ * resources or a FI_FENCE request), schedule the request to be sent later. */
 int _gnix_vc_queue_tx_req(struct gnix_fab_req *req)
 {
 	int rc, queue_tx = 0;
 	struct gnix_vc *vc = req->vc;
+	int connected;
+
+	connected = !__gnix_vc_connected(vc); /* 0 on success */
 
 	fastlock_acquire(&vc->tx_queue_lock);
 
@@ -1427,10 +1658,9 @@ int _gnix_vc_queue_tx_req(struct gnix_fab_req *req)
 		GNIX_INFO(FI_LOG_EP_DATA,
 			  "Queued FI_FENCE request (%p) on VC\n",
 			  req);
-	} else if (vc->conn_state == GNIX_VC_CONNECTED &&
-		   slist_empty(&vc->tx_queue)) {
+	} else if (connected && slist_empty(&vc->tx_queue)) {
 		/* try to initiate request */
-		rc = req->send_fn(req);
+		rc = req->work_fn(req);
 		if (rc != FI_SUCCESS) {
 			queue_tx = 1;
 			GNIX_INFO(FI_LOG_EP_DATA,
@@ -1451,7 +1681,7 @@ int _gnix_vc_queue_tx_req(struct gnix_fab_req *req)
 
 	if (unlikely(queue_tx)) {
 		slist_insert_tail(&req->slist, &vc->tx_queue);
-		_gnix_vc_schedule(vc);
+		_gnix_vc_tx_schedule(vc);
 	}
 
 	fastlock_release(&vc->tx_queue_lock);
@@ -1459,15 +1689,21 @@ int _gnix_vc_queue_tx_req(struct gnix_fab_req *req)
 	return FI_SUCCESS;
 }
 
-int _gnix_vc_push_tx_reqs(struct gnix_vc *vc)
+/* Push TX requests queued on the VC. */
+static int __gnix_vc_push_tx_reqs(struct gnix_vc *vc)
 {
 	int ret, fi_rc = FI_SUCCESS;
 	struct slist *list;
 	struct slist_entry *item;
 	struct gnix_fab_req *req;
 
-	if (vc->conn_state != GNIX_VC_CONNECTED)
+	ret = __gnix_vc_connected(vc);
+	if (ret) {
+		/* The CM will schedule the VC when the connection is complete.
+		 * Return success to allow continued VC TX processing. */
+		_gnix_vc_tx_schedule(vc);
 		return FI_SUCCESS;
+	}
 
 	fastlock_acquire(&vc->tx_queue_lock);
 
@@ -1483,32 +1719,47 @@ int _gnix_vc_push_tx_reqs(struct gnix_vc *vc)
 			GNIX_INFO(FI_LOG_EP_DATA,
 				  "TX request queue stalled on FI_FENCE request: %p (%d)\n",
 				  req, atomic_get(&vc->outstanding_tx_reqs));
+			/* Success is returned to allow processing of more VCs.
+			 * This VC will be rescheduled when the fence request
+			 * is completed. */
 			break;
 		}
 
-		ret = req->send_fn(req);
+		ret = req->work_fn(req);
 		if (ret == FI_SUCCESS) {
 			atomic_inc(&vc->outstanding_tx_reqs);
 			GNIX_INFO(FI_LOG_EP_DATA,
 				  "TX request processed: %p (OTX: %d)\n",
 				  req, atomic_get(&vc->outstanding_tx_reqs));
-		} else if (ret == -FI_EAGAIN) {
-			GNIX_INFO(FI_LOG_EP_DATA,
-				  "TX request queue stalled: %p\n",
-				  req);
-			break;
 		} else {
-			GNIX_WARN(FI_LOG_EP_DATA,
+			/* Work failed.  Reschedule to put this VC back on the
+			 * end of the list. */
+			_gnix_vc_tx_schedule(vc);
+
+			GNIX_INFO(FI_LOG_EP_DATA,
 				  "Failed to push TX request %p: %s\n",
-				  req,
-				  fi_strerror(-ret));
-			fi_rc = ret;
-			assert(0);
+				  req, fi_strerror(-ret));
+
+			/* FI_ENOSPC is reserved to indicate a lack of TXDs,
+			 * which are shared by all VCs on the NIC.  Return
+			 * error to stall processing of VCs in this case.  The
+			 * other likely error is a lack of SMSG credits, which
+			 * only halts this VC. */
+			if (ret == -FI_ENOSPC) {
+				fi_rc = -FI_EAGAIN;
+			} else if (ret != -FI_EAGAIN) {
+				/* TODO report error? */
+				GNIX_WARN(FI_LOG_EP_DATA,
+					  "Failed to push TX request %p: %s\n",
+					  req, fi_strerror(-ret));
+			} /* else return success to keep processing TX VCs */
 			break;
 		}
 
 		slist_remove_head(&vc->tx_queue);
 		item = list->head;
+
+		/* Return success if the queue is emptied. */
 	}
 
 	fastlock_release(&vc->tx_queue_lock);
@@ -1516,156 +1767,73 @@ int _gnix_vc_push_tx_reqs(struct gnix_vc *vc)
 	return fi_rc;
 }
 
-/* Force the request to be queued, do not allow an inline send. */
-int _gnix_vc_force_queue_req(struct gnix_fab_req *req)
+static struct gnix_vc *__gnix_nic_next_pending_tx_vc(struct gnix_nic *nic)
 {
-	struct gnix_vc *vc = req->vc;
+	struct gnix_vc *vc = NULL;
 
-	fastlock_acquire(&vc->req_queue_lock);
-	slist_insert_tail(&req->slist, &vc->req_queue);
-	_gnix_vc_schedule(vc);
-	fastlock_release(&vc->req_queue_lock);
+	fastlock_acquire(&nic->tx_vc_lock);
+	vc = dlist_first_entry(&nic->tx_vcs, struct gnix_vc, tx_list);
+	if (vc)
+		dlist_remove(&vc->tx_list);
+	fastlock_release(&nic->tx_vc_lock);
 
-	return FI_SUCCESS;
-}
-
-int _gnix_vc_queue_req(struct gnix_fab_req *req)
-{
-	int rc, queue_req = 0;
-	struct gnix_vc *vc = req->vc;
-
-	fastlock_acquire(&vc->req_queue_lock);
-
-	if (vc->conn_state == GNIX_VC_CONNECTED) {
-		/* try to initiate request */
-		rc = req->send_fn(req);
-		if (rc != FI_SUCCESS) {
-			queue_req = 1;
-			GNIX_INFO(FI_LOG_EP_DATA,
-				  "Queued request (%p) on full VC\n",
-				  req);
-		} else {
-			atomic_inc(&vc->outstanding_reqs);
-			GNIX_INFO(FI_LOG_EP_DATA,
-				  "Request processed: %p (OREQs: %d)\n",
-				  req, atomic_get(&vc->outstanding_reqs));
-		}
-	} else {
-		queue_req = 1;
-		GNIX_INFO(FI_LOG_EP_DATA,
-			  "Queued request (%p) on busy VC\n",
-			  req);
+	if (vc) {
+		GNIX_INFO(FI_LOG_EP_CTRL, "Dequeued TX VC (%p)\n", vc);
+		_gnix_clear_bit(&vc->flags, GNIX_VC_FLAG_TX_SCHEDULED);
 	}
 
-	if (unlikely(queue_req)) {
-		slist_insert_tail(&req->slist, &vc->req_queue);
-		_gnix_vc_schedule(vc);
-	}
-
-	fastlock_release(&vc->req_queue_lock);
-
-	return FI_SUCCESS;
+	return vc;
 }
 
-int _gnix_vc_push_reqs(struct gnix_vc *vc)
-{
-	int ret, fi_rc = FI_SUCCESS;
-	struct slist *list;
-	struct slist_entry *item;
-	struct gnix_fab_req *req;
-
-	if (vc->conn_state != GNIX_VC_CONNECTED)
-		return FI_SUCCESS;
-
-	fastlock_acquire(&vc->req_queue_lock);
-
-	list = &vc->req_queue;
-	item = list->head;
-	while (item != NULL) {
-		req = (struct gnix_fab_req *)container_of(item,
-							  struct gnix_fab_req,
-							  slist);
-		ret = req->send_fn(req);
-		if (ret == FI_SUCCESS) {
-			atomic_inc(&vc->outstanding_reqs);
-			GNIX_INFO(FI_LOG_EP_DATA,
-				  "Request processed: %p (OTX: %d)\n",
-				  req, atomic_get(&vc->outstanding_reqs));
-		} else if (ret == -FI_EAGAIN) {
-			GNIX_INFO(FI_LOG_EP_DATA,
-				  "Request queue stalled: %p\n",
-				  req);
-			break;
-		} else {
-			GNIX_WARN(FI_LOG_EP_DATA,
-				  "Failed to push request %p: %s\n",
-				  req,
-				  fi_strerror(-ret));
-			fi_rc = ret;
-			assert(0);
-			break;
-		}
-
-		slist_remove_head(&vc->req_queue);
-		item = list->head;
-	}
-
-	fastlock_release(&vc->req_queue_lock);
-
-	return fi_rc;
-}
-
-int _gnix_vc_progress(struct gnix_vc *vc)
+/* Progress VC TXs.  Exit when all VCs TX queues are empty or stalled. */
+static int __gnix_nic_vc_tx_progress(struct gnix_nic *nic)
 {
 	int ret;
-	struct gnix_cm_nic *cm_nic;
+	struct gnix_vc *first_vc = NULL, *vc;
 
-	if (unlikely(vc->conn_state < GNIX_VC_CONNECTED)) {
-		cm_nic = vc->ep->cm_nic;
-		ret = _gnix_cm_nic_progress(cm_nic);
-		if ((ret != FI_SUCCESS) && (ret != -FI_EAGAIN))
-			GNIX_WARN(FI_LOG_EP_CTRL,
-				  "_gnix_cm_nic_progress() failed: %s\n",
-				   fi_strerror(-ret));
-		/* waiting to connect, check back later */
-		return -FI_EAGAIN;
-	}
+	while ((vc = __gnix_nic_next_pending_tx_vc(nic))) {
+		ret = __gnix_vc_push_tx_reqs(vc);
+		if (ret != FI_SUCCESS)
+			break;
 
-	/* Process pending RXs */
-	if (unlikely(
-	    _gnix_test_and_clear_bit(&vc->flags, GNIX_VC_FLAG_RX_PENDING))) {
-		fastlock_acquire(&vc->ep->nic->lock);
-		ret = _gnix_vc_dequeue_smsg(vc);
-		fastlock_release(&vc->ep->nic->lock);
-		if (unlikely(ret != FI_SUCCESS)) {
-			GNIX_WARN(FI_LOG_EP_CTRL,
-				  "_gnix_vc_dequeue_smsg() failed: %s\n",
-				  fi_strerror(-ret));
-			return ret;
+		if (!first_vc) {
+			/* Record first VC processed. */
+			first_vc = vc;
+		} else if (vc == first_vc) {
+			/* VCs can self reschedule or be rescheduled in other
+			 * threads.  Exit if we loop back to the first VC. */
+			break;
 		}
 	}
 
-	/* Initiate non-TX requests */
-	if (!slist_empty(&vc->req_queue)) {
-		ret = _gnix_vc_push_reqs(vc);
-		if (ret != FI_SUCCESS) {
-			GNIX_WARN(FI_LOG_EP_CTRL,
-				  "_gnix_vc_push_tx_reqs() failed: %s\n",
-				  fi_strerror(-ret));
-			return ret;
-		}
-	}
+	return FI_SUCCESS;
+}
 
-	/* Initiate pending TXs */
-	if (!slist_empty(&vc->tx_queue)) {
-		ret = _gnix_vc_push_tx_reqs(vc);
-		if (ret != FI_SUCCESS) {
-			GNIX_WARN(FI_LOG_EP_CTRL,
-				  "_gnix_vc_push_tx_reqs() failed: %s\n",
-				  fi_strerror(-ret));
-			return ret;
-		}
-	}
+/* Progress all NIC VCs needing work. */
+int _gnix_nic_vc_progress(struct gnix_nic *nic)
+{
+	/* Process VCs with RX traffic pending */
+	__gnix_nic_vc_rx_progress(nic);
+
+	/* Process deferred request work (deferred RX processing, etc.) */
+	__gnix_nic_vc_work_progress(nic);
+
+	/* Process VCs with TX traffic pending */
+	__gnix_nic_vc_tx_progress(nic);
+
+	return FI_SUCCESS;
+}
+
+/* Schedule VC to have all work queues processed.  This should only be needed
+ * for newly connected VCs.
+ *
+ * TODO This is currently used to advance CM state.
+ */
+int _gnix_vc_schedule(struct gnix_vc *vc)
+{
+	_gnix_vc_rx_schedule(vc);
+	__gnix_vc_work_schedule(vc);
+	_gnix_vc_tx_schedule(vc);
 
 	return FI_SUCCESS;
 }

--- a/prov/gni/test/cancel.c
+++ b/prov/gni/test/cancel.c
@@ -254,6 +254,7 @@ Test(gnix_cancel, cancel_ep_send)
 	struct fi_cq_err_entry buf;
 	struct gnix_vc *vc;
 	void *foobar_ptr = NULL;
+	gnix_ht_key_t *key;
 
 	/* simulate a posted request */
 	gnix_ep = container_of(ep[0], struct gnix_fid_ep, ep_fid);
@@ -264,14 +265,17 @@ Test(gnix_cancel, cancel_ep_send)
 	req->user_context = foobar_ptr;
 	req->type = GNIX_FAB_RQ_SEND;
 
-	/* find vc, insert request */
+	/* allocate, store vc */
 	ret = _gnix_vc_alloc(gnix_ep, NULL, &vc);
 	cr_assert(ret == FI_SUCCESS, "_gnix_vc_alloc failed");
 
+	key = (gnix_ht_key_t *)&gnix_ep->my_name.gnix_addr;
+	ret = _gnix_ht_insert(gnix_ep->vc_ht, *key, vc);
+
+	/* make a dummy request */
 	fastlock_acquire(&vc->tx_queue_lock);
 	slist_insert_head(&req->slist, &vc->tx_queue);
 	fastlock_release(&vc->tx_queue_lock);
-	_gnix_vc_schedule(vc);
 
 	/* cancel simulated request */
 	ret = fi_cancel(&ep[0]->fid, foobar_ptr);

--- a/prov/gni/test/cancel.c
+++ b/prov/gni/test/cancel.c
@@ -271,6 +271,7 @@ Test(gnix_cancel, cancel_ep_send)
 
 	key = (gnix_ht_key_t *)&gnix_ep->my_name.gnix_addr;
 	ret = _gnix_ht_insert(gnix_ep->vc_ht, *key, vc);
+	cr_assert(!ret);
 
 	/* make a dummy request */
 	fastlock_acquire(&vc->tx_queue_lock);
@@ -290,9 +291,6 @@ Test(gnix_cancel, cancel_ep_send)
 	cr_assert(buf.err == FI_ECANCELED, "error code mismatch");
 	cr_assert(buf.prov_errno == FI_ECANCELED, "prov error code mismatch");
 	cr_assert(buf.len == 128, "length mismatch");
-
-	ret = _gnix_vc_destroy(vc);
-	cr_assert(ret == FI_SUCCESS, "_gnix_vc_destroy failed");
 }
 
 Test(gnix_cancel, cancel_ep_recv)


### PR DESCRIPTION
There are two distinct commits related to progress here.  The first fixes up a couple issues I saw with Howard's last progress fixes.  The second is a refactor of VC progress.  The second commit message describes the refactored code (it's copied from the function description of _gnix_nic_vc_progress()).

This code is clearer and more efficient.  It takes care of a problem I noticed which we haven't seen yet where a VC would not not scheduled for push it's TX queue after TXDs were freed on a different VC.

I still have a couple things to do here before it's done, but it passes all tests (except ep_cancel).  

Yet to do in this commit:
1. Fix EP cancel searching of new VC queues.
2. Fix gnix_vc_destroy teardown of new VC queues.

Yet to do in the future:
1. Fix CM progress.  Currently the CM relies on calls to _gnix_vc_progress() to progress it's state.  That doesn't seem ideal.

@hppritcha @sungeunchoi @jswaro
