### PR TITLE
prov/gni:config - add war for a bug in gni

### DIFF
--- a/prov/gni/configure.m4
+++ b/prov/gni/configure.m4
@@ -46,10 +46,19 @@ dnl looks like we need to get rid of some white space
 
        AC_CHECK_DECLS([GNI_VERSION_FMA_CHAIN_TRANSACTIONS],
                        [],
-                       [AC_MSG_WARN([GNI provider requires CLE 5.2UP04 or higher. Disabling gni provider.])
+                       [AC_MSG_WARN([GNI provider requires CLE 5.2.UP04 or higher. Disabling gni provider.])
                        gni_header_happy=0
                        ],
                        [[#include "$gni_path_to_gni_pub"]])
+
+dnl unfortunately GNI_VERSION_FMA_CHAIN_TRANSACTIONS has an issue with CLE 5.2UP03
+        if test -f /etc/opt/cray/release/clerelease; then
+            cle_52up03_check=`grep 5.2.UP03 /etc/opt/cray/release/clerelease`
+            AS_IF([test "$cle_52up03_check" = "5.2.UP03"],
+                  [gni_header_happy=0
+                   AC_MSG_WARN([GNI provider requires CLE 5.2.UP04 or higher. Disabling gni provider.])
+                  ],[])
+        fi
 
 	have_criterion=false
 	criterion_tests_present=true


### PR DESCRIPTION
Well it turns out that gni_pub.h isn't entirely
accurate about `GNI_CtPostFma`.  It turns out some
of the functionality was implemented in CLE 5.2UP03,
but not what is currently needed by the GNI provider.
So the sentinel check GNI_VERSION_FMA_CHAIN_TRANSACTIONS
only partly works, screening out CLE5.2UP02 and older
but not the problem with CLE 5.2UP03.

Add a hack workaround to check for this CLE release and
if that's what installed, don't currently build the GNI
provider.

@sungeunchoi 

Signed-off-by: Howard Pritchard howardp@lanl.gov
