### PR TITLE
prov/gni/src: Fixed "HAVE_ATOMICS" build warnings.

### DIFF
--- a/prov/gni/include/gnix_bitmap.h
+++ b/prov/gni/include/gnix_bitmap.h
@@ -26,7 +26,7 @@
 
 typedef uint64_t gnix_bitmap_value_t;
 
-#if HAVE_ATOMICS
+#ifdef HAVE_ATOMICS
 #include <stdatomic.h>
 
 typedef atomic_uint_fast64_t gnix_bitmap_block_t;

--- a/prov/gni/src/gnix_bitmap.c
+++ b/prov/gni/src/gnix_bitmap.c
@@ -10,7 +10,7 @@
 
 #include "gnix_bitmap.h"
 
-#if HAVE_ATOMICS
+#ifdef HAVE_ATOMICS
 
 #define __gnix_init_block(block) atomic_init(block, 0)
 #define __gnix_set_block(bitmap, index, value) \
@@ -265,4 +265,3 @@ int _gnix_free_bitmap(gnix_bitmap_t *bitmap)
 
 	return 0;
 }
-


### PR DESCRIPTION
Fixes "...warning: "HAVE_ATOMICS" is not defined" when building with gcc 4.3.4.
@sungeunchoi 
