### PR TITLE
prov/gni: Fix race in multi-recv tests

### DIFF
--- a/prov/gni/test/rdm_sr.c
+++ b/prov/gni/test/rdm_sr.c
@@ -354,7 +354,9 @@ void rdm_sr_check_cqe(struct fi_cq_tagged_entry *cqe, void *ctx,
 
 	if (flags & FI_RECV) {
 		cr_assert(cqe->len == len, "CQE length mismatch");
-		cr_assert(cqe->buf == addr, "CQE address mismatch");
+
+		if (!(flags & FI_MULTI_RECV))
+			cr_assert(cqe->buf == addr, "CQE address mismatch");
 
 		if (flags & FI_REMOTE_CQ_DATA)
 			cr_assert(cqe->data == data, "CQE data mismatch");


### PR DESCRIPTION
CQ events can arrive out of order in the FI_MULTI_RECV unit tests, making it
difficult to predict the address in a CQE.  Disable buf field validation in
FI_MULTI_RECV CQEs.

Signed-off-by: Zach Tiffany ztiffany@cray.com

@sungeunchoi 
