### PR TITLE
Only retrieve debug strings if log enabled

### DIFF
--- a/prov/gni/include/gnix_util.h
+++ b/prov/gni/include/gnix_util.h
@@ -73,36 +73,38 @@ extern atomic_t gnix_debug_next_tid;
  * unique thread id.  Do not use them directly.  Rather use the normal
  * GNIX_* macros.
  */
-#define GNIX_LOG_INTERNAL(FI_LOG_FN, subsystem, fmt, ...)	\
-	do {							\
-		const int fmt_len = 256;			\
-		char new_fmt[fmt_len];				\
-		if (gnix_debug_tid  == ~(uint32_t) 0) {		\
-			gnix_debug_tid = atomic_inc(&gnix_debug_next_tid); \
-		}						\
-		if (gnix_debug_pid == ~(uint32_t) 0) {		\
-			gnix_debug_pid = getpid();		\
-		}						\
-		snprintf(new_fmt, fmt_len, "[%%d:%%d] %s", fmt);	\
-		FI_LOG_FN(&gnix_prov, subsystem, new_fmt,		\
-			  gnix_debug_pid, gnix_debug_tid, ##__VA_ARGS__); \
+#define GNIX_LOG_INTERNAL(FI_LOG_FN, LEVEL, subsystem, fmt, ...)	\
+	do {	\
+		if (fi_log_enabled(&gnix_prov, LEVEL, subsystem)) { \
+			const int fmt_len = 256;			\
+			char new_fmt[fmt_len];				\
+			if (gnix_debug_tid  == ~(uint32_t) 0) {		\
+				gnix_debug_tid = atomic_inc(&gnix_debug_next_tid); \
+			}						\
+			if (gnix_debug_pid == ~(uint32_t) 0) {		\
+				gnix_debug_pid = getpid();		\
+			}						\
+			snprintf(new_fmt, fmt_len, "[%%d:%%d] %s", fmt);	\
+			FI_LOG_FN(&gnix_prov, subsystem, new_fmt,		\
+				  gnix_debug_pid, gnix_debug_tid, ##__VA_ARGS__); \
+		} \
 	} while (0)
 
 #endif
 
 #define GNIX_WARN(subsystem, ...)                                              \
-	GNIX_LOG_INTERNAL(FI_WARN, subsystem, __VA_ARGS__)
+	GNIX_LOG_INTERNAL(FI_WARN, FI_LOG_WARN, subsystem, __VA_ARGS__)
 #define GNIX_TRACE(subsystem, ...)                                             \
-	GNIX_LOG_INTERNAL(FI_TRACE, subsystem, __VA_ARGS__)
+	GNIX_LOG_INTERNAL(FI_TRACE, FI_LOG_TRACE, subsystem, __VA_ARGS__)
 #define GNIX_INFO(subsystem, ...)                                              \
-	GNIX_LOG_INTERNAL(FI_INFO, subsystem, __VA_ARGS__)
+	GNIX_LOG_INTERNAL(FI_INFO, FI_LOG_INFO, subsystem, __VA_ARGS__)
 #define GNIX_DEBUG(subsystem, ...)                                             \
-	GNIX_LOG_INTERNAL(FI_DBG, subsystem, __VA_ARGS__)
+	GNIX_LOG_INTERNAL(FI_DBG, FI_LOG_DEBUG, subsystem, __VA_ARGS__)
 #define GNIX_ERR(subsystem, ...)                                               \
-	GNIX_LOG_INTERNAL(GNIX_FI_PRINT, subsystem, __VA_ARGS__)
+	GNIX_LOG_INTERNAL(GNIX_FI_PRINT, FI_LOG_WARN, subsystem, __VA_ARGS__)
 #define GNIX_FATAL(subsystem, ...)                                             \
 	do { \
-		GNIX_LOG_INTERNAL(GNIX_FI_PRINT, subsystem, __VA_ARGS__); \
+		GNIX_LOG_INTERNAL(GNIX_FI_PRINT, FI_LOG_WARN, subsystem, __VA_ARGS__); \
 		abort(); \
 	} while (0)
 


### PR DESCRIPTION
Performance could drop by as much as 80% in debug
builds due to the unconditional calls of sprintf
and atomic functions. This commit adds the FI_LOG_*
levels to the GNIX_\* log calls and passes those log
levels to the fi_log_enabled function

Signed-off-by: James Swaro jswaro@cray.com

closes #596 
