### PR TITLE
prov/gni: fix issues with triggereds ops merge

### DIFF
--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -1921,14 +1921,7 @@ int _gnix_vc_queue_tx_req(struct gnix_fab_req *req)
 		}
 	}
 
-	/*
-	 * don't treat -FI_EAGAIN as an error
-	 */
-
-	if (rc == -FI_EAGAIN)
-		rc = FI_SUCCESS;
-
-	return rc;
+	return FI_SUCCESS;
 }
 
 /* Push TX requests queued on the VC. */


### PR DESCRIPTION
Signed-off-by: Zach Tiffany ztiffany@cray.com

@sungeunchoi @hppritcha 

There's no reason to return an error from queue_tx_req() right now.
