### PR TITLE
prov/gni: enhance cdm_id generation

### DIFF
--- a/prov/gni/include/gnix_cm_nic.h
+++ b/prov/gni/include/gnix_cm_nic.h
@@ -154,15 +154,28 @@ int _gnix_cm_nic_enable(struct gnix_cm_nic *cm_nic);
 int _gnix_cm_nic_progress(struct gnix_cm_nic *cm_nic);
 
 /**
- * @brief function to return a unique 32 bit id for the ptag/cookie associated
- *        with the supplied domain.
+ * @brief generate a cdm_id to be used in call to  GNI_CdmCreate based on a seed
+ * value previously returned from _gnix_cm_nic_get_cdm_seed_set
  *
- * @param[in]  domain  pointer to a previously allocated gnix_fid_domain struct
- * @param[out] id      Unique id on the local node for the given ptag/cookie
- *                     associated with the supplied domain.
- * @return             FI_SUCCESS on success.  Currently no other error codes
- *                     can be returned.
+ * @param[in]  domain  pointer to previously allocated gnix_fid_domain struct
+ * @param[in]  seed    seed value to be used for creating cdm_id
+ * @param[out] id      pointer to address where the 32 bit ids will be returned
+ * @return FI_SUCCESS upon generation of 32 bit id.
  */
-int _gnix_get_new_cdm_id(struct gnix_fid_domain *domain, uint32_t *id);
+int _gnix_cm_nic_create_cdm_id(struct gnix_fid_domain *domain, uint32_t seed,
+			       uint32_t *id);
+
+/**
+ * @brief generate a set of contiguous, unique 32 bit seed values to supply
+ * to _gnix_cm_nic_create_cdm_id to generate cdm_id for calls to GNI_CdmCreate
+ *
+ * @param[in]  domain  pointer to previously allocated gnix_fid_domain struct
+ * @param[in]  nseeds  number of seeds to be allocated
+ * @param[out] seeds   pointer to address where the 32 bit seeds will be
+ *                     returned
+ * @return FI_SUCCESS upon generate ion of 32 bit id.
+ */
+int _gnix_cm_nic_get_cdm_seed_set(struct gnix_fid_domain *domain, int nseeds,
+				  uint32_t *seeds);
 
 #endif /* _GNIX_CM_NIC_H_ */

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -1401,7 +1401,7 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 {
 	int ret = FI_SUCCESS;
 	int tsret = FI_SUCCESS;
-	uint32_t cdm_id;
+	uint32_t cdm_id, seed;
 	struct gnix_fid_domain *domain_priv;
 	struct gnix_fid_ep *ep_priv;
 	gnix_hashtable_attr_t gnix_ht_attr;
@@ -1540,10 +1540,21 @@ int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 				ep_priv->cm_nic->my_name.gnix_addr.device_addr;
 			ep_priv->my_name.cm_nic_cdm_id =
 				ep_priv->cm_nic->my_name.gnix_addr.cdm_id;
-			ret = _gnix_get_new_cdm_id(domain_priv, &cdm_id);
+
+			ret = _gnix_cm_nic_get_cdm_seed_set(domain_priv, 1,
+							    &seed);
 			if (ret != FI_SUCCESS) {
 				GNIX_WARN(FI_LOG_EP_CTRL,
-					    "gnix_get_new_cdm_id call returned %s\n",
+					    "gnix_cdm_nic_get_cdm_seed_set returned %s\n",
+					     fi_strerror(-ret));
+				goto err;
+			}
+			ret = _gnix_cm_nic_create_cdm_id(domain_priv,
+							 seed,
+							 &cdm_id);
+			if (ret != FI_SUCCESS) {
+				GNIX_WARN(FI_LOG_EP_CTRL,
+					    "gnix_cm_nic_create_cdm_id returned %s\n",
 					     fi_strerror(-ret));
 				goto err;
 			}


### PR DESCRIPTION
In preparation for support of SEP, change the
method used for allocating unique values for cdm_id
generation such that a block of unique values can
be allocated.

@ztiffany 
@e-harvey 
@sungeunchoi 

Signed-off-by: Howard Pritchard howardp@lanl.gov
