### PR TITLE
prov/gni: better configury check for CFMA

### DIFF
--- a/prov/gni/configure.m4
+++ b/prov/gni/configure.m4
@@ -49,21 +49,11 @@ AC_DEFUN([FI_GNI_CONFIGURE],[
 dnl looks like we need to get rid of some white space
                gni_path_to_gni_pub=${gni_path_to_gni_pub%?}/gni_pub.h
 
-               AC_CHECK_DECLS([GNI_VERSION_FMA_CHAIN_TRANSACTIONS],
-                              [],
+               AC_CHECK_TYPES([gni_ct_get_post_descriptor_t], [],
                               [AC_MSG_WARN([GNI provider requires CLE 5.2.UP04 or higher. Disabling gni provider.])
                                gni_header_happy=0
                               ],
                               [[#include "$gni_path_to_gni_pub"]])
-
-dnl unfortunately GNI_VERSION_FMA_CHAIN_TRANSACTIONS has an issue with CLE 5.2UP03
-               if test -f /etc/opt/cray/release/clerelease; then
-                      cle_52up03_check=`grep 5.2.UP03 /etc/opt/cray/release/clerelease`
-                      AS_IF([test "$cle_52up03_check" = "5.2.UP03"],
-                            [gni_header_happy=0
-                             AC_MSG_WARN([GNI provider requires CLE 5.2.UP04 or higher. Disabling gni provider.])
-                            ],[])
-               fi
 
                AS_IF([test -d $srcdir/prov/gni/test],
                      [AC_ARG_WITH([criterion], [AS_HELP_STRING([--with-criterion],


### PR DESCRIPTION
Improve configury check for chained FMA.
This approach allows an optional uGNI
lib/headers to be used on pre CLE 5.2up04
systems.

@chuckfossen 

Signed-off-by: Howard Pritchard howardp@lanl.gov
