### PR TITLE
prov/gni: fix race condition in non-aligned send

### DIFF
--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -358,8 +358,7 @@ static int __gnix_rndzv_req_complete(void *arg, gni_return_t tx_status)
 		 * complete. */
 		req->msg.status |= tx_status;
 
-		atomic_dec(&req->msg.outstanding_txds);
-		if (atomic_get(&req->msg.outstanding_txds)) {
+		if (atomic_dec(&req->msg.outstanding_txds) == 1) {
 			_gnix_nic_tx_free(req->gnix_ep->nic, txd);
 			GNIX_INFO(FI_LOG_EP_DATA,
 				  "Received first RDMA chain TXD, req: %p\n",


### PR DESCRIPTION
There was a race condition in the non-aligned get
part of the send/recv path that caused hangs for
certain criterion tests.

@sungeunchoi 
Fixes ofi-cray/libfabric-cray#795

Signed-off-by: Howard Pritchard howardp@lanl.gov
