### PR TITLE
prov/gni: Fix valgrind warnings about conditional jump in api_cq criterion tests.

### DIFF
--- a/prov/gni/test/api_cq.c
+++ b/prov/gni/test/api_cq.c
@@ -323,6 +323,9 @@ void api_cq_send_recv(int len)
 	struct fi_msg_rma rma_msg;
 	struct fi_rma_iov rma_iov;
 
+	iov.iov_base = NULL;
+	iov.iov_len = 0;
+
 	api_cq_init_data(source, len, 0xab);
 	api_cq_init_data(target, len, 0);
 


### PR DESCRIPTION
valgrind warns about a conditional jump depending on unitialized values in the _gnix_rma fn.  struct iovec iov was not intialized in the fn api_cq_send_recv.

Signed-off-by: Evan Harvey eharvey@lanl.gov

fixes #737 

@sungeunchoi
