### PR TITLE
prov/gni: fix of FABRIC_DIRECT_ENABLED

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -800,7 +800,7 @@ int gnix_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
  * when using fabric direct.  If the API function is static use the STATIC
  * macro to bind symbols globally when compiling with fabric direct.
  */
-#if FABRIC_DIRECT_ENABLED
+#ifdef FABRIC_DIRECT_ENABLED
 #define DIRECT_FN __attribute__((visibility ("default")))
 #define STATIC
 #else


### PR DESCRIPTION
Since FABRIC_DIRECT_ENABLED is just AC_DEFINED it
may actually not be present in config.h.  So have
to use ifdef rather than just if.

@e-harvey 

Signed-off-by: Howard Pritchard howardp@lanl.gov
