### PR TITLE
prov/gni: properly initialize atomic variable

### DIFF
--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -768,6 +768,7 @@ ssize_t _gnix_rma(struct gnix_fid_ep *ep, enum gnix_fab_req_type fr_type,
 	req->vc = vc;
 	req->user_context = context;
 	req->work_fn = _gnix_rma_post_req;
+	atomic_initialize(&req->rma.outstanding_txds, 0);
 
 	if (fr_type == GNIX_FAB_RQ_RDMA_READ &&
 	    (rem_addr & GNI_READ_ALIGN_MASK || len & GNI_READ_ALIGN_MASK)) {


### PR DESCRIPTION
An atomic variable used in rma fab reqs wasn't
getting properly initialized, resulting in
criterion test aborts when libfabric was built
with --enable-debug option.

@ztiffany 
@sungeunchoi  - may want to pull this in for @bcernohous  hang problem

Signed-off-by: Howard Pritchard howardp@lanl.gov
