### PR TITLE
prov/gni: Doubled the max timeout for the rdm_fi_pcd unit tests.

### DIFF
--- a/prov/gni/test/rdm_fi_pcd_trecv_msg.c
+++ b/prov/gni/test/rdm_fi_pcd_trecv_msg.c
@@ -268,7 +268,7 @@ static char *target;
 static char *source;
 static struct fid_mr *rem_mr, *loc_mr;
 static uint64_t mr_key;
-static const int max_test_time = 5;
+static const int max_test_time = 10;
 
 /* test variables */
 static int elapsed;


### PR DESCRIPTION
Since a sometimes hangs for
more than 5 seconds while waiting for CQ events the criterion
test was timing out causing an assertion failure.

Fixes #752 
@sungeunchoi 
