### PR TITLE
Change GNIX_WARN to GNIX_INFO in gnix_vec_at

### DIFF
--- a/prov/gni/src/gnix_vector.c
+++ b/prov/gni/src/gnix_vector.c
@@ -226,7 +226,7 @@ inline int _gnix_vec_at(gnix_vector_t *vec, void **element, gnix_vec_index_t ind
 		if (likely((uint64_t) vec->vector[index])) {
 			*element = vec->vector[index];
 		} else {
-			GNIX_WARN(FI_LOG_EP_CTRL, "There is no element at index "
+			GNIX_INFO(FI_LOG_EP_CTRL, "There is no element at index "
 				  "%lu in _gnix_vec_at\n", index);
 			return -FI_ECANCELED;
 		}


### PR DESCRIPTION
- When _gnix_vec_at is called and the vector has a NULL value at the specified index, many unnecessary warnings are printed.

Fixes #788 
@tonyzinger @sungeunchoi 
