### PR TITLE
Fix setting of domain parameters rx_cq_size and tx_cq_size.

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -286,10 +286,6 @@ struct gnix_fid_domain {
 	uint32_t cdm_id_seed;
 	/* user tunable parameters accessed via open_ops functions */
 	struct gnix_ops_domain params;
-	/* size of gni tx cqs for this domain */
-	uint32_t gni_tx_cq_size;
-	/* size of gni rx cqs for this domain */
-	uint32_t gni_rx_cq_size;
 	/* additional gni cq modes to use for this domain */
 	gni_cq_mode_t gni_cq_modes;
 	/* additional gni cq modes to use for this domain */

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -394,11 +394,11 @@ int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	domain->params.mbox_num_per_slab = default_mbox_num_per_slab;
 	domain->params.mbox_maxcredit = default_mbox_maxcredit;
 	domain->params.mbox_msg_maxsize = default_mbox_msg_maxsize;
+	domain->params.rx_cq_size = default_rx_cq_size;
+	domain->params.tx_cq_size = default_tx_cq_size;
 	domain->params.max_retransmits = default_max_retransmits;
 	domain->params.err_inject_count = default_err_inject_count;
 
-	domain->gni_tx_cq_size = default_tx_cq_size;
-	domain->gni_rx_cq_size = default_rx_cq_size;
 	domain->gni_cq_modes = gnix_def_gni_cq_modes;
 	_gnix_ref_init(&domain->ref_cnt, 1, __domain_destruct);
 

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -751,7 +751,7 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 		 */
 
 		status = GNI_CqCreate(nic->gni_nic_hndl,
-					domain->gni_tx_cq_size,
+					domain->params.tx_cq_size,
 					0,                  /* no delay count */
 					GNI_CQ_NOBLOCK |
 					domain->gni_cq_modes,
@@ -768,7 +768,7 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 		}
 
 		status = GNI_CqCreate(nic->gni_nic_hndl,
-					domain->gni_tx_cq_size,
+					domain->params.tx_cq_size,
 					0,
 					GNI_CQ_BLOCKING |
 						domain->gni_cq_modes,
@@ -788,7 +788,7 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 		 */
 
 		status = GNI_CqCreate(nic->gni_nic_hndl,
-					domain->gni_rx_cq_size,
+					domain->params.rx_cq_size,
 					0,
 					GNI_CQ_NOBLOCK |
 						domain->gni_cq_modes,
@@ -804,7 +804,7 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 		}
 
 		status = GNI_CqCreate(nic->gni_nic_hndl,
-					domain->gni_rx_cq_size,
+					domain->params.rx_cq_size,
 					0,
 					GNI_CQ_BLOCKING |
 					domain->gni_cq_modes,
@@ -835,7 +835,8 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 
 		fastlock_init(&nic->lock);
 
-		ret = __gnix_nic_tx_freelist_init(nic, domain->gni_tx_cq_size);
+		ret = __gnix_nic_tx_freelist_init(nic,
+						  domain->params.tx_cq_size);
 		if (ret != FI_SUCCESS)
 			goto err1;
 


### PR DESCRIPTION
Some how I (and my reviewer ;-) missed the fact that I was setting the
params for rx and tx cq size, but using the old fields.  Oops.

@e-harvey @ztiffany @jswaro @hppritcha 

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com
