### PR TITLE
prov/gni: Reduce runtime of buddy allocator unit tests.

### DIFF
--- a/prov/gni/include/gnix_buddy_allocator.h
+++ b/prov/gni/include/gnix_buddy_allocator.h
@@ -41,7 +41,7 @@
 #include "gnix_util.h"
 #include "gnix.h"
 
-#define MIN_BLOCK_SIZE 16
+#define MIN_BLOCK_SIZE 256
 
 /* The following table was taken from:
  * http://graphics.stanford.edu/~seander/bithacks.html#IntegerLogDeBruijn

--- a/prov/gni/test/buddy_allocator.c
+++ b/prov/gni/test/buddy_allocator.c
@@ -36,7 +36,7 @@
 #include <criterion/criterion.h>
 #include <time.h>
 
-#define LEN (32 * 1024 * 1024)	/* buddy_handle->len */
+#define LEN (1024 * 1024)	/* buddy_handle->len */
 #define MAX_LEN (LEN / 2)	/* buddy_handle->max */
 #define MIN_LEN MIN_BLOCK_SIZE
 


### PR DESCRIPTION
Reduce runtime of buddy allocator unit tests by:
- Reducing base block size
- Reducing min block size

@jswaro 
