### PR TITLE
prov/gni: Remove Criterion assertion for checking that RDM and DGRAM info struct is the last in the list

### DIFF
--- a/prov/gni/test/ep.c
+++ b/prov/gni/test/ep.c
@@ -105,7 +105,6 @@ Test(endpoint_info, info)
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	cr_assert(!ret, "fi_getinfo");
 	cr_assert_eq(fi->ep_attr->type, FI_EP_RDM);
-	cr_assert_eq(fi->next, NULL);
 
 	fi_freeinfo(fi);
 
@@ -113,7 +112,6 @@ Test(endpoint_info, info)
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	cr_assert(!ret, "fi_getinfo");
 	cr_assert_eq(fi->ep_attr->type, FI_EP_DGRAM);
-	cr_assert_eq(fi->next, NULL);
 
 	fi_freeinfo(fi);
 	fi_freeinfo(hints);


### PR DESCRIPTION
@chuckfossen 

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com
