### PR TITLE
prov/gni: add --ntasks=1 to run_gnitest script

### DIFF
--- a/prov/gni/test/run_gnitest
+++ b/prov/gni/test/run_gnitest
@@ -54,7 +54,7 @@ if [ ! -f "$gnitest_bin" ]; then
 fi
 
 if [ $launcher = "srun" ]; then
-    args="-N1 --exclusive --cpu_bind=none -t00:10:00"
+    args="-N1 --exclusive --cpu_bind=none -t00:10:00 --ntasks=1"
 else
     args="-n1 -N1 -j0 -cc none -t600"
 fi


### PR DESCRIPTION
Turns out when using a persistently allocated
allocation for slurm (using salloc), that the
--ntasks argument needs to be present on srun
line.

@sungeunchoi 

Signed-off-by: Howard Pritchard howardp@lanl.gov
