### PR TITLE
prov/gni: Implement FI_MULTI_RECV

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -128,7 +128,7 @@ extern "C" {
 #define GNIX_RMA_CHAINED		(1ULL << 63)	/* RMA only flag */
 
 #define GNIX_MSG_RENDEZVOUS		(1ULL << 61)	/* MSG only flag */
-#define GNIX_MSG_DOUBLE_GET		(1ULL << 62)	/* MSG only flag */
+#define GNIX_MSG_GET_TAIL		(1ULL << 62)	/* MSG only flag */
 
 /*
  * Cray gni provider supported flags for fi_getinfo argument for now, needs
@@ -365,6 +365,7 @@ struct gnix_fid_ep {
 	int enabled;
 	int send_selective_completion;
 	int recv_selective_completion;
+	int min_multi_recv;
 	/* note this free list will be initialized for thread safe */
 	struct gnix_s_freelist fr_freelist;
 	struct gnix_reference ref_cnt;

--- a/prov/gni/include/gnix_ep.h
+++ b/prov/gni/include/gnix_ep.h
@@ -37,6 +37,9 @@
 #include "gnix.h"
 #include "gnix_nic.h"
 
+/* Default minimum multi receive buffer size. */
+#define GNIX_OPT_MIN_MULTI_RECV_DEFAULT	64
+
 /*
  * enum of tags used for GNI_SmsgSendWTag
  * and callbacks at receive side to process

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -1408,6 +1408,8 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 		ep_priv->op_flags |= info->rx_attr->op_flags;
 	ep_priv->op_flags &= GNIX_EP_OP_FLAGS;
 
+	ep_priv->min_multi_recv = GNIX_OPT_MIN_MULTI_RECV_DEFAULT;
+
 	ret = __fr_freelist_init(ep_priv);
 	if (ret != FI_SUCCESS) {
 		GNIX_WARN(FI_LOG_EP_CTRL,


### PR DESCRIPTION
-Match several send requests to a single receive request.
-Use req->send_len consistently to hold the real number of bytes to be moved.
-Test for truncated, unaligned send buffer earlier to allow send_len to hold
actual number of bytes moved.
-Use req->send_len to fill a CQ entry's length field.
-Rename GNIX_MSG_DOUBLE_GET to GNIX_MSG_GET_TAIL for clarity.

Fixes ofi-cray/libfabric-cray#580.

Signed-off-by: Zach Tiffany ztiffany@cray.com

@hppritcha @sungeunchoi @jswaro @chuckfossen 
