### PR TITLE
Accelerated vc lookup when using av type FI_AV_TABLE

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -377,12 +377,10 @@ struct gnix_fid_ep {
 	struct gnix_ep_name my_name;
 	struct gnix_cm_nic *cm_nic;
 	struct gnix_nic *nic;
-	fastlock_t vc_ht_lock;
-	union {
-		struct gnix_hashtable *vc_ht;
-		struct gnix_vc **vc_table;      /* used for FI_AV_TABLE */
-		struct gnix_vc *vc;
-	};
+	fastlock_t vc_lock;
+	struct gnix_hashtable *vc_ht;
+	struct gnix_vector *vc_table;   /* used for FI_AV_TABLE */
+	struct gnix_vc *vc;		/* used for FI_EP_MSG */
 	/* lock for unexp and posted recv queue */
 	fastlock_t recv_queue_lock;
 	/* used for unexpected receives */

--- a/prov/gni/include/gnix_av.h
+++ b/prov/gni/include/gnix_av.h
@@ -93,6 +93,69 @@ int _gnix_av_reverse_lookup(struct gnix_fid_av *gnix_av,
 			    struct gnix_address gnix_addr,
 			    fi_addr_t *fi_addr);
 
+/*******************************************************************************
+ * If the caller already knows the av type they can call the lookups directly
+ * using the following functions.
+ ******************************************************************************/
+
+/**
+ * @brief (FI_AV_TABLE) Return the gnix address using its corresponding
+ * fi_addr.
+ *
+ * @param[in] int_av		The AV to use for the lookup.
+ * @param[in] fi_addr		The corresponding fi_addr_t.
+ * @param[in/out] entry_ptr	The pointer to an address in the entry table.
+ *
+ * @return FI_SUCCESS on successfully looking up the entry in the entry table.
+ * @return -FI_EINVAL upon passing an invalid parameter.
+ */
+int _gnix_table_lookup(struct gnix_fid_av *int_av,
+		       fi_addr_t fi_addr,
+		       struct gnix_av_addr_entry **entry_ptr);
+
+/**
+ * @brief (FI_AV_MAP) Return the gnix address using its corresponding
+ * fi_addr.
+ *
+ * @param[in] int_av		The AV to use for the lookup.
+ * @param[in] fi_addr		The corresponding fi_addr_t.
+ * @param[in/out] entry_ptr	The pointer to an address in the entry table.
+ *
+ * @return FI_SUCCESS on successfully looking up the entry in the entry table.
+ * @return -FI_EINVAL upon passing an invalid parameter.
+ */
+int _gnix_map_lookup(struct gnix_fid_av *int_av,
+		     fi_addr_t fi_addr,
+		     struct gnix_av_addr_entry **entry_ptr);
+
+/**
+ * @brief (FI_AV_TABLE) Return fi_addr using its corresponding gnix address.
+ *
+ * @param[in] int_av		The AV to use for the lookup.
+ * @param[in] gnix_addr		The gnix address
+ * @param[in/out] fi_addr	The pointer to the corresponding fi_addr.
+ *
+ * @return FI_SUCCESS on successfully looking up the entry in the entry table.
+ * @return -FI_EINVAL upon passing an invalid parameter.
+ */
+int _gnix_table_reverse_lookup(struct gnix_fid_av *int_av,
+			       struct gnix_address gnix_addr,
+			       fi_addr_t *fi_addr);
+
+/**
+ * @brief (FI_AV_MAP) Return fi_addr using its corresponding gnix address.
+ *
+ * @param[in] int_av		The AV to use for the lookup.
+ * @param[in] gnix_addr		The gnix address
+ * @param[in/out] fi_addr	The pointer to the corresponding fi_addr.
+ *
+ * @return FI_SUCCESS on successfully looking up the entry in the entry table.
+ * @return -FI_EINVAL upon passing an invalid parameter.
+ */
+int _gnix_map_reverse_lookup(struct gnix_fid_av *int_av,
+			     struct gnix_address gnix_addr,
+			     fi_addr_t *fi_addr);
+
 /**
  * @brief Return the string representation of the FI address.
  *

--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -54,6 +54,7 @@ extern "C" {
 #define GNIX_VC_MODE_DG_POSTED		(1U << 2)
 #define GNIX_VC_MODE_PENDING_MSGS	(1U << 3)
 #define GNIX_VC_MODE_PEER_CONNECTED	(1U << 4)
+#define GNIX_VC_MODE_IN_TABLE		(1U << 5)
 
 /* VC flags */
 #define GNIX_VC_FLAG_RX_SCHEDULED	0

--- a/prov/gni/src/gnix_av.c
+++ b/prov/gni/src/gnix_av.c
@@ -539,6 +539,33 @@ static int map_reverse_lookup(struct gnix_fid_av *int_av,
 /*******************************************************************************
  * FI_AV API implementations.
  ******************************************************************************/
+int _gnix_table_lookup(struct gnix_fid_av *int_av,
+		       fi_addr_t fi_addr,
+		       struct gnix_av_addr_entry **entry_ptr)
+{
+	return table_lookup(int_av, fi_addr, entry_ptr);
+}
+
+int _gnix_table_reverse_lookup(struct gnix_fid_av *int_av,
+			       struct gnix_address gnix_addr,
+			       fi_addr_t *fi_addr)
+{
+	return table_reverse_lookup(int_av, gnix_addr, fi_addr);
+}
+
+int _gnix_map_lookup(struct gnix_fid_av *int_av,
+		     fi_addr_t fi_addr,
+		     struct gnix_av_addr_entry **entry_ptr)
+{
+	return map_lookup(int_av, fi_addr, entry_ptr);
+}
+
+int _gnix_map_reverse_lookup(struct gnix_fid_av *int_av,
+			     struct gnix_address gnix_addr,
+			     fi_addr_t *fi_addr)
+{
+	return map_reverse_lookup(int_av, gnix_addr, fi_addr);
+}
 
 int _gnix_av_lookup(struct gnix_fid_av *gnix_av, fi_addr_t fi_addr,
 		    struct gnix_av_addr_entry **entry_ptr)


### PR DESCRIPTION
- When using FI_AV_TABLE the provider can use a vector to lookup vc's
- It was found that we cannot always perform a lookup in the av table when only the gnix_addr is provided since the gnix_addr, fi_addr pair is not always found by doing a reverse lookup in the av table. This is because the receiver may not have inserted it's fi_addr into the av during vc connection setup.
- @hppritcha added a fi_addr lookup function to quickly check for a vc in the vector without acquiring the vc_lock and return it if it's found; if the vc is not found in the table we must acquire the vc_lock and check the hash table for the vc, allocate and connect it if it's not found in the hash table, and insert the vc into the hash table and vector so we can use the fast vector lookup next time around.
- The ep structure now doesn't use a union for the vc_table and vc_ht members since both are initialized and used for the case of FI_AV_TABLE.
- The vc_ht and vc_table are initialized when the endpoint is bound.

Here are the new performance numbers using the changes in this PR that @hppritcha collected for `osu_mbw_mr` from the `osu-micro-benchmarks-5.0/mpi/pt2pt` benchmarks: http://hastebin.com/xetimodema.md.

The osu_mbw_mr tests in the link above show the message rate has increased by ~10% for messages of size 1-16 using the accelerated lookup with FI_AV_TABLE.

@sungeunchoi @chuckfossen @ztiffany @jswaro @jshimek
