### PR TITLE
Small fix-ups

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -42,6 +42,7 @@ extern "C" {
 #include <config.h>
 #endif /* HAVE_CONFIG_H */
 
+#include <stdlib.h>
 #include <stdbool.h>
 
 #include <rdma/fabric.h>

--- a/prov/gni/include/gnix_tags.h
+++ b/prov/gni/include/gnix_tags.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -60,6 +60,7 @@
 #ifndef PROV_GNI_SRC_GNIX_TAGS_H_
 #define PROV_GNI_SRC_GNIX_TAGS_H_
 
+#include <stdlib.h>
 #include <fi.h>
 #include <fi_list.h>
 

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -1755,7 +1755,6 @@ struct fi_ops_tagged gnix_ep_tagged_ops = {
 	.sendv = gnix_ep_tsendv,
 	.sendmsg = gnix_ep_tsendmsg,
 	.inject = gnix_ep_tinject,
-	.senddata = fi_no_tagged_senddata,
 	.senddata = gnix_ep_tsenddata,
 	.injectdata = fi_no_tagged_injectdata,
 };

--- a/prov/gni/test/av.c
+++ b/prov/gni/test/av.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -33,6 +33,7 @@
 
 #include <stdio.h>
 #include <stddef.h>
+#include <stdlib.h>
 
 #include "fi.h"
 #include "rdma/fi_domain.h"

--- a/prov/gni/test/cntr.c
+++ b/prov/gni/test/cntr.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -378,10 +378,7 @@ static void do_write(int len)
 
 
 	old_w_cnt = fi_cntr_read(write_cntr);
-	cr_assert(old_w_cnt >= 0);
-
 	old_r_cnt = fi_cntr_read(read_cntr);
-	cr_assert(old_r_cnt >= 0);
 
 	sz = fi_write(ep[0], source, len,
 			 loc_mr, gni_addr[1], (uint64_t)target, mr_key,
@@ -390,7 +387,6 @@ static void do_write(int len)
 
 	do {
 		new_w_cnt = fi_cntr_read(write_cntr);
-		cr_assert(new_w_cnt >= 0);
 		if (new_w_cnt == (old_w_cnt + 1))
 			break;
 		pthread_yield();
@@ -399,7 +395,6 @@ static void do_write(int len)
 	cr_assert(check_data(source, target, len), "Data mismatch");
 
 	new_r_cnt = fi_cntr_read(read_cntr);
-	cr_assert(new_r_cnt >= 0);
 
 	/*
 	 * no fi_read called so old and new read cnts should be equal
@@ -424,10 +419,7 @@ static void do_write_wait(int len)
 	init_data(target, len, 0);
 
 	old_w_cnt = fi_cntr_read(write_cntr);
-	cr_assert(old_w_cnt >= 0);
-
 	old_r_cnt = fi_cntr_read(read_cntr);
-	cr_assert(old_r_cnt >= 0);
 
 	for (i = 0; i < iters; i++) {
 		sz = fi_write(ep[0], source, len,
@@ -443,7 +435,6 @@ static void do_write_wait(int len)
 	cr_assert(check_data(source, target, len), "Data mismatch");
 
 	new_r_cnt = fi_cntr_read(read_cntr);
-	cr_assert(new_r_cnt >= 0);
 
 	/*
 	 * no fi_read called so old and new read cnts should be equal
@@ -467,10 +458,7 @@ static void do_read(int len)
 	init_data(target, len, 0xad);
 
 	old_w_cnt = fi_cntr_read(write_cntr);
-	cr_assert(old_w_cnt >= 0);
-
 	old_r_cnt = fi_cntr_read(read_cntr);
-	cr_assert(old_r_cnt >= 0);
 
 	sz = fi_read(ep[0], source, len,
 			loc_mr, gni_addr[1], (uint64_t)target, mr_key,
@@ -479,7 +467,6 @@ static void do_read(int len)
 
 	do {
 		new_r_cnt = fi_cntr_read(read_cntr);
-		cr_assert(new_r_cnt >= 0);
 		if (new_r_cnt == (old_r_cnt + 1))
 			break;
 		pthread_yield();
@@ -488,7 +475,6 @@ static void do_read(int len)
 	cr_assert(check_data(source, target, len), "Data mismatch");
 
 	new_w_cnt = fi_cntr_read(write_cntr);
-	cr_assert(new_w_cnt >= 0);
 
 	/*
 	 * no fi_read called so old and new read cnts should be equal
@@ -508,10 +494,7 @@ static void do_read_wait(int len)
 	init_data(target, len, 0xad);
 
 	old_w_cnt = fi_cntr_read(write_cntr);
-	cr_assert(old_w_cnt >= 0);
-
 	old_r_cnt = fi_cntr_read(read_cntr);
-	cr_assert(old_r_cnt >= 0);
 
 	for (i = 0; i < iters; i++) {
 		sz = fi_read(ep[0], source, len,
@@ -525,7 +508,6 @@ static void do_read_wait(int len)
 	cr_assert(check_data(source, target, len), "Data mismatch");
 
 	new_w_cnt = fi_cntr_read(write_cntr);
-	cr_assert(new_w_cnt >= 0);
 
 	/*
 	 * no fi_read called so old and new read cnts should be equal
@@ -554,10 +536,7 @@ Test(cntr, send_recv)
 	char s_buffer[128], r_buffer[128];
 
 	old_s_cnt = fi_cntr_read(write_cntr);
-	cr_assert(old_s_cnt >= 0);
-
 	old_r_cnt = fi_cntr_read(rcv_cntr);
-	cr_assert(old_r_cnt >= 0);
 
 	for (i = 0; i < 16; i++) {
 		sprintf(s_buffer, "Hello there iter=%d", i);

--- a/prov/gni/test/dlist-utils.c
+++ b/prov/gni/test/dlist-utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -32,6 +32,8 @@
 
 #include <stdio.h>
 #include <sys/time.h>
+#include <stdlib.h>
+
 #include <fi_list.h>
 
 #include "gnix_util.h"

--- a/prov/gni/test/eq.c
+++ b/prov/gni/test/eq.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -30,6 +30,8 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+#include <stdlib.h>
 
 #include "gnix_eq.h"
 #include "gnix.h"

--- a/prov/gni/test/queue.c
+++ b/prov/gni/test/queue.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -30,6 +30,8 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+#include <stdlib.h>
 
 #include "gnix_queue.h"
 

--- a/prov/gni/test/rdm_atomic.c
+++ b/prov/gni/test/rdm_atomic.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -1601,7 +1601,7 @@ Test(rdm_atomic, atomicinject)
 	loops = 0;
 	while (*((int64_t *)target) != min) {
 		ret = fi_cq_read(send_cq[0], &cqe, 1); /* for progress */
-		cr_assert(ret == -EAGAIN,
+		cr_assert(ret == -FI_EAGAIN,
 			  "Received unexpected event\n");
 
 		pthread_yield();
@@ -1622,7 +1622,7 @@ Test(rdm_atomic, atomicinject)
 	loops = 0;
 	while (*((int64_t *)target) != min) {
 		ret = fi_cq_read(send_cq[0], &cqe, 1); /* for progress */
-		cr_assert(ret == -EAGAIN,
+		cr_assert(ret == -FI_EAGAIN,
 			  "Received unexpected event\n");
 
 		pthread_yield();
@@ -1642,7 +1642,7 @@ Test(rdm_atomic, atomicinject)
 	loops = 0;
 	while (*((float *)target) != min_fp) {
 		ret = fi_cq_read(send_cq[0], &cqe, 1); /* for progress */
-		cr_assert(ret == -EAGAIN,
+		cr_assert(ret == -FI_EAGAIN,
 			  "Received unexpected event\n");
 
 		pthread_yield();
@@ -1662,7 +1662,7 @@ Test(rdm_atomic, atomicinject)
 	loops = 0;
 	while (*((double *)target) != min_dp) {
 		ret = fi_cq_read(send_cq[0], &cqe, 1); /* for progress */
-		cr_assert(ret == -EAGAIN,
+		cr_assert(ret == -FI_EAGAIN,
 			  "Received unexpected event\n");
 
 		pthread_yield();

--- a/prov/gni/test/rdm_rma.c
+++ b/prov/gni/test/rdm_rma.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -687,7 +687,7 @@ void do_inject_write(int len)
 		while (source[i] != target[i]) {
 			/* for progress */
 			ret = fi_cq_read(send_cq[0], &cqe, 1);
-			cr_assert(ret == -EAGAIN,
+			cr_assert(ret == -FI_EAGAIN,
 				  "Received unexpected event\n");
 
 			pthread_yield();
@@ -776,7 +776,7 @@ void do_inject_writedata(int len)
 		while (source[i] != target[i]) {
 			/* for progress */
 			ret = fi_cq_read(send_cq[0], &cqe, 1);
-			cr_assert(ret == -EAGAIN,
+			cr_assert(ret == -FI_EAGAIN,
 				  "Received unexpected event\n");
 
 			pthread_yield();


### PR DESCRIPTION
Fix little things including all warnings when compiling --enable-debug:
- #include <stdlib.h> for malloc
- double initialized field
- unnecessary cr_asserts in cnt tests
- Change -EAGAIN to -FI_EAGAIN in rdm_rma and rdm_atomic tests

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com

Closes #610 

@hppritcha @ztiffany @jshimek @e-harvey @jswaro @chuckfossen 
