### PR TITLE
prov/gni: refactor cm nic code

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -298,6 +298,7 @@ struct gnix_fid_domain {
 	struct dlist_entry nic_list;
 	struct gnix_fid_fabric *fabric;
 	struct gnix_cm_nic *cm_nic;
+	fastlock_t cm_nic_lock;
 	uint8_t ptag;
 	uint32_t cookie;
 	uint32_t cdm_id_seed;

--- a/prov/gni/include/gnix_cm_nic.h
+++ b/prov/gni/include/gnix_cm_nic.h
@@ -45,10 +45,8 @@ typedef int gnix_cm_nic_rcv_cb_func(struct gnix_cm_nic *cm_nic,
 /**
  * @brief GNI provider connection management (cm) nic structure
  *
- * @var lock           spin lock for protecting calls in to GNI using
- *                     gni_nic_hndl
- * @var gni_cdm_hndl   underlying gni cdm handle associated with this nic
- * @var gni_nic_hndl   underlying gni nic handle associated with this nic
+ * @var lock           spin lock for protecting tx/rx ctx alloc calls
+ * @var nic            pointer to gnix_nic associated with this cm nic
  * @var dgram_hndl     handle to dgram allocator associated with this nic
  * @var domain         GNI provider domain associated with this nic
  * @var addr_to_ep_ht  Hash table for looking up ep bound to this
@@ -65,8 +63,7 @@ typedef int gnix_cm_nic_rcv_cb_func(struct gnix_cm_nic *cm_nic,
  */
 struct gnix_cm_nic {
 	fastlock_t lock;
-	gni_cdm_handle_t gni_cdm_hndl;
-	gni_nic_handle_t gni_nic_hndl;
+	struct gnix_nic *nic;
 	struct gnix_dgram_hndl *dgram_hndl;
 	struct gnix_fid_domain *domain;
 	struct gnix_hashtable *addr_to_ep_ht;

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -88,6 +88,8 @@ typedef int (*smsg_completer_fn_t)(void  *desc, gni_return_t);
 struct gnix_nic_attr {
 	gni_cdm_handle_t gni_cdm_hndl;
 	gni_nic_handle_t gni_nic_hndl;
+	bool use_cdm_id;
+	uint32_t cdm_id;
 };
 
 /**

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -517,6 +517,7 @@ int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 
 	domain->control_progress = info->domain_attr->control_progress;
 	domain->data_progress = info->domain_attr->data_progress;
+	fastlock_init(&domain->cm_nic_lock);
 
 	*dom = &domain->domain_fid;
 	return FI_SUCCESS;


### PR DESCRIPTION
Refactor the cm nic code as part of a campaign
to reduce use of Aries NIC resources per process.
This refactor now has the cm_nic embed a gnix_nic
struct.  The gnix_nic can then be reused for
RDMA network requests.  This also cuts down on
the number of HW CQs required per process.

@sungeunchoi 
@ztiffany 

Signed-off-by: Howard Pritchard howardp@lanl.gov
