### PR TITLE
prov/gni: Acclerated vc lookup.

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -374,11 +374,11 @@ struct gnix_fid_ep {
 	struct gnix_ep_name my_name;
 	struct gnix_cm_nic *cm_nic;
 	struct gnix_nic *nic;
-	fastlock_t vc_ht_lock;
+	fastlock_t vc_lock;
 	union {
 		struct gnix_hashtable *vc_ht;
-		struct gnix_vc **vc_table;      /* used for FI_AV_TABLE */
-		struct gnix_vc *vc;
+		struct gnix_vector *vc_table;   /* used for FI_AV_TABLE */
+		struct gnix_vc *vc;		/* used for FI_EP_MSG */
 	};
 	/* lock for unexp and posted recv queue */
 	fastlock_t recv_queue_lock;

--- a/prov/gni/include/gnix_av.h
+++ b/prov/gni/include/gnix_av.h
@@ -93,6 +93,69 @@ int _gnix_av_reverse_lookup(struct gnix_fid_av *gnix_av,
 			    struct gnix_address gnix_addr,
 			    fi_addr_t *fi_addr);
 
+/*******************************************************************************
+ * If the caller already knows the av type they can call the lookups directly
+ * using the following functions.
+ ******************************************************************************/
+
+/**
+ * @brief (FI_AV_TABLE) Return the gnix address using its corresponding
+ * fi_addr.
+ *
+ * @param[in] int_av		The AV to use for the lookup.
+ * @param[in] fi_addr		The corresponding fi_addr_t.
+ * @param[in/out] entry_ptr	The pointer to an address in the entry table.
+ *
+ * @return FI_SUCCESS on successfully looking up the entry in the entry table.
+ * @return -FI_EINVAL upon passing an invalid parameter.
+ */
+int _gnix_table_lookup(struct gnix_fid_av *int_av,
+		       fi_addr_t fi_addr,
+		       struct gnix_av_addr_entry **entry_ptr);
+
+/**
+ * @brief (FI_AV_MAP) Return the gnix address using its corresponding
+ * fi_addr.
+ *
+ * @param[in] int_av		The AV to use for the lookup.
+ * @param[in] fi_addr		The corresponding fi_addr_t.
+ * @param[in/out] entry_ptr	The pointer to an address in the entry table.
+ *
+ * @return FI_SUCCESS on successfully looking up the entry in the entry table.
+ * @return -FI_EINVAL upon passing an invalid parameter.
+ */
+int _gnix_map_lookup(struct gnix_fid_av *int_av,
+		     fi_addr_t fi_addr,
+		     struct gnix_av_addr_entry **entry_ptr);
+
+/**
+ * @brief (FI_AV_TABLE) Return fi_addr using its corresponding gnix address.
+ *
+ * @param[in] int_av		The AV to use for the lookup.
+ * @param[in] gnix_addr		The gnix address
+ * @param[in/out] fi_addr	The pointer to the corresponding fi_addr.
+ *
+ * @return FI_SUCCESS on successfully looking up the entry in the entry table.
+ * @return -FI_EINVAL upon passing an invalid parameter.
+ */
+int _gnix_table_reverse_lookup(struct gnix_fid_av *int_av,
+			       struct gnix_address gnix_addr,
+			       fi_addr_t *fi_addr);
+
+/**
+ * @brief (FI_AV_MAP) Return fi_addr using its corresponding gnix address.
+ *
+ * @param[in] int_av		The AV to use for the lookup.
+ * @param[in] gnix_addr		The gnix address
+ * @param[in/out] fi_addr	The pointer to the corresponding fi_addr.
+ *
+ * @return FI_SUCCESS on successfully looking up the entry in the entry table.
+ * @return -FI_EINVAL upon passing an invalid parameter.
+ */
+int _gnix_map_reverse_lookup(struct gnix_fid_av *int_av,
+			     struct gnix_address gnix_addr,
+			     fi_addr_t *fi_addr);
+
 /**
  * @brief Return the string representation of the FI address.
  *

--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -54,6 +54,7 @@ extern "C" {
 #define GNIX_VC_MODE_DG_POSTED		(1U << 2)
 #define GNIX_VC_MODE_PENDING_MSGS	(1U << 3)
 #define GNIX_VC_MODE_PEER_CONNECTED	(1U << 4)
+#define GNIX_VC_MODE_IN_TABLE		(1U << 5)
 
 /* VC flags */
 #define GNIX_VC_FLAG_RX_SCHEDULED	0

--- a/prov/gni/src/gnix_av.c
+++ b/prov/gni/src/gnix_av.c
@@ -539,6 +539,33 @@ static int map_reverse_lookup(struct gnix_fid_av *int_av,
 /*******************************************************************************
  * FI_AV API implementations.
  ******************************************************************************/
+int _gnix_table_lookup(struct gnix_fid_av *int_av,
+		       fi_addr_t fi_addr,
+		       struct gnix_av_addr_entry **entry_ptr)
+{
+	return table_lookup(int_av, fi_addr, entry_ptr);
+}
+
+int _gnix_table_reverse_lookup(struct gnix_fid_av *int_av,
+			       struct gnix_address gnix_addr,
+			       fi_addr_t *fi_addr)
+{
+	return table_reverse_lookup(int_av, gnix_addr, fi_addr);
+}
+
+int _gnix_map_lookup(struct gnix_fid_av *int_av,
+		     fi_addr_t fi_addr,
+		     struct gnix_av_addr_entry **entry_ptr)
+{
+	return map_lookup(int_av, fi_addr, entry_ptr);
+}
+
+int _gnix_map_reverse_lookup(struct gnix_fid_av *int_av,
+			     struct gnix_address gnix_addr,
+			     fi_addr_t *fi_addr)
+{
+	return map_reverse_lookup(int_av, gnix_addr, fi_addr);
+}
 
 int _gnix_av_lookup(struct gnix_fid_av *gnix_av, fi_addr_t fi_addr,
 		    struct gnix_av_addr_entry **entry_ptr)

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -46,6 +46,7 @@
 #include "gnix_ep.h"
 #include "gnix_hashtable.h"
 #include "gnix_vc.h"
+#include "gnix_vector.h"
 #include "gnix_msg.h"
 #include "gnix_rma.h"
 #include "gnix_atomic.h"
@@ -251,6 +252,95 @@ static inline ssize_t __ep_senddata(struct fid_ep *ep, const void *buf,
 	return _gnix_send(gnix_ep, (uint64_t)buf, len, desc, dest_addr,
 			  context, sd_flags, data, tag);
 }
+
+static void __gnix_vc_destroy_ht_entry(void *val)
+{
+	struct gnix_vc *vc = (struct gnix_vc *) val;
+
+	_gnix_vc_destroy(vc);
+}
+
+/*******************************************************************************
+ * EP vc initialization helper
+ ******************************************************************************/
+static inline int __gnix_ep_init_vc(struct gnix_fid_ep *ep_priv)
+{
+	int ret, type;
+	gnix_hashtable_attr_t gnix_ht_attr;
+	gnix_vec_attr_t gnix_vec_attr;
+
+	type = ep_priv->av->type;
+
+	if (likely(type == FI_AV_TABLE)) {
+		/* Initialize VC vector for FI_AV_TABLE */
+		ep_priv->vc_table = calloc(1, sizeof(struct gnix_vector));
+		if(ep_priv->vc_table == NULL)
+			goto err;
+
+		gnix_vec_attr.vec_initial_size = ep_priv->domain->params.ct_init_size;
+		gnix_vec_attr.vec_maximum_size = ep_priv->domain->params.ct_max_size;
+		gnix_vec_attr.vec_increase_step = ep_priv->domain->params.ct_step;
+		gnix_vec_attr.vec_increase_type = GNIX_VEC_INCREASE_MULT;
+		gnix_vec_attr.vec_internal_locking = GNIX_VEC_UNLOCKED;
+
+		ret = _gnix_vec_init(ep_priv->vc_table, &gnix_vec_attr);
+                GNIX_DEBUG(
+			FI_LOG_EP_CTRL,
+			"ep_priv->vc_table = %p, ep_priv->vc_table->vector = %p\n",
+			ep_priv->vc_table, ep_priv->vc_table->vector);
+                if (ret != FI_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL, "_gnix_vec_init returned %s\n",
+				  fi_strerror(ret));
+			goto err;
+		}
+	} else if (type == FI_AV_MAP) {
+		/* Initialize VC hashtable for FI_AV_MAP */
+		ep_priv->vc_ht = calloc(1, sizeof(struct gnix_hashtable));
+		if (ep_priv->vc_ht == NULL)
+			goto err;
+
+		gnix_ht_attr.ht_initial_size = ep_priv->domain->params.ct_init_size;
+		gnix_ht_attr.ht_maximum_size = ep_priv->domain->params.ct_max_size;
+		gnix_ht_attr.ht_increase_step = ep_priv->domain->params.ct_step;
+		gnix_ht_attr.ht_increase_type = GNIX_HT_INCREASE_MULT;
+		gnix_ht_attr.ht_collision_thresh = 500;
+		gnix_ht_attr.ht_hash_seed = 0xdeadbeefbeefdead;
+		gnix_ht_attr.ht_internal_locking = 0;
+		gnix_ht_attr.destructor = __gnix_vc_destroy_ht_entry;
+
+		ret = _gnix_ht_init(ep_priv->vc_ht, &gnix_ht_attr);
+		if (ret != FI_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "_gnix_ht_init returned %s\n",
+				  fi_strerror(-ret));
+			goto err;
+		}
+	} else {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "in __gnix_ep_init_vc av type \"%d\" invalid\n",
+			  type);
+        }
+
+	return FI_SUCCESS;
+
+err:
+	if (ep_priv->vc_table != NULL) {
+		_gnix_vec_close(ep_priv->vc_table);
+
+		free(ep_priv->vc_table);
+		ep_priv->vc_table = NULL;
+	}
+
+	if (ep_priv->vc_ht != NULL) {
+		_gnix_ht_destroy(ep_priv->vc_ht); /* may not be initialized but
+						     okay */
+		free(ep_priv->vc_ht);
+		ep_priv->vc_ht = NULL;
+	}
+
+	return ret;
+}
+
 
 /*******************************************************************************
  * EP messaging API function implementations.
@@ -1162,6 +1252,18 @@ static void __ep_destruct(void *obj)
 					  fi_strerror(-ret));
 			}
 		}
+
+		if (ep->vc_table != NULL) {
+			ret = _gnix_vec_close(ep->vc_table);
+			if (ret == FI_SUCCESS) {
+				free(ep->vc_table);
+				ep->vc_table = NULL;
+			} else {
+				GNIX_WARN(FI_LOG_EP_CTRL,
+					  "_gnix_vec_close returned %s\n",
+					  fi_strerror(-ret));
+			}
+		}
 	}
 
 	if (ep->send_cq) {
@@ -1316,6 +1418,7 @@ DIRECT_FN STATIC int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 			break;
 		}
 		ep->av = av;
+		__gnix_ep_init_vc(ep);
 		_gnix_ref_get(ep->av);
 		break;
 	case FI_CLASS_CNTR:
@@ -1420,13 +1523,6 @@ DIRECT_FN int gnix_pep_bind(fid_t fid, fid_t *bfid, uint64_t flags)
 	return -FI_ENOSYS;
 }
 
-static void __gnix_vc_destroy_ht_entry(void *val)
-{
-	struct gnix_vc *vc = (struct gnix_vc *) val;
-
-	_gnix_vc_destroy(vc);
-}
-
 /*
  * helper function for initializing an ep of type
  * GNIX_EPN_TYPE_BOUND
@@ -1521,7 +1617,6 @@ DIRECT_FN int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 	uint32_t cdm_id, seed;
 	struct gnix_fid_domain *domain_priv;
 	struct gnix_fid_ep *ep_priv;
-	gnix_hashtable_attr_t gnix_ht_attr;
 	gnix_ht_key_t *key_ptr;
 	bool free_list_inited = false;
 
@@ -1667,32 +1762,11 @@ DIRECT_FN int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 				  ret);
 			goto err;
 		}
-
-		gnix_ht_attr.ht_initial_size = domain_priv->params.ct_init_size;
-		gnix_ht_attr.ht_maximum_size = domain_priv->params.ct_max_size;
-		gnix_ht_attr.ht_increase_step = domain_priv->params.ct_step;
-		gnix_ht_attr.ht_increase_type = GNIX_HT_INCREASE_MULT;
-		gnix_ht_attr.ht_collision_thresh = 500;
-		gnix_ht_attr.ht_hash_seed = 0xdeadbeefbeefdead;
-		gnix_ht_attr.ht_internal_locking = 0;
-		gnix_ht_attr.destructor = __gnix_vc_destroy_ht_entry;
-
-		ep_priv->vc_ht = calloc(1, sizeof(struct gnix_hashtable));
-		if (ep_priv->vc_ht == NULL)
-			goto err;
-		ret = _gnix_ht_init(ep_priv->vc_ht, &gnix_ht_attr);
-		if (ret != FI_SUCCESS) {
-			GNIX_WARN(FI_LOG_EP_CTRL,
-				    "gnix_ht_init call returned %d\n",
-				     ret);
-			goto err;
-		}
-		fastlock_init(&ep_priv->vc_ht_lock);
-
 	} else {
 		ep_priv->cm_nic = NULL;
 		ep_priv->vc = NULL;
 	}
+	fastlock_init(&ep_priv->vc_lock);
 
 	ep_priv->progress_fn = NULL;
 	ep_priv->rx_progress_fn = NULL;
@@ -1725,13 +1799,6 @@ err:
 
 	if (free_list_inited == true)
 		__fr_freelist_destroy(ep_priv);
-
-	if (ep_priv->vc_ht != NULL) {
-		_gnix_ht_destroy(ep_priv->vc_ht); /* may not be initialized but
-						     okay */
-		free(ep_priv->vc_ht);
-		ep_priv->vc_ht = NULL;
-	}
 
 	if (ep_priv->cm_nic != NULL)
 		ret = _gnix_cm_nic_free(ep_priv->cm_nic);
@@ -1772,7 +1839,7 @@ static inline struct gnix_fab_req *__find_tx_req(
 	GNIX_DEBUG(FI_LOG_EP_CTRL, "searching VCs for the correct context to"
 		   " cancel, context=%p", context);
 
-	fastlock_acquire(&ep->vc_ht_lock);
+	fastlock_acquire(&ep->vc_lock);
 	while ((vc = _gnix_ht_iterator_next(&iter))) {
 		fastlock_acquire(&vc->tx_queue_lock);
 		entry = slist_remove_first_match(&vc->tx_queue,
@@ -1783,7 +1850,7 @@ static inline struct gnix_fab_req *__find_tx_req(
 			break;
 		}
 	}
-	fastlock_release(&ep->vc_ht_lock);
+	fastlock_release(&ep->vc_lock);
 
 	return req;
 }

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -50,6 +50,7 @@
 #include "gnix_mbox_allocator.h"
 #include "gnix_hashtable.h"
 #include "gnix_av.h"
+#include "gnix_vector.h"
 
 /*
  * forward declarations and local struct defs.
@@ -70,6 +71,367 @@ static int __gnix_vc_push_tx_reqs(struct gnix_vc *vc);
 /*******************************************************************************
  * Helper functions
  ******************************************************************************/
+/**
+ * Insert vc based on AV type and favor FI_AV_TABLE
+ *
+ * @assumption: ep, ep->av, index, key are all valid non-null ptrs.
+ */
+static inline int __gnix_vc_insert(struct gnix_fid_ep *ep,
+				   fi_addr_t *index,
+				   gnix_ht_key_t *key,
+				   struct gnix_vc *vc)
+{
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+	int ret, av_type = ep->av->type;
+
+	if (likely(av_type == FI_AV_TABLE)) {
+		fastlock_acquire(&ep->vc_lock);
+		ret = _gnix_vec_insert_at(ep->vc_table, (void *) vc, *index);
+
+		if (ret == -FI_ENOSPC) {
+			fastlock_release(&ep->vc_lock);
+			return ret;
+		}
+
+
+		if (unlikely(ret != FI_SUCCESS)) {
+			GNIX_FATAL(FI_LOG_EP_CTRL,
+				   "_gnix_vec_insert_at returned %s\n",
+				   fi_strerror(-ret));
+		}
+
+		vc->modes |= GNIX_VC_MODE_IN_TABLE;
+		fastlock_release(&ep->vc_lock);
+	} else if (av_type == FI_AV_MAP){
+		fastlock_acquire(&ep->vc_lock);
+		ret = _gnix_ht_insert(ep->vc_ht, *key, (void *) vc);
+
+		/* vc was inserted into ht between call to lookup and here! */
+		if (ret == -FI_ENOSPC) {
+			fastlock_release(&ep->vc_lock);
+			return ret;
+		}
+
+		if (unlikely(ret != FI_SUCCESS)) {
+			GNIX_FATAL(FI_LOG_EP_CTRL,
+				   "_gnix_ht_insert returned %s\n",
+				   fi_strerror(-ret));
+		}
+
+		vc->modes |= GNIX_VC_MODE_IN_HT;
+		fastlock_release(&ep->vc_lock);
+	} else {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "Invalid AV type \"%d\" in __gnix_vc_insert\n",
+			  av_type);
+                return -FI_EINVAL;
+	}
+
+	return ret;
+}
+
+/**
+ * Lookup VC based on AV type and favor FI_AV_TABLE.  If the AV type
+ * is FI_AV_TABLE, then table_dest_addr will be populated. If the AV type
+ * is FI_AV_MAP, then key and ht_dest_addr will be populated.  In either
+ * case av_entry and vc_ptr will be populated.
+ *
+ * @assumption: The user correctly sets is_dest_addr_gnix_addr;
+ * if key is non-null then it is the correct key for the given dest_addr;
+ * ep is non-null;
+ * vc_ptr is non-null.
+ *
+ * TODO: Only lock the vc_lock when looking up the VC.
+ */
+static inline int __gnix_vc_lookup_vc(struct gnix_fid_ep *ep, void *dest_addr,
+				      bool is_dest_addr_gnix_addr,
+				      struct gnix_av_addr_entry **av_entry,
+				      gnix_ht_key_t **key,
+				      fi_addr_t *table_dest_addr,
+				      struct gnix_address *ht_dest_addr,
+				      struct gnix_vc **vc_ptr)
+{
+	struct gnix_fid_av *av = ep->av;
+	int av_type = av->type, ret = FI_SUCCESS;
+	gnix_ht_key_t *key_ptr = *key;
+
+	/*
+	 * Ensure that vc_ptr is NULL before vc lookup as
+	 * functions rely on vc_ptr being NULL to determine
+	 * whether the vc was found during the lookup.
+	 */
+	*vc_ptr = NULL;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+
+	if (likely((av_type == FI_AV_TABLE))) {
+		/* Check to see if the user passed in a gnix address */
+		if (is_dest_addr_gnix_addr) {
+			ret = _gnix_table_reverse_lookup(
+				av, *((struct gnix_address *) dest_addr),
+				table_dest_addr);
+
+                        GNIX_INFO(FI_LOG_EP_CTRL, "gnix_addr: %llx\n",
+                                  *((struct gnix_address *)dest_addr));
+                        if (ret != FI_SUCCESS) {
+				GNIX_WARN(FI_LOG_EP_CTRL,
+					  "_gnix_table_reverse_lookup returned %s\n",
+					  fi_strerror(-ret));
+				return ret;
+			}
+		} else {
+			*table_dest_addr = *((fi_addr_t *) dest_addr);
+
+                        GNIX_INFO(FI_LOG_EP_CTRL, "fi_addr_t: %llx\n",
+                                  *table_dest_addr);
+                }
+
+		ret = _gnix_table_lookup(av, *table_dest_addr, av_entry);
+		assert(*av_entry);
+
+		if (ret != FI_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "_gnix_table_lookup returned %s\n",
+				  fi_strerror(-ret));
+			return ret;
+		}
+		/* fastlock_acquire(&ep->vc_lock); */
+                ret = _gnix_vec_at(ep->vc_table, (void **)vc_ptr,
+                                   *table_dest_addr);
+                /* fastlock_release(&ep->vc_lock); */
+                GNIX_DEBUG(FI_LOG_EP_CTRL, "Found vc %p at vector index %llu\n",
+                           *vc_ptr, *table_dest_addr);
+
+                /* Ignore FI_ECANCELED as it's returned when looking up a entry
+                 * that is empty */
+                if (ret != -FI_ECANCELED && ret != FI_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL, "_gnix_vec_at returned %s\n",
+				  fi_strerror(-ret));
+                }
+
+		return ret;
+	} else if (av_type == FI_AV_MAP) {
+		if (key_ptr == NULL) {
+			/* Check to see if the user passed in a gnix address */
+			if (is_dest_addr_gnix_addr) {
+				*ht_dest_addr = *((struct gnix_address *)
+						  dest_addr);
+
+                                GNIX_INFO(FI_LOG_EP_CTRL, "gnix_addr: 0x%llx\n",
+					  *ht_dest_addr);
+
+				key_ptr = malloc(sizeof(gnix_ht_key_t));
+				assert(key_ptr);
+
+                                memcpy(key_ptr, ht_dest_addr,
+                                       sizeof(gnix_ht_key_t));
+                                *av_entry =
+                                    _gnix_ht_lookup(av->map_ht, *key_ptr);
+
+                                assert(*av_entry);
+			} else {
+				ret = _gnix_map_lookup(av,
+						       *((fi_addr_t *)dest_addr),
+						       av_entry);
+                                assert(*av_entry);
+                                GNIX_DEBUG(FI_LOG_EP_CTRL,
+					   "av_entry at %p in __gnix_vc_lookup_vc",
+					   *av_entry);
+
+                                if (ret != FI_SUCCESS) {
+					GNIX_WARN(FI_LOG_EP_CTRL,
+						  "_gnix_map_lookup returned %s\n",
+						  fi_strerror(-ret));
+					return ret;
+				}
+				memcpy(ht_dest_addr, &((av_entry[0])->gnix_addr),
+				       sizeof(struct gnix_address));
+
+				key_ptr = malloc(sizeof(gnix_ht_key_t));
+				assert(key_ptr);
+
+                                memcpy(key_ptr, ht_dest_addr,
+                                       sizeof(gnix_ht_key_t));
+
+                                GNIX_INFO(FI_LOG_EP_CTRL,
+					  "fi_addr_t: 0x%llx gnix_addr: 0x%llx\n",
+					  *((fi_addr_t *) dest_addr),
+					  (av_entry[0])->gnix_addr);
+			}
+
+		}
+		/* fastlock_acquire(&ep->vc_lock); */
+		*vc_ptr = (struct gnix_vc *)_gnix_ht_lookup(ep->vc_ht, *key_ptr);
+		/* fastlock_release(&ep->vc_lock); */
+		*key = key_ptr;
+                GNIX_DEBUG(FI_LOG_EP_CTRL,
+                           "Found vc %p at hashtable key %llu\n", *vc_ptr,
+                           *key_ptr);
+                return ret;
+	} else {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "Invalid FI_AV type of \"%d\" in __gnix_vc_lookup_vc",
+			  av_type);
+		return -FI_EINVAL;
+	}
+}
+
+/**
+ * Look up the vc, if it's found just return it, otherwise allocate a new vc,
+ * insert it into the hashtable or vector, and connect it.
+ *
+ * @assumption: ep is non-null;
+ * dest_addr is valid;
+ * is_dest_addr_gnix_addr is correct for the given dest_addr;
+ * vc_ptr is non-null.
+ */
+static inline int __gnix_vc_get_vc(struct gnix_fid_ep *ep, void *dest_addr,
+				   bool is_dest_addr_gnix_addr,
+				   struct gnix_vc **vc_ptr)
+{
+	struct gnix_fid_av *av = ep->av;
+	assert(av);
+	int av_type = av->type, ret = FI_SUCCESS;
+	struct gnix_av_addr_entry *av_entry = NULL;
+	gnix_ht_key_t *key_ptr = NULL;
+	struct gnix_vc *vc_tmp = NULL;
+	fi_addr_t table_dest_addr;
+	struct gnix_address ht_dest_addr;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+        GNIX_DEBUG(FI_LOG_EP_CTRL,
+                   "ep->vc_table = %p, ep->vc_table->vector = %p\n",
+                   ep->vc_table, ep->vc_table->vector);
+
+        fastlock_acquire(&ep->vc_lock);
+
+	/*
+         * if AV type is FI_AV_TABLE, table_dest_addr will be filled in;
+         * otherwise
+         * if AV type is FI_AV_MAP, ht_dest_addr and key will be filled in.
+         */
+        ret = __gnix_vc_lookup_vc(ep, dest_addr, is_dest_addr_gnix_addr,
+                                  &av_entry, &key_ptr, &table_dest_addr,
+                                  &ht_dest_addr, &vc_tmp);
+
+        /* Ignore FI_ECANCELED as it's returned when looking up an empty entry */
+	if (ret != -FI_ECANCELED && ret != FI_SUCCESS) {
+		GNIX_WARN(FI_LOG_EP_CTRL, "__gnix_vc_lookup_vc returned %s\n",
+			  fi_strerror(-ret));
+                return ret;
+	}
+
+	/* VC not found in hashtable or vector */
+	if (vc_tmp == NULL) {
+		ret = _gnix_vc_alloc(ep,
+				     av_entry,
+				     &vc_tmp);
+		if (ret != FI_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_DATA,
+				  "_gnix_vc_alloc returned %s\n",
+				  fi_strerror(-ret));
+			goto err;
+		}
+
+		if (likely(av_type == FI_AV_TABLE)) {
+			ret = _gnix_vec_insert_at(ep->vc_table, (void *)vc_tmp,
+						  table_dest_addr);
+
+			if (ret == -FI_ECANCELED) {
+                          GNIX_INFO(FI_LOG_EP_CTRL, "in __gnix_vc_get_vc no "
+				    "space was left in hte "
+				    "vector\n");
+
+                                _gnix_vc_destroy(vc_tmp);
+                                ret = _gnix_vec_at(ep->vc_table,
+						   (void **)&vc_tmp,
+						   table_dest_addr);
+
+                                if (ret == -FI_ECANCELED) {
+					GNIX_INFO(FI_LOG_EP_CTRL,
+						  "in __gnix_vc_get_vc the vector "
+						  "was found to be full\n");
+                                        goto err;
+				}
+				fastlock_release(&ep->vc_lock);
+				return FI_SUCCESS;
+			}
+
+			if (ret != FI_SUCCESS) {
+				GNIX_WARN(FI_LOG_EP_CTRL,
+					  "_gnix_vec_insert_at returned %s\n",
+					  fi_strerror(-ret));
+                                goto err;
+			}
+
+			vc_tmp->modes |= GNIX_VC_MODE_IN_TABLE;
+		} else if (av_type == FI_AV_MAP) {
+			assert(key_ptr);
+                        ret = _gnix_ht_insert(ep->vc_ht, *key_ptr,
+                                              (void *)vc_tmp);
+
+                        /* VC was inserted into ht between call to lookup and
+                         * here! */
+                        if (ret == -FI_ENOSPC) {
+				GNIX_INFO(FI_LOG_EP_CTRL, "in __gnix_vc_get_vc no "
+					  "space was left in the "
+					  "ht\n");
+                                _gnix_vc_destroy(vc_tmp);
+                                vc_tmp = (struct gnix_vc *)_gnix_ht_lookup(
+					ep->vc_ht, *key_ptr);
+                                fastlock_release(&ep->vc_lock);
+				assert(vc_tmp != NULL);
+				assert(vc_tmp->modes & GNIX_VC_MODE_IN_HT);
+				*vc_ptr = vc_tmp;
+				return FI_SUCCESS;
+			}
+
+			if (ret != FI_SUCCESS) {
+				GNIX_WARN(FI_LOG_EP_CTRL,
+					  "_gnix_ht_insert returned %s\n",
+					  fi_strerror(-ret));
+                                goto err;
+			}
+
+			vc_tmp->modes |= GNIX_VC_MODE_IN_HT;
+                        GNIX_TRACE(FI_LOG_EP_CTRL,
+                                   "vc_tmp mode set to IN_HT\n");
+                } else {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "Invalid AV type \"%d\" in __gnix_vc_get_vc\n",
+				  av_type);
+                        goto err;
+		}
+
+		fastlock_release(&ep->vc_lock);
+
+		ret = _gnix_vc_connect(vc_tmp);
+
+		if (ret != FI_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL, "_gnix_vc_connect returned %s\n",
+				  fi_strerror(-ret));
+                        goto err;
+		}
+	} else
+		fastlock_release(&ep->vc_lock);
+
+	if (key_ptr)
+		free(key_ptr);
+
+	*vc_ptr = vc_tmp;
+	return ret;
+
+err:
+	if (key_ptr)
+		free(key_ptr);
+
+	if (vc_tmp)
+		_gnix_vc_destroy(vc_tmp);
+	fastlock_release(&ep->vc_lock);
+	return ret;
+}
+
 
 /*******************************************************************************
  * connection request /response message pack/unpack functions
@@ -369,8 +731,10 @@ static int __gnix_vc_connect_to_same_cm_nic(struct gnix_vc *vc)
 	struct gnix_vc *vc_peer;
 	gni_smsg_attr_t smsg_mbox_attr;
 	gni_smsg_attr_t smsg_mbox_attr_peer;
-	gnix_ht_key_t *key_ptr;
-	struct gnix_av_addr_entry entry;
+	gnix_ht_key_t *key_ptr = NULL;
+	struct gnix_av_addr_entry *entry = NULL;
+	fi_addr_t table_dest_addr;
+	struct gnix_address ht_dest_addr;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
@@ -390,15 +754,15 @@ static int __gnix_vc_connect_to_same_cm_nic(struct gnix_vc *vc)
 		goto exit;
 	}
 
-	fastlock_acquire(&ep->vc_ht_lock);
+	fastlock_acquire(&ep->vc_lock);
 	if ((vc->conn_state == GNIX_VC_CONNECTING) ||
 	    (vc->conn_state == GNIX_VC_CONNECTED)) {
-		fastlock_release(&ep->vc_ht_lock);
+		fastlock_release(&ep->vc_lock);
 		return FI_SUCCESS;
 	} else
 		vc->conn_state = GNIX_VC_CONNECTING;
 
-	fastlock_release(&ep->vc_ht_lock);
+	fastlock_release(&ep->vc_lock);
 
 	GNIX_DEBUG(FI_LOG_EP_CTRL, "moving vc %p state to connecting\n", vc);
 
@@ -434,11 +798,23 @@ static int __gnix_vc_connect_to_same_cm_nic(struct gnix_vc *vc)
 		goto exit;
 	}
 
-	key_ptr = (gnix_ht_key_t *)&ep->my_name.gnix_addr;
+        /*
+         * Lookup VC for this EP.
+         *
+         * if AV type is FI_AV_TABLE, table_dest_addr will be filled in;
+         * otherwise if AV type is FI_AV_MAP, ht_dest_addr, and key_ptr
+	 * (if it's null) will be filled in.
+         */
+        GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+	key_ptr = NULL;
+	fastlock_acquire(&ep_peer->vc_lock);
+        ret = __gnix_vc_lookup_vc(ep_peer, &ep->my_name.gnix_addr, true, &entry,
+                                  &key_ptr, &table_dest_addr, &ht_dest_addr,
+                                  &vc_peer);
 
-	fastlock_acquire(&ep_peer->vc_ht_lock);
-	vc_peer = (struct gnix_vc *)_gnix_ht_lookup(ep_peer->vc_ht,
-						   *key_ptr);
+        if (ret != FI_SUCCESS) {
+		GNIX_WARN(FI_LOG_EP_CTRL, "__gnix_vc_lookup_vc returned %s\n", fi_strerror(-ret));
+	}
 
 	/*
 	 * handle the special case of connecting to self
@@ -475,10 +851,10 @@ static int __gnix_vc_connect_to_same_cm_nic(struct gnix_vc *vc)
 	}
 
 	if (vc_peer == NULL) {
-		entry.gnix_addr = ep->my_name.gnix_addr;
-		entry.cm_nic_cdm_id = ep->my_name.cm_nic_cdm_id;
+		entry->gnix_addr = ep->my_name.gnix_addr;
+		entry->cm_nic_cdm_id = ep->my_name.cm_nic_cdm_id;
 		ret = _gnix_vc_alloc(ep_peer,
-				     &entry,
+				     entry,
 				     &vc_peer);
 		if (ret != FI_SUCCESS) {
 			GNIX_WARN(FI_LOG_EP_CTRL,
@@ -487,16 +863,14 @@ static int __gnix_vc_connect_to_same_cm_nic(struct gnix_vc *vc)
 			goto exit_w_lock;
 		}
 
-		ret = _gnix_ht_insert(ep_peer->vc_ht,
-				      *key_ptr,
-				      vc_peer);
-		if (ret != FI_SUCCESS) {
-			GNIX_WARN(FI_LOG_EP_CTRL,
-				  "_gnix_ht_insert returned %s\n",
-				  fi_strerror(-ret));
-			goto exit_w_lock;
-		}
-		vc_peer->modes |= GNIX_VC_MODE_IN_HT;
+		fastlock_release(&ep_peer->vc_lock);
+                ret = __gnix_vc_insert(ep_peer, &table_dest_addr, key_ptr,
+                                       vc_peer);
+
+                /* potentially allocated in _gnix_vc_lookup_vc */
+		if (key_ptr)
+			free(key_ptr);
+		fastlock_acquire(&ep_peer->vc_lock);
 	}
 
 	vc_peer->conn_state = GNIX_VC_CONNECTING;
@@ -559,7 +933,7 @@ static int __gnix_vc_connect_to_same_cm_nic(struct gnix_vc *vc)
 		   vc_peer);
 
 exit_w_lock:
-	fastlock_release(&ep_peer->vc_ht_lock);
+	fastlock_release(&ep_peer->vc_lock);
 exit:
 	return ret;
 }
@@ -605,7 +979,7 @@ static int __gnix_vc_hndl_conn_resp(struct gnix_cm_nic *cm_nic,
 	ep = vc->ep;
 	assert(ep != NULL);
 
-	fastlock_acquire(&ep->vc_ht_lock);
+	fastlock_acquire(&ep->vc_lock);
 
 	/*
 	 * at this point vc should be in connecting state
@@ -643,7 +1017,7 @@ static int __gnix_vc_hndl_conn_resp(struct gnix_cm_nic *cm_nic,
 		   " moving vc %p to state connected\n",vc);
 
 	vc->peer_caps = peer_caps;
-	fastlock_release(&ep->vc_ht_lock);
+	fastlock_release(&ep->vc_lock);
 
 	ret = _gnix_vc_schedule(vc);
 	if (ret != FI_SUCCESS)
@@ -654,7 +1028,7 @@ static int __gnix_vc_hndl_conn_resp(struct gnix_cm_nic *cm_nic,
 	return ret;
 err:
 	vc->conn_state = GNIX_VC_CONN_ERROR;
-	fastlock_release(&ep->vc_ht_lock);
+	fastlock_release(&ep->vc_lock);
 	return ret;
 }
 
@@ -666,7 +1040,7 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 	gni_return_t __attribute__((unused)) status;
 	struct gnix_fid_ep *ep = NULL;
 	gnix_ht_key_t *key_ptr;
-	struct gnix_av_addr_entry entry;
+	struct gnix_av_addr_entry *entry;
 	struct gnix_address src_addr, target_addr;
 	struct gnix_vc *vc = NULL;
 	struct gnix_vc *vc_try = NULL;
@@ -677,9 +1051,10 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 	uint64_t peer_caps;
 	struct wq_hndl_conn_req *data = NULL;
 	gni_mem_handle_t tmp_mem_hndl;
+	fi_addr_t table_dest_addr;
+	struct gnix_address ht_dest_addr;
 
 	ssize_t __attribute__((unused)) len;
-
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
 	/*
@@ -722,28 +1097,36 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 
 	/*
 	 * look to see if there is a VC already for the
-	 * address of the connecting EP.
+	 * source address of the connecting EP.
+	 *
+	 * if AV type is FI_AV_TABLE, table_dest_addr will be filled in; otherwise
+	 * if AV type is FI_AV_MAP, ht_dest_addr and key_ptr (if it's null)
+	 * will be filled in.
 	 */
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+	key_ptr = NULL;
+        ret = __gnix_vc_lookup_vc(ep, &src_addr, true, &entry, &key_ptr,
+                                  &table_dest_addr, &ht_dest_addr, &vc);
 
-	key_ptr = (gnix_ht_key_t *)&src_addr;
-
-	fastlock_acquire(&ep->vc_ht_lock);
-	vc = (struct gnix_vc *)_gnix_ht_lookup(ep->vc_ht,
-					       *key_ptr);
+        if (ret != FI_SUCCESS) {
+		GNIX_WARN(FI_LOG_EP_CTRL, "__gnix_vc_lookup_vc returned %s\n",
+			  fi_strerror(-ret));
+	}
 
 	/*
  	 * if there is no corresponding vc in the hash,
  	 * or there is an entry and its not in connecting state
  	 * go down the conn req ack route.
  	 */
-
+	fastlock_acquire(&ep->vc_lock);
 	if ((vc == NULL)  ||
 	    (vc->conn_state == GNIX_VC_CONN_NONE)) {
 		if (vc == NULL) {
-			entry.gnix_addr = src_addr;
-			entry.cm_nic_cdm_id = src_cm_nic_addr.cdm_id;
+			assert(entry);
+			entry->gnix_addr = src_addr;
+			entry->cm_nic_cdm_id = src_cm_nic_addr.cdm_id;
 			ret = _gnix_vc_alloc(ep,
-					     &entry,
+					     entry,
 					     &vc_try);
 			if (ret != FI_SUCCESS) {
 				GNIX_WARN(FI_LOG_EP_CTRL,
@@ -753,9 +1136,16 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 			}
 
 			vc_try->conn_state = GNIX_VC_CONNECTING;
-			ret = _gnix_ht_insert(ep->vc_ht,
-					      *key_ptr,
-					      vc_try);
+
+			fastlock_release(&ep->vc_lock);
+                        ret = __gnix_vc_insert(ep, &table_dest_addr, key_ptr,
+                                               vc_try);
+
+                        /* potentially allocated in _gnix_vc_lookup_vc */
+			if (key_ptr)
+				free(key_ptr);
+			fastlock_acquire(&ep->vc_lock);
+
 			if (likely(ret == FI_SUCCESS)) {
 				vc = vc_try;
 				vc->modes |= GNIX_VC_MODE_IN_HT;
@@ -763,7 +1153,7 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 				if (ret == -FI_ENOSPC)
 					_gnix_vc_destroy(vc_try);
 				GNIX_WARN(FI_LOG_EP_DATA,
-				  "_gnix_ht_insert returned %s\n",
+				  "__gnix_vc_insert returned %s\n",
 				   fi_strerror(-ret));
 				goto err;
 			}
@@ -809,7 +1199,7 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 		dlist_insert_before(&work_req->list, &cm_nic->cm_nic_wq);
 		fastlock_release(&cm_nic->wq_lock);
 
-		fastlock_release(&ep->vc_ht_lock);
+		fastlock_release(&ep->vc_lock);
 
 		ret = _gnix_vc_schedule(vc);
 		if (ret != FI_SUCCESS)
@@ -854,7 +1244,7 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 		GNIX_DEBUG(FI_LOG_EP_CTRL, "moving vc %p state to connected\n",
 			vc);
 
-		fastlock_release(&ep->vc_ht_lock);
+		fastlock_release(&ep->vc_lock);
 
 		ret = _gnix_vc_schedule(vc);
 		if (ret != FI_SUCCESS)
@@ -948,7 +1338,7 @@ static int __gnix_vc_conn_ack_prog_fn(void *data, int *complete_ptr)
 	if (cm_nic == NULL)
 		return -FI_EINVAL;
 
-	fastlock_acquire(&ep->vc_ht_lock);
+	fastlock_acquire(&ep->vc_lock);
 
 	/*
 	 * we may have already been moved to connected or
@@ -1048,7 +1438,7 @@ static int __gnix_vc_conn_ack_prog_fn(void *data, int *complete_ptr)
 	}
 
 exit:
-	fastlock_release(&ep->vc_ht_lock);
+	fastlock_release(&ep->vc_lock);
 
 	*complete_ptr = complete;
 	return ret;
@@ -1064,6 +1454,7 @@ static int __gnix_vc_conn_req_prog_fn(void *data, int *complete_ptr)
 	struct gnix_fid_ep *ep = NULL;
 	struct gnix_fid_domain *dom = NULL;
 	struct gnix_cm_nic *cm_nic = NULL;
+	struct gnix_fid_av *av = NULL;
 	char sbuf[GNIX_CM_NIC_MAX_MSG_SIZE] = {0};
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
@@ -1080,7 +1471,11 @@ static int __gnix_vc_conn_req_prog_fn(void *data, int *complete_ptr)
 	if (cm_nic == NULL)
 		return -FI_EINVAL;
 
-	fastlock_acquire(&ep->vc_ht_lock);
+	av = ep->av;
+	if (av == NULL)
+		return -FI_EINVAL;
+
+	fastlock_acquire(&ep->vc_lock);
 
 	if ((vc->conn_state == GNIX_VC_CONNECTING) ||
 		(vc->conn_state == GNIX_VC_CONNECTED)) {
@@ -1088,15 +1483,28 @@ static int __gnix_vc_conn_req_prog_fn(void *data, int *complete_ptr)
 			goto err;
 	}
 
-	/*
-	 * sanity check that the vc is in the hash table
-	 */
+	if (unlikely(av->type == FI_AV_MAP)) {
+		/*
+		 * sanity check that the vc is in the hash table
+		 */
 
-	if (!(vc->modes & GNIX_VC_MODE_IN_HT)) {
-		GNIX_WARN(FI_LOG_EP_CTRL, "vc not in hashtable\n");
-		assert(vc->modes & GNIX_VC_MODE_IN_HT);
-		ret = -FI_EINVAL;
-		goto err;
+		if (!(vc->modes & GNIX_VC_MODE_IN_HT)) {
+			GNIX_WARN(FI_LOG_EP_CTRL, "vc not in hashtable\n");
+			assert(vc->modes & GNIX_VC_MODE_IN_HT);
+			ret = -FI_EINVAL;
+			goto err;
+		}
+	} else {
+		/*
+		 * sanity check that the vc is in the vector
+		 */
+
+		if (!(vc->modes & GNIX_VC_MODE_IN_TABLE)) {
+			GNIX_WARN(FI_LOG_EP_CTRL, "vc not in vector\n");
+			assert(vc->modes & GNIX_VC_MODE_IN_TABLE);
+			ret = -FI_EINVAL;
+			goto err;
+		}
 	}
 
 	/*
@@ -1176,7 +1584,7 @@ static int __gnix_vc_conn_req_prog_fn(void *data, int *complete_ptr)
 			  fi_strerror(-ret));
 
 err:
-	fastlock_release(&ep->vc_ht_lock);
+	fastlock_release(&ep->vc_lock);
 	*complete_ptr = complete;
 	return ret;
 }
@@ -1204,7 +1612,6 @@ static int __gnix_vc_conn_req_comp_fn(void *data)
 /*******************************************************************************
  * Internal API functions
  ******************************************************************************/
-
 int _gnix_vc_alloc(struct gnix_fid_ep *ep_priv,
 		   struct gnix_av_addr_entry *entry, struct gnix_vc **vc)
 
@@ -1542,6 +1949,8 @@ static int __gnix_vc_connected(struct gnix_vc *vc)
 /* Schedule the VC for RX progress. */
 int _gnix_vc_rx_schedule(struct gnix_vc *vc)
 {
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
 	struct gnix_nic *nic = vc->ep->nic;
 
 	if (!_gnix_test_and_set_bit(&vc->flags, GNIX_VC_FLAG_RX_SCHEDULED)) {
@@ -1607,6 +2016,8 @@ int _gnix_vc_dequeue_smsg(struct gnix_vc *vc)
 static int __gnix_vc_rx_progress(struct gnix_vc *vc)
 {
 	int ret;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
 	ret = __gnix_vc_connected(vc);
 	if (ret) {
@@ -1677,6 +2088,7 @@ static int __gnix_vc_nic_rx_progress(struct gnix_nic *nic)
 /* Schedule the VC for work progress. */
 static int __gnix_vc_work_schedule(struct gnix_vc *vc)
 {
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 	struct gnix_nic *nic = vc->ep->nic;
 
 	/* Don't bother scheduling if there's no work to do. */
@@ -1802,6 +2214,7 @@ static int __gnix_vc_nic_work_progress(struct gnix_nic *nic)
 /* Schedule the VC for TX progress. */
 int _gnix_vc_tx_schedule(struct gnix_vc *vc)
 {
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 	struct gnix_nic *nic = vc->ep->nic;
 
 	/* Don't bother scheduling if there's no work to do. */
@@ -2049,6 +2462,8 @@ int _gnix_vc_nic_progress(struct gnix_nic *nic)
  */
 int _gnix_vc_schedule(struct gnix_vc *vc)
 {
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
 	_gnix_vc_rx_schedule(vc);
 	__gnix_vc_work_schedule(vc);
 	_gnix_vc_tx_schedule(vc);
@@ -2056,99 +2471,18 @@ int _gnix_vc_schedule(struct gnix_vc *vc)
 	return FI_SUCCESS;
 }
 
-static int __gnix_vc_ep_rdm_get_vc(struct gnix_fid_ep *ep, fi_addr_t dest_addr,
-			    struct gnix_vc **vc_ptr)
-{
-	int ret = FI_SUCCESS;
-	struct gnix_vc *vc = NULL, *vc_tmp;
-	struct gnix_fid_av *av;
-	struct gnix_av_addr_entry *av_entry;
-	gnix_ht_key_t key;
-
-	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
-
-	av = ep->av;
-	assert(av != NULL);
-
-	ret = _gnix_av_lookup(av, dest_addr, &av_entry);
-	if (ret != FI_SUCCESS) {
-		GNIX_WARN(FI_LOG_EP_DATA,
-			  "_gnix_av_lookup for addr 0x%llx returned %s \n",
-			  dest_addr, fi_strerror(-ret));
-		goto err;
-	}
-
-	GNIX_INFO(FI_LOG_EP_CTRL, "fi_addr_t: 0x%llx gnix_addr: 0x%llx\n",
-		  dest_addr, av_entry->gnix_addr);
-
-	memcpy(&key, &av_entry->gnix_addr, sizeof(gnix_ht_key_t));
-
-	fastlock_acquire(&ep->vc_ht_lock);
-	vc = (struct gnix_vc *)_gnix_ht_lookup(ep->vc_ht,
-						key);
-	if (vc == NULL) {
-		ret = _gnix_vc_alloc(ep,
-				     av_entry,
-				     &vc_tmp);
-		if (ret != FI_SUCCESS) {
-			GNIX_WARN(FI_LOG_EP_DATA,
-				  "_gnix_vc_alloc returned %s\n",
-				  fi_strerror(-ret));
-			goto err_w_lock;
-		}
-		ret = _gnix_ht_insert(ep->vc_ht, key,
-					vc_tmp);
-		if (likely(ret == FI_SUCCESS)) {
-			vc = vc_tmp;
-			vc->modes |= GNIX_VC_MODE_IN_HT;
-			fastlock_release(&ep->vc_ht_lock);
-			ret = _gnix_vc_connect(vc);
-			if (ret != FI_SUCCESS) {
-				GNIX_WARN(FI_LOG_EP_DATA,
-					"_gnix_vc_connect returned %s\n",
-					   fi_strerror(-ret));
-				goto err;
-			}
-		} else if (ret == -FI_ENOSPC) {
-			_gnix_vc_destroy(vc_tmp);
-			vc = _gnix_ht_lookup(ep->vc_ht, key);
-			fastlock_release(&ep->vc_ht_lock);
-			assert(vc != NULL);
-			assert(vc->modes & GNIX_VC_MODE_IN_HT);
-			ret = FI_SUCCESS;
-		} else {
-			GNIX_WARN(FI_LOG_EP_DATA,
-				  "_gnix_ht_insert returned %s\n",
-				   fi_strerror(-ret));
-			goto err_w_lock;
-		}
-	} else  {
-		fastlock_release(&ep->vc_ht_lock);
-	}
-
-	*vc_ptr = vc;
-	return ret;
-
-err_w_lock:
-	fastlock_release(&ep->vc_ht_lock);
-err:
-	if (vc != NULL)
-		_gnix_vc_destroy(vc);
-	return ret;
-}
-
 int _gnix_vc_ep_get_vc(struct gnix_fid_ep *ep, fi_addr_t dest_addr,
-			struct gnix_vc **vc_ptr)
+		       struct gnix_vc **vc_ptr)
 {
 	int ret;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
 	if (GNIX_EP_RDM_DGM(ep->type)) {
-		ret = __gnix_vc_ep_rdm_get_vc(ep, dest_addr, vc_ptr);
+		ret = __gnix_vc_get_vc(ep, (void *) &dest_addr, false, vc_ptr);
 		if (unlikely(ret != FI_SUCCESS)) {
 			GNIX_WARN(FI_LOG_EP_DATA,
-				  "__gnix_vc_ep_get_vc returned %s\n",
+				  "__gnix_vc_get_vc returned %s\n",
 				   fi_strerror(-ret));
 			return ret;
 		}
@@ -2209,4 +2543,3 @@ int _gnix_vc_cm_init(struct gnix_cm_nic *cm_nic)
 
 	return ret;
 }
-


### PR DESCRIPTION
Since FI_AV_TABLE  essentially provides an index into a table of vc's the gnix provider now uses a vector instead of a hashtable for getting/storing vc's using FI_AV_TABLE. To accomplish this a few functions were added to gnix_vc.c:
    \* __gnix_vc_insert
    \* __gnix_vc_lookup_vc
    \* __gnix_vc_get_vc
These functions simply provide a means of inserting or looking up the vc based on the address vector type. Other minor changes were made to gnix_ep.c in order to initialize the appropriate vc lookup method
based on the address vector type. A couple of static functions were also added to gnix_av.h inorder to accelerate the translations of a fi_addr_t to a gnix_address or vice versa since the av type is known during the vc lookup. Lastly, an additional table mode was added to gnix_vc.h for updating and checking the vc mode during operation.

Signed-off-by: Evan Harvey eharvey@lanl.gov

@hppritcha @ztiffany 

fixes #645 
