### PR TITLE
Support fi_read() of unaligned remote data.

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -115,7 +115,11 @@ extern "C" {
  */
 
 #define GNIX_SUPPRESS_COMPLETION	(1ULL << 60)	/* TX only flag */
+
 #define GNIX_RMA_RDMA			(1ULL << 61)	/* RMA only flag */
+#define GNIX_RMA_INDIRECT		(1ULL << 62)	/* RMA only flag */
+#define GNIX_RMA_CHAINED		(1ULL << 63)	/* RMA only flag */
+
 #define GNIX_MSG_RENDEZVOUS		(1ULL << 61)	/* MSG only flag */
 
 /*
@@ -411,6 +415,10 @@ struct gnix_fab_req_rma {
 	uint64_t                 rem_addr;
 	uint64_t                 rem_mr_key;
 	uint64_t                 imm;
+	void                     *align_buf;
+	struct gnix_fid_mem_desc *align_md;
+	atomic_t                 outstanding_txds;
+	gni_return_t             status;
 };
 
 struct gnix_fab_req_msg {

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -107,6 +107,13 @@ extern "C" {
 #endif
 
 /*
+ * GNI GET alignment
+ */
+
+#define GNI_READ_ALIGN		4
+#define GNI_READ_ALIGN_MASK	(GNI_READ_ALIGN - 1)
+
+/*
  * Flags
  * The 64-bit flag field is used as follows:
  * 1-grow up    common (usable with multiple operations)
@@ -436,6 +443,8 @@ struct gnix_fab_req_msg {
 	uint64_t                     imm;
 	gni_mem_handle_t             rma_mdh;
 	uint64_t                     rma_id;
+	uint32_t                     rndzv_head;
+	uint32_t                     rndzv_tail;
 };
 
 struct gnix_fab_req_amo {

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -212,6 +212,8 @@ struct gnix_smsg_eager_hdr {
  * @var addr       address of the rendezvous send buffer
  * @var len        length in bytes of the send buffer
  * @var req_addr   local request address
+ * @var head       unaligned data at the head of a rendezvous send
+ * @var tail       unaligned data at the tail of a rendezvous send
  */
 struct gnix_smsg_rndzv_start_hdr {
 	uint64_t flags;
@@ -221,6 +223,8 @@ struct gnix_smsg_rndzv_start_hdr {
 	uint64_t addr;
 	size_t len;
 	uint64_t req_addr;
+	uint32_t head;
+	uint32_t tail;
 };
 
 /**

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -257,7 +257,10 @@ struct gnix_smsg_rma_data_hdr {
 struct gnix_tx_descriptor {
 	struct dlist_entry          list;
 	union {
-		gni_post_descriptor_t            gni_desc;
+		struct {
+			gni_post_descriptor_t        gni_desc;
+			gni_ct_get_post_descriptor_t gni_ct_descs[2];
+		};
 		struct gnix_smsg_eager_hdr       eager_hdr;
 		struct gnix_smsg_rndzv_start_hdr rndzv_start_hdr;
 		struct gnix_smsg_rndzv_fin_hdr   rndzv_fin_hdr;

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -1366,7 +1366,6 @@ static inline struct gnix_fab_req *__find_tx_req(
 
 	fastlock_acquire(&ep->vc_ht_lock);
 	while ((vc = _gnix_ht_iterator_next(&iter))) {
-		GNIX_INFO(0, "searching vc: %p\n", vc);
 		fastlock_acquire(&vc->tx_queue_lock);
 		entry = slist_remove_first_match(&vc->tx_queue,
 				__match_context, context);

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -81,6 +81,46 @@ static void __gnix_msg_send_fr_complete(struct gnix_fab_req *req,
 	_gnix_fr_free(req->gnix_ep, req);
 }
 
+static int __recv_err(struct gnix_fid_ep *ep, void *context, uint64_t flags,
+		      size_t len, void *addr, uint64_t data, uint64_t tag,
+		      size_t olen, int err, int prov_errno, void *err_data)
+{
+	int rc;
+
+	if (ep->recv_cq) {
+		rc = _gnix_cq_add_error(ep->recv_cq, context, flags, len,
+					addr, data, tag, olen, err,
+					prov_errno, err_data);
+		if (rc != FI_SUCCESS)  {
+			GNIX_WARN(FI_LOG_EP_DATA,
+				  "_gnix_cq_add_error returned %d\n",
+				  rc);
+		}
+	}
+
+	if (ep->recv_cntr) {
+		rc = _gnix_cntr_inc_err(ep->recv_cntr);
+		if (rc != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_EP_DATA,
+				  "_gnix_cntr_inc_err() failed: %d\n",
+				  rc);
+	}
+
+	return FI_SUCCESS;
+}
+
+static int __gnix_msg_recv_err(struct gnix_fid_ep *ep, struct gnix_fab_req *req)
+{
+	uint64_t flags = FI_RECV | FI_MSG;
+
+	flags |= req->msg.send_flags & FI_TAGGED;
+
+	return __recv_err(ep, req->user_context, flags, req->msg.recv_len,
+			  (void *)req->msg.recv_addr, req->msg.imm,
+			  req->msg.tag, 0, FI_ECANCELED,
+			  GNI_RC_TRANSACTION_ERROR, NULL);
+}
+
 static int __recv_completion(
 		struct gnix_fid_ep *ep,
 		struct gnix_fab_req *req,
@@ -115,8 +155,8 @@ static int __recv_completion(
 	return FI_SUCCESS;
 }
 
-static inline int __gnix_recv_completion(struct gnix_fid_ep *ep,
-				  struct gnix_fab_req *req)
+static inline int __gnix_msg_recv_completion(struct gnix_fid_ep *ep,
+					     struct gnix_fab_req *req)
 {
 	uint64_t flags = FI_RECV | FI_MSG;
 
@@ -133,7 +173,7 @@ static inline int __gnix_recv_completion(struct gnix_fid_ep *ep,
 			_gnix_vc_peer_fi_addr(req->vc));
 }
 
-static int __gnix_send_err(struct gnix_fid_ep *ep, struct gnix_fab_req *req)
+static int __gnix_msg_send_err(struct gnix_fid_ep *ep, struct gnix_fab_req *req)
 {
 	uint64_t flags = FI_SEND | FI_MSG;
 	int rc;
@@ -162,8 +202,8 @@ static int __gnix_send_err(struct gnix_fid_ep *ep, struct gnix_fab_req *req)
 	return FI_SUCCESS;
 }
 
-static int __gnix_send_completion(struct gnix_fid_ep *ep,
-				  struct gnix_fab_req *req)
+static int __gnix_msg_send_completion(struct gnix_fid_ep *ep,
+				      struct gnix_fab_req *req)
 {
 	uint64_t flags = FI_SEND | FI_MSG;
 	int rc;
@@ -192,40 +232,6 @@ static int __gnix_send_completion(struct gnix_fid_ep *ep,
 	return FI_SUCCESS;
 }
 
-static int __gnix_send_smsg_err(struct gnix_tx_descriptor *txd)
-{
-	struct gnix_fab_req *req = txd->req;
-	int rc;
-
-	/* SMSG is auto-retransmitting.  If GNI returned error, we're done. */
-
-	GNIX_INFO(FI_LOG_EP_DATA, "Failed transaction: %p\n", req);
-	rc = __gnix_send_err(req->gnix_ep, req);
-	if (rc != FI_SUCCESS)
-		GNIX_WARN(FI_LOG_EP_DATA,
-			  "__gnix_send_err() failed: %d\n",
-			  rc);
-
-	__gnix_msg_send_fr_complete(req, txd);
-	return FI_SUCCESS;
-}
-
-static int __gnix_send_post_err(struct gnix_tx_descriptor *txd)
-{
-	struct gnix_fab_req *req = txd->req;
-
-	req->tx_failures++;
-	if (req->tx_failures < req->gnix_ep->domain->params.max_retransmits) {
-		GNIX_INFO(FI_LOG_EP_DATA,
-			  "Requeueing failed request: %p\n", req);
-		return _gnix_vc_queue_work_req(req);
-	}
-
-	/* TODO should this be fatal? A request will sit waiting at the
-	 * peer. */
-	return __gnix_send_smsg_err(txd);
-}
-
 static int __gnix_rndzv_req_send_fin(void *arg)
 {
 	struct gnix_fab_req *req = (struct gnix_fab_req *)arg;
@@ -243,16 +249,12 @@ static int __gnix_rndzv_req_send_fin(void *arg)
 	nic = ep->nic;
 	assert(nic != NULL);
 
-	txd = (struct gnix_tx_descriptor *)req->txd;
-	if (!txd) {
-		rc = _gnix_nic_tx_alloc(nic, &txd);
-		if (rc) {
-			GNIX_INFO(FI_LOG_EP_DATA,
-				  "_gnix_nic_tx_alloc() failed: %d\n",
-				  rc);
-			return -FI_ENOSPC;
-		}
-		req->txd = txd;
+	rc = _gnix_nic_tx_alloc(nic, &txd);
+	if (rc) {
+		GNIX_INFO(FI_LOG_EP_DATA,
+				"_gnix_nic_tx_alloc() failed: %d\n",
+				rc);
+		return -FI_ENOSPC;
 	}
 
 	txd->rndzv_fin_hdr.req_addr = req->msg.rma_id;
@@ -268,13 +270,11 @@ static int __gnix_rndzv_req_send_fin(void *arg)
 
 	if (status == GNI_RC_NOT_DONE) {
 		_gnix_nic_tx_free(nic, txd);
-		req->txd = NULL;
 		GNIX_INFO(FI_LOG_EP_DATA,
 			  "GNI_SmsgSendWTag returned %s\n",
 			  gni_err_str[status]);
 	} else if (status != GNI_RC_SUCCESS) {
 		_gnix_nic_tx_free(nic, txd);
-		req->txd = NULL;
 		GNIX_WARN(FI_LOG_EP_DATA,
 			  "GNI_SmsgSendWTag returned %s\n",
 			  gni_err_str[status]);
@@ -320,8 +320,21 @@ static int __gnix_rndzv_req_complete(void *arg, gni_return_t tx_status)
 	struct gnix_fab_req *req = txd->req;
 	int ret;
 
+	_gnix_nic_tx_free(req->gnix_ep->nic, txd);
+
 	if (tx_status != GNI_RC_SUCCESS) {
-		return __gnix_send_post_err(txd);
+		req->tx_failures++;
+		if (req->tx_failures <
+		    req->gnix_ep->domain->params.max_retransmits) {
+
+			GNIX_INFO(FI_LOG_EP_DATA,
+				  "Requeueing failed request: %p\n", req);
+			return _gnix_vc_queue_work_req(req);
+		}
+
+		/* TODO should this be fatal? A request will sit waiting at the
+		 * peer. */
+		return __gnix_msg_recv_err(req->gnix_ep, req);
 	}
 
 	__gnix_msg_copy_unaligned_get_data(req);
@@ -334,9 +347,7 @@ static int __gnix_rndzv_req_complete(void *arg, gni_return_t tx_status)
 		fi_close(&req->msg.recv_md->mr_fid.fid);
 	}
 
-	req->txd = txd;
 	req->work_fn = __gnix_rndzv_req_send_fin;
-
 	ret = _gnix_vc_queue_work_req(req);
 
 	return ret;
@@ -406,6 +417,7 @@ static int __gnix_rndzv_req(void *arg)
 	} else {
 		status = GNI_PostRdma(req->vc->gni_ep, &txd->gni_desc);
 		if (status != GNI_RC_SUCCESS) {
+			_gnix_nic_tx_free(nic, txd);
 			GNIX_INFO(FI_LOG_EP_DATA, "GNI_PostRdma failed: %s\n",
 				  gni_err_str[status]);
 		}
@@ -429,15 +441,20 @@ static int __comp_eager_msg_w_data(void *data, gni_return_t tx_status)
 	int ret = FI_SUCCESS;
 
 	if (tx_status != GNI_RC_SUCCESS) {
-		return __gnix_send_smsg_err(tdesc);
+		GNIX_INFO(FI_LOG_EP_DATA, "Failed transaction: %p\n", req);
+		ret = __gnix_msg_send_err(req->gnix_ep, req);
+		if (ret != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_EP_DATA,
+				  "__gnix_msg_send_err() failed: %d\n",
+				  ret);
+	} else {
+		/* Successful delivery.  Generate completions. */
+		ret = __gnix_msg_send_completion(req->gnix_ep, req);
+		if (ret != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_EP_DATA,
+				  "__gnix_msg_send_completion() failed: %d\n",
+				  ret);
 	}
-
-	/* Successful delivery.  Generate completions. */
-	ret = __gnix_send_completion(req->gnix_ep, req);
-	if (ret != FI_SUCCESS)
-		GNIX_WARN(FI_LOG_EP_DATA,
-			  "__gnix_send_completion() failed: %d\n",
-			  ret);
 
 	__gnix_msg_send_fr_complete(req, tdesc);
 
@@ -488,17 +505,26 @@ static int __comp_rndzv_msg_recv_done(void *data, gni_return_t tx_status)
 static int __comp_rndzv_start(void *data, gni_return_t tx_status)
 {
 	struct gnix_tx_descriptor *txd = (struct gnix_tx_descriptor *)data;
+	struct gnix_fab_req *req = txd->req;
+	int ret;
 
 	if (tx_status != GNI_RC_SUCCESS) {
-		return __gnix_send_smsg_err(txd);
+		GNIX_INFO(FI_LOG_EP_DATA, "Failed transaction: %p\n", txd->req);
+		ret = __gnix_msg_send_err(req->gnix_ep, req);
+		if (ret != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_EP_DATA,
+				  "__gnix_msg_send_err() failed: %d\n",
+				  ret);
+		__gnix_msg_send_fr_complete(req, txd);
+	} else {
+		/* Just free the TX descriptor for now.  The request remains
+		 * active until the remote peer notifies us that they're done
+		 * with the send buffer. */
+		_gnix_nic_tx_free(txd->req->gnix_ep->nic, txd);
+
+		GNIX_INFO(FI_LOG_EP_DATA, "Completed RNDZV_START, req: %p\n",
+			  txd->req);
 	}
-
-	/* Just free the TX descriptor for now.  The request remains active
-	 * until the remote peer notifies us that they're done with the send
-	 * buffer. */
-	_gnix_nic_tx_free(txd->req->gnix_ep->nic, txd);
-
-	GNIX_INFO(FI_LOG_EP_DATA, "Completed RNDZV_START, req: %p\n", txd->req);
 
 	return FI_SUCCESS;
 }
@@ -515,19 +541,19 @@ static int __comp_rndzv_fin(void *data, gni_return_t tx_status)
 		/* TODO should this be fatal? A request will sit waiting at the
 		 * peer. */
 		GNIX_WARN(FI_LOG_EP_DATA, "Failed transaction: %p\n", req);
-		ret = __gnix_send_err(req->gnix_ep, req);
+		ret = __gnix_msg_recv_err(req->gnix_ep, req);
 		if (ret != FI_SUCCESS)
 			GNIX_WARN(FI_LOG_EP_DATA,
-					"__gnix_send_err() failed: %d\n",
+					"__gnix_msg_recv_err() failed: %d\n",
 					ret);
 	} else {
 		GNIX_INFO(FI_LOG_EP_DATA, "Completed RNDZV_FIN, req: %p\n",
 			  req);
 
-		ret = __gnix_recv_completion(req->gnix_ep, req);
+		ret = __gnix_msg_recv_completion(req->gnix_ep, req);
 		if (ret != FI_SUCCESS)
 			GNIX_WARN(FI_LOG_EP_DATA,
-				  "__gnix_recv_completion() failed: %d\n",
+				  "__gnix_msg_recv_completion() failed: %d\n",
 				  ret);
 	}
 
@@ -606,7 +632,7 @@ static int __smsg_eager_msg_w_data(void *data, void *msg)
 		req->msg.recv_len = MIN(req->msg.send_len, req->msg.recv_len);
 		memcpy((void *)req->msg.recv_addr, data_ptr, req->msg.recv_len);
 
-		__gnix_recv_completion(ep, req);
+		__gnix_msg_recv_completion(ep, req);
 		_gnix_fr_free(ep, req);
 	} else {
 		/* Add new unexpected receive request. */
@@ -836,7 +862,7 @@ static int __smsg_rndzv_fin(void *data, void *msg)
 	ep = req->gnix_ep;
 	assert(ep != NULL);
 
-	__gnix_send_completion(ep, req);
+	__gnix_msg_send_completion(ep, req);
 
 	atomic_dec(&req->vc->outstanding_tx_reqs);
 
@@ -985,7 +1011,6 @@ static int  __gnix_discard_request(struct gnix_fid_ep *ep,
 				"returning rndzv completion for req, %p", req);
 
 		/* Complete rendezvous request, skipping data transfer. */
-		req->txd = NULL;
 		req->work_fn = __gnix_rndzv_req_send_fin;
 		ret = _gnix_vc_queue_work_req(req);
 	} else {
@@ -1139,7 +1164,7 @@ ssize_t _gnix_recv(struct gnix_fid_ep *ep, uint64_t buf, size_t len,
 			memcpy((void *)buf, tmp_buf, req->msg.recv_len);
 			free(tmp_buf);
 
-			__gnix_recv_completion(ep, req);
+			__gnix_msg_recv_completion(ep, req);
 			_gnix_fr_free(ep, req);
 		}
 	} else {
@@ -1147,23 +1172,9 @@ ssize_t _gnix_recv(struct gnix_fid_ep *ep, uint64_t buf, size_t len,
 		 * were looking for, return FI_ENOMSG
 		 */
 		if (r_flags) {
-			if (ep->recv_cq) {
-				ret = _gnix_cq_add_error(ep->recv_cq, context, flags,
-						len, (void *) buf, 0, tag, len, FI_ENOMSG,
-						FI_ENOMSG, NULL);
-				if (ret) {
-					GNIX_ERR(FI_LOG_EP_DATA, "could not add error to CQ, "
-							"cq=%p\n", ep->recv_cq);
-				}
-			}
-
-			if (ep->recv_cntr) {
-				ret = _gnix_cntr_inc_err(ep->recv_cntr);
-				if (ret) {
-					GNIX_ERR(FI_LOG_EP_DATA, "could not add error to cntr,"
-							"cntr=%p", ep->recv_cntr);
-				}
-			}
+			__recv_err(ep, context, flags, len,
+				   (void *)buf, 0, tag, len, FI_ENOMSG,
+				   FI_ENOMSG, NULL);
 
 			/* if handling trecvmsg flags, return here
 			 * Never post a receive request from this type of context

--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -49,8 +49,6 @@
 /* Threshold to switch from indirect transfer to chained transfer to move
  * unaligned read data. */
 #define GNIX_RMA_UREAD_CHAINED_THRESH		60
-#define GNI_READ_ALIGN				4
-#define GNI_READ_ALIGN_MASK			(GNI_READ_ALIGN - 1)
 
 static int __gnix_rma_send_err(struct gnix_fid_ep *ep,
 			       struct gnix_fab_req *req)
@@ -140,7 +138,7 @@ static void __gnix_rma_copy_chained_get_data(struct gnix_fab_req *req)
 	tail_len = (req->rma.rem_addr + req->rma.len) & GNI_READ_ALIGN_MASK;
 
 	if (head_off) {
-		GNIX_INFO(0, "writing %d bytes to %p\n",
+		GNIX_INFO(FI_LOG_EP_DATA, "writing %d bytes to %p\n",
 			  head_len, req->rma.loc_addr);
 		memcpy((void *)req->rma.loc_addr,
 		       req->rma.align_buf + head_off,
@@ -152,7 +150,8 @@ static void __gnix_rma_copy_chained_get_data(struct gnix_fab_req *req)
 			       req->rma.len -
 			       tail_len;
 
-		GNIX_INFO(0, "writing %d bytes to %p\n", tail_len, addr);
+		GNIX_INFO(FI_LOG_EP_DATA, "writing %d bytes to %p\n",
+			  tail_len, addr);
 		memcpy((void *)addr,
 		       req->rma.align_buf + GNI_READ_ALIGN,
 		       tail_len);
@@ -417,7 +416,8 @@ static void __gnix_rma_fill_pd_chained_get(struct gnix_fab_req *req,
 		txd->gni_ct_descs[desc_idx].next_descr = NULL;
 	}
 
-	GNIX_INFO(0, "ct_rem_addr[0] = %p %p, ct_rem_addr[1] = %p %p\n",
+	GNIX_INFO(FI_LOG_EP_DATA,
+		  "ct_rem_addr[0] = %p %p, ct_rem_addr[1] = %p %p\n",
 		  txd->gni_ct_descs[0].remote_addr,
 		  txd->gni_ct_descs[0].local_addr,
 		  txd->gni_ct_descs[1].remote_addr,
@@ -854,8 +854,8 @@ ssize_t _gnix_rma(struct gnix_fid_ep *ep, enum gnix_fab_req_type fr_type,
 		req->flags |= GNIX_RMA_RDMA;
 	}
 
-	GNIX_INFO(0, "Queuing (%p %p %d)\n",
-		  (void *) loc_addr, (void *)rem_addr, len);
+	GNIX_INFO(FI_LOG_EP_DATA, "Queuing (%p %p %d)\n",
+		  (void *)loc_addr, (void *)rem_addr, len);
 
 	return _gnix_vc_queue_tx_req(req);
 

--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -631,9 +631,9 @@ int _gnix_rma_post_req(void *data)
 	txd->gni_desc.cq_mode = GNI_CQMODE_GLOBAL_EVENT; /* check flags */
 	txd->gni_desc.dlvr_mode = GNI_DLVMODE_PERFORMANCE; /* check flags */
 
-	if (indirect) {
+	if (unlikely(indirect)) {
 		__gnix_rma_fill_pd_indirect_get(fab_req, txd);
-	} else if (chained) {
+	} else if (unlikely(chained)) {
 		__gnix_rma_fill_pd_chained_get(fab_req, txd, &mdh);
 	} else {
 		txd->gni_desc.local_addr = (uint64_t)fab_req->rma.loc_addr;
@@ -771,7 +771,9 @@ ssize_t _gnix_rma(struct gnix_fid_ep *ep, enum gnix_fab_req_type fr_type,
 
 	if (fr_type == GNIX_FAB_RQ_RDMA_READ &&
 	    (rem_addr & GNI_READ_ALIGN_MASK || len & GNI_READ_ALIGN_MASK)) {
-		/* Copy unaligned data through the inject buffer. */
+		/* TODO: Copy unaligned data through the inject buffer for now.
+		 * This path would benefit from an allocator which provides
+		 * small pre-registered buffers for this use. */
 		align_buf = req->inject_buf;
 		rc = gnix_mr_reg(&ep->domain->domain_fid.fid, align_buf,
 				GNIX_INJECT_SIZE, FI_READ, 0, 0, 0, &align_mr,


### PR DESCRIPTION
GNI requires the target address and length of a remote read to be 4 byte
aligned.  Read aligned data into an intermediate buffer to support libfabric
reads of unaligned remote data.

Fixes ofi-cray/libfabric-cray#488.

Signed-off-by: Zach Tiffany ztiffany@cray.com

@hppritcha @sungeunchoi @jswaro
