### PR TITLE
prov/gni: disable criterion config for dist

### DIFF
--- a/prov/gni/configure.m4
+++ b/prov/gni/configure.m4
@@ -37,32 +37,36 @@ AC_DEFUN([FI_GNI_CONFIGURE],[
 	       ])
 
 	have_criterion=false
+	criterion_tests_present=true
 
-	AC_ARG_WITH([criterion],
-		[AS_HELP_STRING([--with-criterion],
-			       [Location for criterion unit testing framework])])
+	AS_IF([test -d $srcdir/prov/gni/test],
+	      [AC_ARG_WITH([criterion], [AS_HELP_STRING([--with-criterion],
+		       [Location for criterion unit testing framework])])],
+		 	[criterion_tests_present=false])
 
 	if test "$with_criterion" != "" && test "$with_criterion" != "no"; then
-		AC_MSG_CHECKING([criterion path])
-		if test -d "$with_criterion"; then
-			AC_MSG_RESULT([yes])
-			CPPFLAGS="-I$with_criterion/include $CPPFLAGS"
-			if test -d "$with_criterion/lib"; then
-				LDFLAGS="$CRAY_ALPS_LLI_STATIC_LIBS -L$with_criterion/lib $LDFLAGS"
-				have_criterion=true
-			elif test -d "$with_criterion/lib64"; then
-				LDFLAGS="$CRAY_ALPS_LLI_STATIC_LIBS -L$with_criterion/lib64 $LDFLAGS"
-				have_criterion=true
+		AS_IF([test "$criterion_tests_present" = "true"],
+			[AC_MSG_CHECKING([criterion path])
+			 if test -d "$with_criterion"; then
+				AC_MSG_RESULT([yes])
+				CPPFLAGS="-I$with_criterion/include $CPPFLAGS"
+				if test -d "$with_criterion/lib"; then
+					LDFLAGS="$CRAY_ALPS_LLI_STATIC_LIBS -L$with_criterion/lib $LDFLAGS"
+					have_criterion=true
+				elif test -d "$with_criterion/lib64"; then
+					LDFLAGS="$CRAY_ALPS_LLI_STATIC_LIBS -L$with_criterion/lib64 $LDFLAGS"
+					have_criterion=true
+				else
+					have_criterion=false
+				fi
+				FI_PKG_CHECK_MODULES([CRAY_PMI], [cray-pmi],
+						   [],
+						   [have_criterion=false])
 			else
-				have_criterion=false
-			fi
-			FI_PKG_CHECK_MODULES([CRAY_PMI], [cray-pmi],
-					   [],
-					   [have_criterion=false])
-		else
-			AC_MSG_RESULT([no])
-			AC_MSG_ERROR([criterion requested but invalid path given])
-		fi
+				AC_MSG_RESULT([no])
+				AC_MSG_ERROR([criterion requested but invalid path given])
+			fi],
+			[AC_MSG_ERROR([criterion requested tests not available])])
 	fi
 
 	AM_CONDITIONAL([HAVE_CRITERION], [test "x$have_criterion" = "xtrue"])


### PR DESCRIPTION
The criterion tests are not included in the dist
tarball.  Modify configury to report an error
at configure time if --with-criterion option is
supplied when building from a dist tarball rather
than failing during make.

@sungeunchoi 

Signed-off-by: Howard Pritchard howardp@lanl.gov
