### PR TITLE
prov/gni: don't include criterion stuff with dist

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,6 +37,10 @@ linkback = $(top_builddir)/src/libfabric.la
 bin_PROGRAMS = \
 	util/fi_info
 
+bin_SCRIPTS =
+
+nodist_DIR =
+
 util_fi_info_SOURCES = \
 	util/info.c
 util_fi_info_LDADD = $(linkback)

--- a/prov/gni/Makefile.am
+++ b/prov/gni/Makefile.am
@@ -70,8 +70,8 @@ _gni_headers = \
 
 if HAVE_CRITERION
 bin_PROGRAMS += prov/gni/test/gnitest
-dist_bin_SCRIPTS = prov/gni/test/run_gnitest
-prov_gni_test_gnitest_SOURCES = \
+bin_SCRIPTS += prov/gni/test/run_gnitest
+nodist_prov_gni_test_gnitest_SOURCES = \
 	prov/gni/test/allocator.c \
 	prov/gni/test/av.c \
 	prov/gni/test/bitmap.c \
@@ -119,3 +119,4 @@ endif
 
 rdmainclude_HEADERS += \
 	prov/gni/include/fi_ext_gni.h
+nodist_DIR += prov/gni/test


### PR DESCRIPTION
with this commit, make dist or make distcheck no long generates a tarball with criterion unit tests included.

Also set `bin_SCRIPTS` and `nodist_DIR` to empty in top level makefile.am

@sungeunchoi 
@jswaro 

Signed-off-by: Howard Pritchard howardp@lanl.gov
