### PR TITLE
prov/gni: replace info with warn

### DIFF
--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -767,7 +767,7 @@ int _gnix_rma_post_req(void *data)
 
 	if (status != GNI_RC_SUCCESS) {
 		_gnix_nic_tx_free(nic, txd);
-		GNIX_INFO(FI_LOG_EP_DATA, "GNI_Post*() failed: %s\n",
+		GNIX_WARN(FI_LOG_EP_DATA, "GNI_Post*() failed: %s\n",
 			  gni_err_str[status]);
 	}
 


### PR DESCRIPTION
If one of the GNI data motion ops fails, we should
report with WARN log level rather than buried in INFO
output.

Signed-off-by: Howard Pritchard howardp@lanl.gov
