### PR TITLE
prov/gni: fixes for cm lock issues

### DIFF
--- a/prov/gni/include/gnix_cm_nic.h
+++ b/prov/gni/include/gnix_cm_nic.h
@@ -45,7 +45,6 @@ typedef int gnix_cm_nic_rcv_cb_func(struct gnix_cm_nic *cm_nic,
 /**
  * @brief GNI provider connection management (cm) nic structure
  *
- * @var lock           spin lock for protecting tx/rx ctx alloc calls
  * @var nic            pointer to gnix_nic associated with this cm nic
  * @var dgram_hndl     handle to dgram allocator associated with this nic
  * @var domain         GNI provider domain associated with this nic
@@ -62,7 +61,6 @@ typedef int gnix_cm_nic_rcv_cb_func(struct gnix_cm_nic *cm_nic,
  * @var device_id      local Aries device id associated with this nic.
  */
 struct gnix_cm_nic {
-	fastlock_t lock;
 	struct gnix_nic *nic;
 	struct gnix_dgram_hndl *dgram_hndl;
 	struct gnix_fid_domain *domain;

--- a/prov/gni/src/gnix_cm_nic.c
+++ b/prov/gni/src/gnix_cm_nic.c
@@ -524,7 +524,6 @@ int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 	cm_nic->domain = domain;
 	cm_nic->ctrl_progress = domain->control_progress;
 	cm_nic->my_name.name_type = name_type;
-	fastlock_init(&cm_nic->lock);
 	fastlock_init(&cm_nic->wq_lock);
 	dlist_init(&cm_nic->cm_nic_wq);
 

--- a/prov/gni/src/gnix_datagram.c
+++ b/prov/gni/src/gnix_datagram.c
@@ -305,10 +305,11 @@ int _gnix_dgram_wc_post(struct gnix_datagram *d)
 {
 	int ret = FI_SUCCESS;
 	gni_return_t status;
+	struct gnix_nic *nic = d->cm_nic->nic;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
-	fastlock_acquire(&d->cm_nic->lock);
+	fastlock_acquire(&nic->lock);
 	status = GNI_EpPostDataWId(d->gni_ep,
 				   d->dgram_in_buf,
 				   GNI_DATAGRAM_MAXSIZE,
@@ -323,7 +324,7 @@ int _gnix_dgram_wc_post(struct gnix_datagram *d)
 		 */
 		d->state = GNIX_DGRAM_STATE_LISTENING;
 	}
-	fastlock_release(&d->cm_nic->lock);
+	fastlock_release(&nic->lock);
 
 	return ret;
 }
@@ -332,6 +333,7 @@ int _gnix_dgram_bnd_post(struct gnix_datagram *d)
 {
 	gni_return_t status = GNI_RC_SUCCESS;
 	int ret = FI_SUCCESS;
+	struct gnix_nic *nic = d->cm_nic->nic;
 	int post = 1;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
@@ -350,7 +352,7 @@ int _gnix_dgram_bnd_post(struct gnix_datagram *d)
 		goto err;
 	}
 
-	fastlock_acquire(&d->cm_nic->lock);
+	fastlock_acquire(&nic->lock);
 	if (d->pre_post_clbk_fn != NULL) {
 		ret = d->pre_post_clbk_fn(d, &post);
 		if (ret != FI_SUCCESS)
@@ -382,7 +384,8 @@ int _gnix_dgram_bnd_post(struct gnix_datagram *d)
 				ret);
 		}
 	}
-	fastlock_release(&d->cm_nic->lock);
+
+	fastlock_release(&nic->lock);
 
 	if (post) {
 		if ((status != GNI_RC_SUCCESS) &&

--- a/prov/gni/src/gnix_freelist.c
+++ b/prov/gni/src/gnix_freelist.c
@@ -69,7 +69,7 @@ static int __gnix_sfl_refill(struct gnix_s_freelist *fl, int n)
 	 * freeing.  Use an entire element, in case size was padded
 	 * for alignment
 	 */
-	elems = malloc((n+1)*fl->elem_size);
+	elems = calloc((n+1), fl->elem_size);
 	if (elems == NULL) {
 		ret = -FI_ENOMEM;
 		goto err;

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -1699,6 +1699,8 @@ int _gnix_vc_queue_work_req(struct gnix_fab_req *req)
 {
 	struct gnix_vc *vc = req->vc;
 
+	req->slist.next = NULL;  /* keep slist happy */
+
 	fastlock_acquire(&vc->work_queue_lock);
 	slist_insert_tail(&req->slist, &vc->work_queue);
 	__gnix_vc_work_schedule(vc);
@@ -2138,10 +2140,14 @@ int _gnix_vc_cm_init(struct gnix_cm_nic *cm_nic)
 {
 	int ret = FI_SUCCESS;
 	gnix_cm_nic_rcv_cb_func *ofunc = NULL;
+	struct gnix_nic *nic = NULL;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
-	fastlock_acquire(&cm_nic->lock);
+	nic = cm_nic->nic;
+	assert(nic != NULL);
+
+	fastlock_acquire(&nic->lock);
 	ret = _gnix_cm_nic_reg_recv_fn(cm_nic,
 					__gnix_vc_recv_fn,
 					&ofunc);
@@ -2151,7 +2157,7 @@ int _gnix_vc_cm_init(struct gnix_cm_nic *cm_nic)
 			  fi_strerror(-ret));
 	}
 
-	fastlock_release(&cm_nic->lock);
+	fastlock_release(&nic->lock);
 
 	return ret;
 }


### PR DESCRIPTION
Fixes for cm lock issues that lead to race conditions
in vc setup in some cases.

Initiailize next field in slist elements in more
places in provider.

updates ofi-cray/libfabri-cray#661

@ztiffany 
@sungeunchoi 

Signed-off-by: Howard Pritchard howardp@lanl.gov
