### PR TITLE
Remove unnecessary assert in gnix_cq_readfrom

### DIFF
--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -500,8 +500,6 @@ static ssize_t gnix_cq_readfrom(struct fid_cq *cq, void *buf, size_t count,
 	if (_gnix_queue_peek(cq_priv->errors))
 		return -FI_EAVAIL;
 
-	assert(buf);
-
 	fastlock_acquire(&cq_priv->lock);
 
 	while (_gnix_queue_peek(cq_priv->events) && count--) {


### PR DESCRIPTION
Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com

Fixes #646 (gnix_cq_readfrom actually behaved correctly, but there was an additional assert in there also)

@hppritcha 
