### PR TITLE
prov/gni: gnitest compiles with --enable-direct=gni.

### DIFF
--- a/prov/gni/configure.m4
+++ b/prov/gni/configure.m4
@@ -64,6 +64,10 @@ dnl looks like we need to get rid of some white space
                      [criterion_tests_present=false])
 
                if test "$with_criterion" != "" && test "$with_criterion" != "no"; then
+	       	     if test "$enable_direct" != "" && test "$enable_direct" != "no"; then
+		     	gnitest_CPPFLAGS="-I$srcdir/prov/gni/include"
+		     fi
+
                      AS_IF([test "$criterion_tests_present" = "true"],
                            [AC_MSG_CHECKING([criterion path])
                             if test -d "$with_criterion"; then

--- a/prov/gni/include/gnix_ep.h
+++ b/prov/gni/include/gnix_ep.h
@@ -219,6 +219,6 @@ int gnix_scalable_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags);
  * @return -FI_ERRNO	upon an error
  * @return -FI_ENOSYS	if this operation is not supported
  */
-DIRECT_FN int gnix_pep_bind(fid_t fid, fid_t *bfid, uint64_t flags);
+int gnix_pep_bind(fid_t fid, fid_t *bfid, uint64_t flags);
 
 #endif /* _GNIX_EP_H_ */

--- a/prov/gni/test/allocator.c
+++ b/prov/gni/test/allocator.c
@@ -38,6 +38,8 @@
 #include "gnix_mbox_allocator.h"
 
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;

--- a/prov/gni/test/allocator.c
+++ b/prov/gni/test/allocator.c
@@ -40,7 +40,6 @@
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
 
-
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
 static struct fid_ep *ep;

--- a/prov/gni/test/api.c
+++ b/prov/gni/test/api.c
@@ -43,13 +43,7 @@
 #include <limits.h>
 #include <assert.h>
 
-#include <rdma/fabric.h>
-#include <rdma/fi_domain.h>
-#include <rdma/fi_errno.h>
-#include <rdma/fi_endpoint.h>
-#include <rdma/fi_cm.h>
-#include <rdma/fi_atomic.h>
-#include <rdma/fi_tagged.h>
+#include "gnix_rdma_headers.h"
 #include "fi_ext_gni.h"
 
 #include <stdio.h>
@@ -814,4 +808,3 @@ Test(rdm_api, amo_write_read_w_msg)
 	rdm_api_setup_ep();
 	api_write_read(BUF_SZ);
 }
-

--- a/prov/gni/test/api.c
+++ b/prov/gni/test/api.c
@@ -43,14 +43,13 @@
 #include <limits.h>
 #include <assert.h>
 
-#include "gnix_rdma_headers.h"
-#include "fi_ext_gni.h"
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>
 
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+#include "fi_ext_gni.h"
 
 #if 1
 #define dbg_printf(...)

--- a/prov/gni/test/api_cq.c
+++ b/prov/gni/test/api_cq.c
@@ -43,13 +43,7 @@
 #include <limits.h>
 #include <assert.h>
 
-#include <rdma/fabric.h>
-#include <rdma/fi_domain.h>
-#include <rdma/fi_errno.h>
-#include <rdma/fi_endpoint.h>
-#include <rdma/fi_cm.h>
-#include <rdma/fi_atomic.h>
-#include <rdma/fi_tagged.h>
+#include "gnix_rdma_headers.h"
 #include "fi_ext_gni.h"
 
 #include <stdio.h>
@@ -57,6 +51,7 @@
 #include <inttypes.h>
 
 #include <criterion/criterion.h>
+
 
 #if 1
 #define dbg_printf(...)

--- a/prov/gni/test/api_cq.c
+++ b/prov/gni/test/api_cq.c
@@ -43,15 +43,13 @@
 #include <limits.h>
 #include <assert.h>
 
-#include "gnix_rdma_headers.h"
-#include "fi_ext_gni.h"
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>
 
 #include <criterion/criterion.h>
-
+#include "gnix_rdma_headers.h"
+#include "fi_ext_gni.h"
 
 #if 1
 #define dbg_printf(...)

--- a/prov/gni/test/av.c
+++ b/prov/gni/test/av.c
@@ -36,13 +36,13 @@
 #include <stdlib.h>
 
 #include "fi.h"
-#include "rdma/fi_domain.h"
-#include "rdma/fi_prov.h"
+#include "gnix_rdma_headers.h"
 
 #include "gnix.h"
 #include "gnix_av.h"
 
 #include <criterion/criterion.h>
+
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;

--- a/prov/gni/test/av.c
+++ b/prov/gni/test/av.c
@@ -36,13 +36,14 @@
 #include <stdlib.h>
 
 #include "fi.h"
-#include "gnix_rdma_headers.h"
+#include "rdma/fi_domain.h"
+#include "rdma/fi_prov.h"
 
 #include "gnix.h"
 #include "gnix_av.h"
 
 #include <criterion/criterion.h>
-
+#include "gnix_rdma_headers.h"
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;

--- a/prov/gni/test/bitmap.c
+++ b/prov/gni/test/bitmap.c
@@ -41,11 +41,13 @@
 #include <stdint.h>
 #include <sys/time.h>
 
-#include <rdma/fi_errno.h>
+
 #include <gnix_bitmap.h>
 #include "common.h"
 
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 
 gnix_bitmap_t *test_bitmap = NULL;
 int call_free_bitmap = 0;

--- a/prov/gni/test/bitmap.c
+++ b/prov/gni/test/bitmap.c
@@ -41,13 +41,11 @@
 #include <stdint.h>
 #include <sys/time.h>
 
-
 #include <gnix_bitmap.h>
 #include "common.h"
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
-
 
 gnix_bitmap_t *test_bitmap = NULL;
 int call_free_bitmap = 0;

--- a/prov/gni/test/buddy_allocator.c
+++ b/prov/gni/test/buddy_allocator.c
@@ -34,6 +34,8 @@
 
 #include "gnix_buddy_allocator.h"
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 #include <time.h>
 
 #define LEN (1024 * 1024)	/* buddy_handle->len */

--- a/prov/gni/test/buddy_allocator.c
+++ b/prov/gni/test/buddy_allocator.c
@@ -35,7 +35,6 @@
 #include "gnix_buddy_allocator.h"
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
-
 #include <time.h>
 
 #define LEN (1024 * 1024)	/* buddy_handle->len */

--- a/prov/gni/test/cancel.c
+++ b/prov/gni/test/cancel.c
@@ -40,11 +40,11 @@
 #include <string.h>
 #include <pthread.h>
 
-#include <rdma/fabric.h>
-#include <rdma/fi_domain.h>
-#include <rdma/fi_errno.h>
-#include <rdma/fi_endpoint.h>
-#include <rdma/fi_cm.h>
+
+
+
+
+
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -57,6 +57,8 @@
 #include "gnix_ep.h"
 
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;

--- a/prov/gni/test/cancel.c
+++ b/prov/gni/test/cancel.c
@@ -41,11 +41,6 @@
 #include <pthread.h>
 
 
-
-
-
-
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>
@@ -58,7 +53,6 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
-
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;

--- a/prov/gni/test/cntr.c
+++ b/prov/gni/test/cntr.c
@@ -40,11 +40,11 @@
 #include <string.h>
 #include <pthread.h>
 
-#include <rdma/fabric.h>
-#include <rdma/fi_domain.h>
-#include <rdma/fi_errno.h>
-#include <rdma/fi_endpoint.h>
-#include <rdma/fi_cm.h>
+
+
+
+
+
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -56,6 +56,8 @@
 #include "gnix_rma.h"
 
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 
 #if 1
 #define dbg_printf(...)

--- a/prov/gni/test/cntr.c
+++ b/prov/gni/test/cntr.c
@@ -41,11 +41,6 @@
 #include <pthread.h>
 
 
-
-
-
-
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>
@@ -57,7 +52,6 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
-
 
 #if 1
 #define dbg_printf(...)

--- a/prov/gni/test/cq.c
+++ b/prov/gni/test/cq.c
@@ -39,11 +39,11 @@
 #include <time.h>
 #include <string.h>
 
-#include <rdma/fabric.h>
-#include <rdma/fi_domain.h>
-#include <rdma/fi_errno.h>
-#include <rdma/fi_endpoint.h>
-#include <rdma/fi_cm.h>
+
+
+
+
+
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -53,6 +53,8 @@
 #include "gnix.h"
 
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;

--- a/prov/gni/test/cq.c
+++ b/prov/gni/test/cq.c
@@ -40,11 +40,6 @@
 #include <string.h>
 
 
-
-
-
-
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>
@@ -54,7 +49,6 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
-
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;

--- a/prov/gni/test/datagram.c
+++ b/prov/gni/test/datagram.c
@@ -42,11 +42,11 @@
 #include <unistd.h>
 #include <limits.h>
 
-#include <rdma/fabric.h>
-#include <rdma/fi_domain.h>
-#include <rdma/fi_errno.h>
-#include <rdma/fi_endpoint.h>
-#include <rdma/fi_cm.h>
+
+
+
+
+
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -56,6 +56,8 @@
 #include "gnix_cm_nic.h"
 
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;

--- a/prov/gni/test/datagram.c
+++ b/prov/gni/test/datagram.c
@@ -43,11 +43,6 @@
 #include <limits.h>
 
 
-
-
-
-
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>
@@ -57,7 +52,6 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
-
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;

--- a/prov/gni/test/dlist-utils.c
+++ b/prov/gni/test/dlist-utils.c
@@ -39,6 +39,8 @@
 #include "gnix_util.h"
 
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 
 struct element {
 	int val;

--- a/prov/gni/test/dlist-utils.c
+++ b/prov/gni/test/dlist-utils.c
@@ -41,7 +41,6 @@
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
 
-
 struct element {
 	int val;
 	struct dlist_entry entry;

--- a/prov/gni/test/dom.c
+++ b/prov/gni/test/dom.c
@@ -38,14 +38,16 @@
 #include <time.h>
 #include <string.h>
 
-#include <rdma/fabric.h>
-#include <rdma/fi_domain.h>
-#include <rdma/fi_errno.h>
-#include <rdma/fi_endpoint.h>
+
+
+
+
 
 #include "gnix.h"
 
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 
 static struct fid_fabric *fabric;
 static struct fi_info *fi;

--- a/prov/gni/test/dom.c
+++ b/prov/gni/test/dom.c
@@ -39,15 +39,10 @@
 #include <string.h>
 
 
-
-
-
-
 #include "gnix.h"
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
-
 
 static struct fid_fabric *fabric;
 static struct fi_info *fi;

--- a/prov/gni/test/ep.c
+++ b/prov/gni/test/ep.c
@@ -39,14 +39,16 @@
 #include <time.h>
 #include <string.h>
 
-#include <rdma/fabric.h>
-#include <rdma/fi_domain.h>
-#include <rdma/fi_errno.h>
-#include <rdma/fi_endpoint.h>
+
+
+
+
 
 #include "gnix_ep.h"
 
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 
 static struct fi_info *hints;
 static struct fi_info *fi;

--- a/prov/gni/test/ep.c
+++ b/prov/gni/test/ep.c
@@ -40,15 +40,10 @@
 #include <string.h>
 
 
-
-
-
-
 #include "gnix_ep.h"
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
-
 
 static struct fi_info *hints;
 static struct fi_info *fi;

--- a/prov/gni/test/eq.c
+++ b/prov/gni/test/eq.c
@@ -37,6 +37,8 @@
 #include "gnix.h"
 
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 
 static struct fid_fabric *fab;
 static struct fi_info *hints;

--- a/prov/gni/test/eq.c
+++ b/prov/gni/test/eq.c
@@ -39,7 +39,6 @@
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
 
-
 static struct fid_fabric *fab;
 static struct fi_info *hints;
 static struct fi_info *fi;

--- a/prov/gni/test/freelist.c
+++ b/prov/gni/test/freelist.c
@@ -38,6 +38,8 @@
 #include "gnix_freelist.h"
 
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 
 static void setup(void)
 {

--- a/prov/gni/test/freelist.c
+++ b/prov/gni/test/freelist.c
@@ -40,7 +40,6 @@
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
 
-
 static void setup(void)
 {
 	srand(time(NULL));

--- a/prov/gni/test/gnix_rdma_headers.h
+++ b/prov/gni/test/gnix_rdma_headers.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2016 Los Alamos National Security, LLC. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef GNIX_RDMA_HEADERS_H
+#define GNIX_RDMA_HEADERS_H
+
+#ifdef FABRIC_DIRECT_ENABLED
+#define FABRIC_DIRECT
+#endif	/* FABRIC_DIRECT_ENABLED */
+
+#include <rdma/fabric.h>
+#include <rdma/fi_atomic.h>
+#include <rdma/fi_cm.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_eq.h>
+#include <rdma/fi_errno.h>
+#include <rdma/fi_log.h>
+#include <rdma/fi_prov.h>
+#include <rdma/fi_rma.h>
+#include <rdma/fi_tagged.h>
+#include <rdma/fi_trigger.h>
+
+#endif /* GNIX_RDMA_HEADERS_H */

--- a/prov/gni/test/hashtable.c
+++ b/prov/gni/test/hashtable.c
@@ -35,11 +35,13 @@
 #include <stdio.h>
 #include <stdint.h>
 
-#include <rdma/fi_errno.h>
+
 #include <gnix_hashtable.h>
 #include <gnix_bitmap.h>
 
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 
 #define __GNIX_MAGIC_VALUE 0xDEADBEEF
 

--- a/prov/gni/test/hashtable.c
+++ b/prov/gni/test/hashtable.c
@@ -35,13 +35,11 @@
 #include <stdio.h>
 #include <stdint.h>
 
-
 #include <gnix_hashtable.h>
 #include <gnix_bitmap.h>
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
-
 
 #define __GNIX_MAGIC_VALUE 0xDEADBEEF
 

--- a/prov/gni/test/mr.c
+++ b/prov/gni/test/mr.c
@@ -42,11 +42,11 @@
 #include <sys/time.h>
 
 
-#include <rdma/fabric.h>
-#include <rdma/fi_domain.h>
-#include <rdma/fi_errno.h>
-#include <rdma/fi_endpoint.h>
-#include <rdma/fi_cm.h>
+
+
+
+
+
 
 
 #include <stdio.h>
@@ -58,6 +58,8 @@
 #include "common.h"
 
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;

--- a/prov/gni/test/mr.c
+++ b/prov/gni/test/mr.c
@@ -44,11 +44,6 @@
 
 
 
-
-
-
-
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>
@@ -59,7 +54,6 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
-
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;

--- a/prov/gni/test/nic.c
+++ b/prov/gni/test/nic.c
@@ -38,14 +38,16 @@
 #include <time.h>
 #include <string.h>
 
-#include <rdma/fabric.h>
-#include <rdma/fi_domain.h>
-#include <rdma/fi_errno.h>
+
+
+
 
 #include "gnix.h"
 #include "gnix_nic.h"
 
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 
 static struct fi_info *hints;
 static struct fi_info *fi;

--- a/prov/gni/test/nic.c
+++ b/prov/gni/test/nic.c
@@ -39,15 +39,11 @@
 #include <string.h>
 
 
-
-
-
 #include "gnix.h"
 #include "gnix_nic.h"
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
-
 
 static struct fi_info *hints;
 static struct fi_info *fi;

--- a/prov/gni/test/queue.c
+++ b/prov/gni/test/queue.c
@@ -32,11 +32,13 @@
  */
 
 #include <stdlib.h>
-#include <rdma/fabric.h> /* for container_of definition */
+ /* for container_of definition */
 
 #include "gnix_queue.h"
 
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 
 struct gnix_queue *queue;
 

--- a/prov/gni/test/queue.c
+++ b/prov/gni/test/queue.c
@@ -32,13 +32,11 @@
  */
 
 #include <stdlib.h>
- /* for container_of definition */
 
 #include "gnix_queue.h"
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
-
 
 struct gnix_queue *queue;
 

--- a/prov/gni/test/rdm_atomic.c
+++ b/prov/gni/test/rdm_atomic.c
@@ -40,11 +40,11 @@
 #include <string.h>
 #include <pthread.h>
 
-#include <rdma/fabric.h>
-#include <rdma/fi_domain.h>
-#include <rdma/fi_errno.h>
-#include <rdma/fi_endpoint.h>
-#include <rdma/fi_cm.h>
+
+
+
+
+
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -56,6 +56,8 @@
 #include "gnix_atomic.h"
 
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 
 #if 1
 #define dbg_printf(...)

--- a/prov/gni/test/rdm_atomic.c
+++ b/prov/gni/test/rdm_atomic.c
@@ -41,11 +41,6 @@
 #include <pthread.h>
 
 
-
-
-
-
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>
@@ -57,7 +52,6 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
-
 
 #if 1
 #define dbg_printf(...)

--- a/prov/gni/test/rdm_dgram_rma.c
+++ b/prov/gni/test/rdm_dgram_rma.c
@@ -41,11 +41,11 @@
 #include <string.h>
 #include <pthread.h>
 
-#include <rdma/fabric.h>
-#include <rdma/fi_domain.h>
-#include <rdma/fi_errno.h>
-#include <rdma/fi_endpoint.h>
-#include <rdma/fi_cm.h>
+
+
+
+
+
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -57,6 +57,8 @@
 #include "gnix_rma.h"
 
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 
 #if 1
 #define dbg_printf(...)

--- a/prov/gni/test/rdm_dgram_rma.c
+++ b/prov/gni/test/rdm_dgram_rma.c
@@ -42,11 +42,6 @@
 #include <pthread.h>
 
 
-
-
-
-
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>
@@ -58,7 +53,6 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
-
 
 #if 1
 #define dbg_printf(...)

--- a/prov/gni/test/rdm_fi_pcd_trecv_msg.c
+++ b/prov/gni/test/rdm_fi_pcd_trecv_msg.c
@@ -41,12 +41,12 @@
 #include <pthread.h>
 #include <sys/time.h>
 
-#include <rdma/fabric.h>
-#include <rdma/fi_domain.h>
-#include <rdma/fi_errno.h>
-#include <rdma/fi_endpoint.h>
-#include <rdma/fi_cm.h>
-#include <rdma/fi_tagged.h>
+
+
+
+
+
+
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -58,6 +58,8 @@
 #include "gnix_rma.h"
 
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 
 /* Both the send and recv paths use independent state machines within
  * each test to simulate the behavior you would expect in a client/server

--- a/prov/gni/test/rdm_fi_pcd_trecv_msg.c
+++ b/prov/gni/test/rdm_fi_pcd_trecv_msg.c
@@ -42,12 +42,6 @@
 #include <sys/time.h>
 
 
-
-
-
-
-
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>
@@ -59,7 +53,6 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
-
 
 /* Both the send and recv paths use independent state machines within
  * each test to simulate the behavior you would expect in a client/server

--- a/prov/gni/test/rdm_rx_overrun.c
+++ b/prov/gni/test/rdm_rx_overrun.c
@@ -40,11 +40,11 @@
 #include <string.h>
 #include <pthread.h>
 
-#include <rdma/fabric.h>
-#include <rdma/fi_domain.h>
-#include <rdma/fi_errno.h>
-#include <rdma/fi_endpoint.h>
-#include <rdma/fi_cm.h>
+
+
+
+
+
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -56,6 +56,8 @@
 #include "gnix_rma.h"
 
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 
 #define NUM_EPS 61
 const int num_msgs = 10;

--- a/prov/gni/test/rdm_rx_overrun.c
+++ b/prov/gni/test/rdm_rx_overrun.c
@@ -41,11 +41,6 @@
 #include <pthread.h>
 
 
-
-
-
-
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>
@@ -57,7 +52,6 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
-
 
 #define NUM_EPS 61
 const int num_msgs = 10;

--- a/prov/gni/test/rdm_sr.c
+++ b/prov/gni/test/rdm_sr.c
@@ -42,11 +42,11 @@
 #include <unistd.h>
 #include <limits.h>
 
-#include <rdma/fabric.h>
-#include <rdma/fi_domain.h>
-#include <rdma/fi_errno.h>
-#include <rdma/fi_endpoint.h>
-#include <rdma/fi_cm.h>
+
+
+
+
+
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -58,6 +58,8 @@
 #include "gnix_rma.h"
 
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 
 #if 1
 #define dbg_printf(...)

--- a/prov/gni/test/rdm_sr.c
+++ b/prov/gni/test/rdm_sr.c
@@ -43,11 +43,6 @@
 #include <limits.h>
 
 
-
-
-
-
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>
@@ -59,7 +54,6 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
-
 
 #if 1
 #define dbg_printf(...)

--- a/prov/gni/test/rdm_tagged_sr.c
+++ b/prov/gni/test/rdm_tagged_sr.c
@@ -40,12 +40,12 @@
 #include <string.h>
 #include <pthread.h>
 
-#include <rdma/fabric.h>
-#include <rdma/fi_domain.h>
-#include <rdma/fi_errno.h>
-#include <rdma/fi_endpoint.h>
-#include <rdma/fi_cm.h>
-#include <rdma/fi_tagged.h>
+
+
+
+
+
+
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -57,6 +57,8 @@
 #include "gnix_rma.h"
 
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 
 #if 1
 #define dbg_printf(...)

--- a/prov/gni/test/rdm_tagged_sr.c
+++ b/prov/gni/test/rdm_tagged_sr.c
@@ -41,12 +41,6 @@
 #include <pthread.h>
 
 
-
-
-
-
-
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>
@@ -58,7 +52,6 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
-
 
 #if 1
 #define dbg_printf(...)

--- a/prov/gni/test/tags.c
+++ b/prov/gni/test/tags.c
@@ -41,11 +41,13 @@
 #include <stdint.h>
 #include <sys/time.h>
 
-#include <rdma/fi_errno.h>
+
 #include <gnix_tags.h>
 #include <gnix.h>
 
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 #include <criterion/parameterized.h>
 
 static struct fi_info *hints;

--- a/prov/gni/test/tags.c
+++ b/prov/gni/test/tags.c
@@ -41,13 +41,11 @@
 #include <stdint.h>
 #include <sys/time.h>
 
-
 #include <gnix_tags.h>
 #include <gnix.h>
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
-
 #include <criterion/parameterized.h>
 
 static struct fi_info *hints;

--- a/prov/gni/test/utils.c
+++ b/prov/gni/test/utils.c
@@ -42,17 +42,19 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-#include <rdma/fabric.h>
-#include <rdma/fi_domain.h>
-#include <rdma/fi_errno.h>
-#include <rdma/fi_endpoint.h>
-#include <rdma/fi_cm.h>
+
+
+
+
+
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>
 
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 #include "gnix_util.h"
 #include "gnix.h"
 

--- a/prov/gni/test/utils.c
+++ b/prov/gni/test/utils.c
@@ -43,18 +43,12 @@
 #include <unistd.h>
 
 
-
-
-
-
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
-
 #include "gnix_util.h"
 #include "gnix.h"
 

--- a/prov/gni/test/vc.c
+++ b/prov/gni/test/vc.c
@@ -40,11 +40,11 @@
 #include <string.h>
 #include <pthread.h>
 
-#include <rdma/fabric.h>
-#include <rdma/fi_domain.h>
-#include <rdma/fi_errno.h>
-#include <rdma/fi_endpoint.h>
-#include <rdma/fi_cm.h>
+
+
+
+
+
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -57,6 +57,8 @@
 #include "gnix_av.h"
 
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;

--- a/prov/gni/test/vc.c
+++ b/prov/gni/test/vc.c
@@ -41,11 +41,6 @@
 #include <pthread.h>
 
 
-
-
-
-
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>
@@ -58,7 +53,6 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
-
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;

--- a/prov/gni/test/vector.c
+++ b/prov/gni/test/vector.c
@@ -35,6 +35,8 @@
 #include "gnix_vector.h"
 #include <unistd.h>
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 #include <stdlib.h>
 
 gnix_vector_t vec;

--- a/prov/gni/test/vector.c
+++ b/prov/gni/test/vector.c
@@ -36,7 +36,6 @@
 #include <unistd.h>
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
-
 #include <stdlib.h>
 
 gnix_vector_t vec;

--- a/prov/gni/test/wait.c
+++ b/prov/gni/test/wait.c
@@ -37,6 +37,8 @@
 #include <string.h>
 
 #include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
 
 static struct fid_fabric *fab;
 static struct fi_info *hints;

--- a/prov/gni/test/wait.c
+++ b/prov/gni/test/wait.c
@@ -39,7 +39,6 @@
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
 
-
 static struct fid_fabric *fab;
 static struct fi_info *hints;
 static struct fi_info *fi;


### PR DESCRIPTION
- Added new header file to conditionally define FABRIC_DIRECT and include "rdma/*.h"
- Removed "rdma/*.h" includes from gnitest source files and included the new header file.
- Updated gni unit tests to reflect these changes.
- Removed DIRECT_FN from gnix_ep.h.

Fixes #754 
@sungeunchoi @hppritcha 
