### PR TITLE
Added performance measurement tests for the memory registration cache

### DIFF
--- a/prov/gni/Makefile.am
+++ b/prov/gni/Makefile.am
@@ -94,7 +94,8 @@ nodist_prov_gni_test_gnitest_SOURCES = \
 	prov/gni/test/tags.c \
 	prov/gni/test/utils.c \
 	prov/gni/test/vc.c \
-	prov/gni/test/wait.c
+	prov/gni/test/wait.c \
+	prov/gni/test/common.c
 
 prov_gni_test_gnitest_LDFLAGS = $(CRAY_PMI_LIBS) -static
 prov_gni_test_gnitest_CPPFLAGS = $(AM_CPPFLAGS) $(CRAY_PMI_CFLAGS)

--- a/prov/gni/test/bitmap.c
+++ b/prov/gni/test/bitmap.c
@@ -43,6 +43,7 @@
 
 #include <rdma/fi_errno.h>
 #include <gnix_bitmap.h>
+#include "common.h"
 
 #include <criterion/criterion.h>
 
@@ -77,18 +78,6 @@ static inline uint64_t __gnix_load_block(gnix_bitmap_t *bitmap, int index)
 	return ret;
 }
 #endif
-
-void calculate_time_difference(struct timeval *start, struct timeval *end,
-		int *secs_out, int *usec_out)
-{
-	*secs_out = end->tv_sec - start->tv_sec;
-	if (end->tv_usec < start->tv_usec) {
-		*secs_out = *secs_out - 1;
-		*usec_out = (1000000 + end->tv_usec) - start->tv_usec;
-	} else {
-		*usec_out = end->tv_usec - start->tv_usec;
-	}
-}
 
 void __gnix_bitmap_test_setup(void)
 {

--- a/prov/gni/test/common.c
+++ b/prov/gni/test/common.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2015 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "common.h"
+
+void calculate_time_difference(struct timeval *start, struct timeval *end,
+		int *secs_out, int *usec_out)
+{
+	*secs_out = end->tv_sec - start->tv_sec;
+	if (end->tv_usec < start->tv_usec) {
+		*secs_out = *secs_out - 1;
+		*usec_out = (1000000 + end->tv_usec) - start->tv_usec;
+	} else {
+		*usec_out = end->tv_usec - start->tv_usec;
+	}
+}

--- a/prov/gni/test/common.h
+++ b/prov/gni/test/common.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2015 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef PROV_GNI_TEST_COMMON_H_
+#define PROV_GNI_TEST_COMMON_H_
+
+#include <time.h>
+#include <stdint.h>
+#include <sys/time.h>
+
+void calculate_time_difference(struct timeval *start, struct timeval *end,
+		int *secs_out, int *usec_out);
+
+#endif /* PROV_GNI_TEST_COMMON_H_ */


### PR DESCRIPTION
Adds four tests for measuring the four cases of performance for the cache. 

Best case repeated('repeated_registration') tests repeated registration of the same memory region.
Best case overlapping('single_large_registration') tests registration of different regions that are covered by a single larger registration, which _should_ be a best case for the cache. 

The worst case ('non_overlapping_registration') test measures the affects of always registering new memory with the NIC. 

The random ('random_analysis') test measures performance of random registrations over a single region of varying base addresses and lengths. This is intended to test internal structure balancing.

@sungeunchoi @ztiffany @hppritcha 
