### PR TITLE
prov/gni: Updated gnitest.supp to ignore benign leak in gnix_getinfo

### DIFF
--- a/prov/gni/contrib/gnitest.supp
+++ b/prov/gni/contrib/gnitest.supp
@@ -57,6 +57,7 @@
    fun:_gnix_cm_nic_alloc
    fun:gnix_ep_open
    fun:fi_endpoint
+   fun:fi_getinfo@@FABRIC_1.0
 }
 
 #


### PR DESCRIPTION
This leak may be falsely reported due to calling fi_getinfo multiple times.  After freeing the memory valgrind was complaining about, assertions failed in gnitest.

Fixes #790 
@sungeunchoi 
