### PR TITLE
Topic/fix osu coll hangs

### DIFF
--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -323,7 +323,7 @@ static int __gnix_rndzv_req(void *arg)
 	if (!req->msg.recv_md) {
 		rc = gnix_mr_reg(&ep->domain->domain_fid.fid,
 				 (void *)req->msg.recv_addr, req->msg.recv_len,
-				 FI_READ, 0, 0, 0, &auto_mr, NULL);
+				 FI_READ | FI_WRITE, 0, 0, 0, &auto_mr, NULL);
 		if (rc != FI_SUCCESS) {
 			GNIX_INFO(FI_LOG_EP_DATA,
 				  "Failed to auto-register local buffer: %d\n",
@@ -1288,7 +1288,8 @@ ssize_t _gnix_send(struct gnix_fid_ep *ep, uint64_t loc_addr, size_t len,
 	/* need a memory descriptor for large sends */
 	if (rendezvous && !mdesc) {
 		ret = gnix_mr_reg(&ep->domain->domain_fid.fid, (void *)loc_addr,
-				 len, FI_WRITE, 0, 0, 0, &auto_mr, NULL);
+				 len, FI_READ | FI_WRITE, 0, 0, 0,
+				 &auto_mr, NULL);
 		if (ret != FI_SUCCESS) {
 			GNIX_INFO(FI_LOG_EP_DATA,
 				  "Failed to auto-register local buffer: %d\n",

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -1033,9 +1033,9 @@ static int __gnix_vc_conn_req_prog_fn(void *data, int *complete_ptr)
 		GNIX_DEBUG(FI_LOG_EP_CTRL, "moving vc %p state to connecting\n",
 			vc);
 	} else if (ret == -FI_EAGAIN) {
-		ret = _gnix_vc_schedule(vc);
 		ret = FI_SUCCESS;
 	}
+	ret = _gnix_vc_schedule(vc);
 
 err:
 	fastlock_release(&ep->vc_ht_lock);


### PR DESCRIPTION
These small changes allow more of the osu tests to pass.  The memory registration related changes are necessary because the communication pattern in many of the tests used memory both for sending and receiving in some places.  Since the memory registration cache doesn't track the permissions of the region when looking up the corresponding memory for a vaddr/lem, some of the tests would end up
failing with SRSP access permission errors being returned in TX CQEs.  This would cause hangs.

I'm not sure if its worth changing the design of the mr cache at this point to support checking perms as well as vaddr/len for a match.

@ztiffany 
