### PR TITLE
prov/gni: fix up error handling in mbox allocator

### DIFF
--- a/prov/gni/src/gnix_mbox_allocator.c
+++ b/prov/gni/src/gnix_mbox_allocator.c
@@ -387,7 +387,6 @@ static int __create_slab(struct gnix_mbox_alloc_handle *handle)
 
 err_memregister:
 	_gnix_free_bitmap(slab->used);
-	free(slab->used);
 err_alloc_bitmap:
 	munmap(slab->base, total_size);
 err_mmap:


### PR DESCRIPTION
some experimenting for async progress feature revealed
a bug in the clean path for a method in the mbox allocator
when the GNI_MemRegister failed.

@jswaro 

Signed-off-by: Howard Pritchard howardp@lanl.gov
