### PR TITLE
prov/gni: check for GNI_VERSION_FMA_CHAIN_TRANS

### DIFF
--- a/prov/gni/configure.m4
+++ b/prov/gni/configure.m4
@@ -41,6 +41,17 @@ AC_DEFUN([FI_GNI_CONFIGURE],[
                                  [alps_util_happy=0])
 	       ])
 
+       gni_path_to_gni_pub=${CRAY_GNI_HEADERS_CFLAGS:2}
+dnl looks like we need to get rid of some white space
+       gni_path_to_gni_pub=${gni_path_to_gni_pub%?}/gni_pub.h
+
+       AC_CHECK_DECLS([GNI_VERSION_FMA_CHAIN_TRANSACTIONS],
+                       [],
+                       [AC_MSG_WARN([GNI provider requires CLE 5.2UP04 or higher. Disabling gni provider.])
+                       gni_header_happy=0
+                       ],
+                       [[#include "$gni_path_to_gni_pub"]])
+
 	# Pull out gcc version number with regex backreference
 	gcc_version=`gcc --version | head -n1 | sed 's/.*\([[0-9]]\.[[0-9]]\.[[0-9]]\).*/\1/'`
 	if [[ "$gcc_version" \< "$GNI_GCC_VERSION" ]]; then


### PR DESCRIPTION
The GNI provider is making use of chained FMA post
operations, a feature than is only available in
CLE 5.2UP04 and newer.  Check for the presence
of a sentinel macro GNI_VERSION_FMA_CHAIN_TRANSACTIONS
in gni_pub.h. Configure GNI provider off if this
sentinel is not found in gni_pub.h

@e-harvey 
@sungeunchoi 

Fixes #553
