### PR TITLE
Added parens in the reference counting macros

### DIFF
--- a/prov/gni/include/gnix_util.h
+++ b/prov/gni/include/gnix_util.h
@@ -222,14 +222,14 @@ struct gnix_reference {
  */
 #define __ref_get(ptr, var) \
 	({ \
-		struct gnix_reference *ref = &ptr->var; \
+		struct gnix_reference *ref = &(ptr)->var; \
 		int references_held = atomic_inc(&ref->references); \
 		assert(references_held > 0); \
 		references_held; })
 
 #define __ref_put(ptr, var) \
 	({ \
-		struct gnix_reference *ref = &ptr->var; \
+		struct gnix_reference *ref = &(ptr)->var; \
 		int references_held = atomic_dec(&ref->references); \
 		assert(references_held >= 0); \
 		if (references_held == 0) \


### PR DESCRIPTION
Without the appropriate parens, it is possible to have garble the
input in the macro such that it returns code that can't be compiled. This commit
adds the appropriate parens to prevent such behavior

closes #625
