### PR TITLE
prov/gni: Added stressor tests for the buddy allocator.

### DIFF
--- a/prov/gni/include/gnix_buddy_allocator.h
+++ b/prov/gni/include/gnix_buddy_allocator.h
@@ -1,6 +1,7 @@
 /*
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All
+ * rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -75,13 +76,10 @@ static inline uint32_t __gnix_buddy_log2(uint32_t v)
 			      (LEN))
 
 /* Find the bitmap index for block X of size X_LEN */
-#define BITMAP_INDEX(X,\
-		     X_LEN,\
-		     BASE,\
-		     BASE_LEN,\
-		     MIN_LEN) (((size_t) ((X) - (BASE)) / (size_t) (X_LEN)) + \
-			       (BASE_LEN) / ((MIN_LEN) / 2) - (BASE_LEN) / \
-			       ((X_LEN) / 2))
+#define BITMAP_INDEX(X, X_LEN, BASE, BASE_LEN, MIN_LEN) (((size_t) ((X) - (BASE)) / \
+							  (size_t) (X_LEN)) + (BASE_LEN) / \
+							 ((MIN_LEN) / 2) - (BASE_LEN) / \
+							 ((X_LEN) / 2))
 
 /* Find the address of X's buddy block:
  * If the "index" of block X is even then the buddy must be to the right of X,

--- a/prov/gni/include/gnix_buddy_allocator.h
+++ b/prov/gni/include/gnix_buddy_allocator.h
@@ -74,10 +74,14 @@ static inline uint32_t __gnix_buddy_log2(uint32_t v)
 			      (IS_NOT_POW_TWO(LEN)) ? (((LEN) << 1) & ~(LEN)) :\
 			      (LEN))
 
-/* Find the bitmap index for block X */
-#define BITMAP_INDEX(X, BASE, MIN_LEN, LEN) ((size_t) ((X) - (BASE)) /\
-					     (MIN_LEN) + 2 * __gnix_buddy_log2\
-					     ((LEN) / (MIN_LEN)))
+/* Find the bitmap index for block X of size X_LEN */
+#define BITMAP_INDEX(X,\
+		     X_LEN,\
+		     BASE,\
+		     BASE_LEN,\
+		     MIN_LEN) (((size_t) ((X) - (BASE)) / (size_t) (X_LEN)) + \
+			       (BASE_LEN) / ((MIN_LEN) / 2) - (BASE_LEN) / \
+			       ((X_LEN) / 2))
 
 /* Find the address of X's buddy block:
  * If the "index" of block X is even then the buddy must be to the right of X,

--- a/prov/gni/src/gnix_buddy_allocator.c
+++ b/prov/gni/src/gnix_buddy_allocator.c
@@ -1,6 +1,7 @@
 /*
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All
+ * rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/prov/gni/src/gnix_buddy_allocator.c
+++ b/prov/gni/src/gnix_buddy_allocator.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -121,7 +121,7 @@ static inline int __gnix_buddy_create_lists(gnix_buddy_alloc_handle_t
 	uint32_t i, offset = 0;
 
 	alloc_handle->nlists = (uint32_t) __gnix_buddy_log2(alloc_handle->max /
-					       MIN_BLOCK_SIZE) + 1;
+							    MIN_BLOCK_SIZE) + 1;
 	alloc_handle->lists = calloc(1, sizeof(struct dlist_entry) *
 				     alloc_handle->nlists);
 
@@ -152,34 +152,24 @@ static inline int __gnix_buddy_create_lists(gnix_buddy_alloc_handle_t
 static inline void __gnix_buddy_split(gnix_buddy_alloc_handle_t *alloc_handle,
 				      uint32_t j, uint32_t i)
 {
-	void *tmp = NULL;
+	void *tmp = alloc_handle->lists[j].next;
 
-	dlist_remove(tmp = alloc_handle->lists[j].next);
-
-	_gnix_set_bit(&alloc_handle->bitmap,
-		      BITMAP_INDEX(tmp, alloc_handle->base, MIN_BLOCK_SIZE,
-				   OFFSET(MIN_BLOCK_SIZE, j)));
-
+	dlist_remove(tmp);
 
 	/* Split the block until we reach list "i" */
-	for (j--; j > i; j--) {
+	for (; j > i; j--) {
 		_gnix_set_bit(&alloc_handle->bitmap,
-			      BITMAP_INDEX(tmp +
+			      BITMAP_INDEX(tmp,
 					   OFFSET(MIN_BLOCK_SIZE, j),
 					   alloc_handle->base,
-					   MIN_BLOCK_SIZE,
-					   OFFSET(MIN_BLOCK_SIZE, j)));
+					   alloc_handle->len, MIN_BLOCK_SIZE));
 
-		dlist_insert_tail(tmp + OFFSET(MIN_BLOCK_SIZE, j),
-				  alloc_handle->lists + j);
+		dlist_insert_tail(tmp + OFFSET(MIN_BLOCK_SIZE, j - 1),
+				  alloc_handle->lists + j - 1);
 	}
 
 	/* Insert last block into list "i" */
 	dlist_insert_head(tmp, alloc_handle->lists + j);
-
-	/* Insert the buddy block of tmp into list "i" */
-	dlist_insert_tail(tmp + OFFSET(MIN_BLOCK_SIZE, j),
-			  alloc_handle->lists + j);
 }
 
 /**
@@ -216,9 +206,10 @@ static inline void __gnix_buddy_coalesce(gnix_buddy_alloc_handle_t *alloc_handle
 	       !_gnix_test_bit(&alloc_handle->bitmap,
 			       BITMAP_INDEX(BUDDY(*ptr, *block_size,
 						  alloc_handle->base),
+					    *block_size,
 					    alloc_handle->base,
-					    MIN_BLOCK_SIZE,
-					    *block_size))) {
+					    alloc_handle->len,
+					    MIN_BLOCK_SIZE))) {
 
 		dlist_remove(BUDDY(*ptr, *block_size, alloc_handle->base));
 
@@ -230,10 +221,11 @@ static inline void __gnix_buddy_coalesce(gnix_buddy_alloc_handle_t *alloc_handle
 		*block_size *= 2;
 
 		_gnix_clear_bit(&alloc_handle->bitmap,
-				BITMAP_INDEX(*ptr, alloc_handle->base,
-					     MIN_BLOCK_SIZE, *block_size));
+				BITMAP_INDEX(*ptr, *block_size,
+					     alloc_handle->base,
+					     alloc_handle->len,
+					     MIN_BLOCK_SIZE));
 	}
-
 }
 
 int _gnix_buddy_allocator_create(void *base, uint32_t len, uint32_t max,
@@ -361,8 +353,8 @@ int _gnix_buddy_alloc(gnix_buddy_alloc_handle_t *alloc_handle, void **ptr,
 	fastlock_release(&alloc_handle->lock);
 
 	_gnix_set_bit(&alloc_handle->bitmap,
-		      BITMAP_INDEX(*ptr, alloc_handle->base, MIN_BLOCK_SIZE,
-				   block_size));
+		      BITMAP_INDEX(*ptr, block_size, alloc_handle->base,
+				   alloc_handle->len, MIN_BLOCK_SIZE));
 
 	return FI_SUCCESS;
 }
@@ -385,6 +377,10 @@ int _gnix_buddy_free(gnix_buddy_alloc_handle_t *alloc_handle, void *ptr,
 
 	block_size = BLOCK_SIZE(len, MIN_BLOCK_SIZE);
 
+	_gnix_clear_bit(&alloc_handle->bitmap,
+			BITMAP_INDEX(ptr, block_size, alloc_handle->base,
+				     alloc_handle->len, MIN_BLOCK_SIZE));
+
 	fastlock_acquire(&alloc_handle->lock);
 
 	__gnix_buddy_coalesce(alloc_handle, &ptr, &block_size);
@@ -393,10 +389,6 @@ int _gnix_buddy_free(gnix_buddy_alloc_handle_t *alloc_handle, void *ptr,
 			  LIST_INDEX(block_size, MIN_BLOCK_SIZE));
 
 	fastlock_release(&alloc_handle->lock);
-
-	_gnix_clear_bit(&alloc_handle->bitmap,
-			BITMAP_INDEX(ptr, alloc_handle->base, MIN_BLOCK_SIZE,
-				     block_size));
 
 	return FI_SUCCESS;
 }

--- a/prov/gni/test/buddy_allocator.c
+++ b/prov/gni/test/buddy_allocator.c
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All
+ * rights reserved.
  * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/prov/gni/test/buddy_allocator.c
+++ b/prov/gni/test/buddy_allocator.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -32,22 +32,26 @@
 
 #include "gnix_buddy_allocator.h"
 #include <criterion/criterion.h>
+#include <time.h>
 
-#define LEN 1024 * 1024 	/* buddy_handle->len */
-#define MAX_LEN LEN / 1024	/* buddy_handle->max */
-#define MIN_LEN 16		/* buddy_handle->min */
+#define LEN (32 * 1024 * 1024)	/* buddy_handle->len */
+#define MAX_LEN (LEN / 2)	/* buddy_handle->max */
+#define MIN_LEN MIN_BLOCK_SIZE
 
 long *buf = NULL;		/* buddy_handle->base */
 gnix_buddy_alloc_handle_t *buddy_handle;
-void **ptr = NULL;		/* ptrs alloc'd by _gnix_buddy_alloc */
 
+struct ptrs_t {
+	void *ptr;		/* ptrs alloc'd by buddy_alloc */
+	uint32_t size;		/* size of the ptr */
+} *ptrs;
 
 void buddy_allocator_setup(void)
 {
 	int ret;
 
-	ptr = calloc(LEN / MIN_LEN, sizeof(void *));
-	cr_assert(ptr, "buddy_allocator_setup");
+	ptrs = calloc(LEN / MIN_LEN, sizeof(struct ptrs_t));
+	cr_assert(ptrs, "buddy_allocator_setup");
 
 	buf = calloc(LEN, sizeof(long));
 	cr_assert(buf, "buddy_allocator_setup");
@@ -63,7 +67,7 @@ void buddy_allocator_teardown(void)
 	ret = _gnix_buddy_allocator_destroy(buddy_handle);
 	cr_assert(!ret, "_gnix_buddy_allocator_destroy");
 
-	free(ptr);
+	free(ptrs);
 	free(buf);
 }
 
@@ -97,15 +101,17 @@ void buddy_allocator_teardown_error(void)
 	cr_assert_eq(ret, -FI_EINVAL);
 }
 
-void do_alloc(int len)
+/* Sequential alloc */
+void do_alloc(uint32_t len)
 {
-	int i = 0, ret;
+	uint32_t i = 0, ret;
 
 	/* Allocate all the memory and write to each block */
 	for (; i < LEN / len; i++) {
-		ret = _gnix_buddy_alloc(buddy_handle, ptr + i, len);
+		ptrs[i].size = len;
+		ret = _gnix_buddy_alloc(buddy_handle, &ptrs[i].ptr, len);
 		cr_assert(!ret, "_gnix_buddy_alloc");
-		memset(ptr[i], 0xffffffff, len);
+		memset(ptrs[i].ptr, 0, len);
 	}
 
 	/* Ensure that all free lists are empty */
@@ -115,13 +121,14 @@ void do_alloc(int len)
 	}
 }
 
-void do_free(int len)
+/* Sequential free */
+void do_free(uint32_t len)
 {
 	int i = 0, ret;
 
 	/* Free all allocated blocks */
-	for (; i < LEN / len; i++) {
-		ret = _gnix_buddy_free(buddy_handle, ptr[i], len);
+	for (i = 0; i < LEN / len; i++) {
+		ret = _gnix_buddy_free(buddy_handle, ptrs[i].ptr, ptrs[i].size);
 		cr_assert(!ret, "_gnix_buddy_free");
 	}
 
@@ -137,17 +144,69 @@ void do_free(int len)
 TestSuite(buddy_allocator, .init = buddy_allocator_setup,
 	  .fini = buddy_allocator_teardown, .disabled = false);
 
-Test(buddy_allocator, alloc_free)
+/* Sequential alloc and frees */
+Test(buddy_allocator, sequential_alloc_free)
 {
-	int i = MIN_LEN;
+	uint32_t i = MIN_LEN;
 
-	/* Sequential alloc and frees */
 	for (i = MIN_LEN; i <= MAX_LEN; i *= 2) {
 		do_alloc(i);
 		do_free(i);
 	}
+}
 
-	/* TODO: Random allocs and frees */
+/* Pseudo random allocs and frees */
+Test(buddy_allocator, random_alloc_free)
+{
+	int i = 0, j = 0, ret;
+
+	srand((unsigned) time(NULL));
+
+	for (j = MIN_LEN; j <= MAX_LEN; j *= 2) {
+		do {
+			ret = rand() % 100;
+
+			if (ret <= 49) {
+				/* ~50% chance to alloc min size blocks*/
+				ptrs[i].size = MIN_BLOCK_SIZE;
+			} else if (ret >= 50 &&
+				   ret <= 87) {
+				/* ~37% chance to alloc blocks of size
+				 * [MIN_BLOCK_SIZE * 2, MAX_BLOCK_SIZE / 2]
+				 */
+				ptrs[i].size = OFFSET(MIN_BLOCK_SIZE,
+						      (rand() %
+						       (buddy_handle->nlists -
+							1)) + 1);
+			} else {
+				/* ~13% chance to alloc max size blocks */
+				ptrs[i].size = buddy_handle->max;
+			}
+
+			ret = _gnix_buddy_alloc(buddy_handle, &ptrs[i].ptr,
+					  ptrs[i].size);
+			cr_assert_neq(ret, -FI_EINVAL);
+
+			i++;
+		} while (ret != -FI_ENOMEM);
+
+		/* Free all allocated blocks */
+		for (i -= 2; i >= 0; i--) {
+			ret = _gnix_buddy_free(buddy_handle, ptrs[i].ptr,
+					       ptrs[i].size);
+			cr_assert(!ret, "_gnix_buddy_free");
+		}
+
+		/* Ensure that every free list except the last is empty */
+		for (i = 0; i < buddy_handle->nlists - 1; i++) {
+			ret = dlist_empty(buddy_handle->lists + i);
+			cr_assert_eq(ret, 1);
+		}
+		ret = dlist_empty(buddy_handle->lists + i);
+		cr_assert_eq(ret, 0);
+
+		i = 0;
+	}
 }
 
 Test(buddy_allocator, alloc_free_error)
@@ -173,13 +232,13 @@ Test(buddy_allocator, parameter_error)
 	buddy_allocator_teardown_error();
 
 	/* BEGIN: Alloc, invalid parameters */
-	ret = _gnix_buddy_alloc(NULL, ptr, MAX_LEN);
+	ret = _gnix_buddy_alloc(NULL, ptrs->ptr, MAX_LEN);
 	cr_assert_eq(ret, -FI_EINVAL);
 
-	ret = _gnix_buddy_alloc(buddy_handle, ptr, MAX_LEN + 1);
+	ret = _gnix_buddy_alloc(buddy_handle, ptrs->ptr, MAX_LEN + 1);
 	cr_assert_eq(ret, -FI_EINVAL);
 
-	ret = _gnix_buddy_alloc(buddy_handle, ptr, 0);
+	ret = _gnix_buddy_alloc(buddy_handle, ptrs->ptr, 0);
 	cr_assert_eq(ret, -FI_EINVAL);
 
 	ret = _gnix_buddy_alloc(buddy_handle, NULL, MAX_LEN);
@@ -187,7 +246,7 @@ Test(buddy_allocator, parameter_error)
 	/* END: Alloc, invalid parameters */
 
 	/* BEGIN: Free, invalid parameters */
-	ret = _gnix_buddy_free(NULL, ptr, MAX_LEN);
+	ret = _gnix_buddy_free(NULL, ptrs->ptr, MAX_LEN);
 	cr_assert_eq(ret, -FI_EINVAL);
 
 	ret = _gnix_buddy_free(buddy_handle, NULL, MAX_LEN);


### PR DESCRIPTION
Added stressor test for the buddy allocator.  This test (random_alloc_free) does ~50% small allocations (16 bytes) ~37% medium allocations and ~13% large allocations (max block size) until the entire base block has been allocated.  The random_alloc_free test revealed bugs in the following macros and functions:
          \* BITMAP_INDEX
          \* buddy_free
          \* buddy_split
The BITMAP_INDEX macro and functions have been corrected.

@hppritcha @sungeunchoi 
