### PR TITLE
prov/gni: Reduced latency by 60ns - 23us of osu_latency tests

### DIFF
--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -50,6 +50,7 @@ extern "C" {
 #include "gnix_util.h"
 
 #define GNIX_DEF_MAX_NICS_PER_PTAG	4
+#define GNIX_N_CQES 64
 
 extern uint32_t gnix_max_nics_per_ptag;
 

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -491,33 +491,38 @@ static void __nic_get_completed_txd(struct gnix_nic *nic,
 static int __nic_tx_progress(struct gnix_nic *nic, gni_cq_handle_t cq)
 {
 	int ret = FI_SUCCESS;
-	gni_return_t tx_status;
-	struct gnix_tx_descriptor *txd;
+	int i = 0;
+	gni_return_t tx_status[GNIX_N_CQES];
+	struct gnix_tx_descriptor *txd[GNIX_N_CQES] = {NULL};
 
 	do {
-		txd = NULL;
-
 		COND_ACQUIRE(nic->requires_lock, &nic->lock);
-		__nic_get_completed_txd(nic, cq, &txd,
-					&tx_status);
+		for (i = 0; i < GNIX_N_CQES; i++) {
+			__nic_get_completed_txd(nic, cq, &txd[i],
+						&tx_status[i]);
+
+			if (txd[i] == NULL)
+				break;
+		}
 		COND_RELEASE(nic->requires_lock, &nic->lock);
 
-		if (txd && txd->completer_fn) {
-			ret = txd->completer_fn(txd, tx_status);
-			if (ret != FI_SUCCESS) {
-				/*
-				 * TODO: need to post error to CQ
-				 */
-				GNIX_WARN(FI_LOG_EP_DATA,
-					  "TXD completer failed: %d", ret);
+		for (i = 0; i < GNIX_N_CQES; i++) {
+			if (txd[i] && (txd[i])->completer_fn) {
+				ret = (txd[i])->completer_fn(txd[i], tx_status[i]);
+				if (ret != FI_SUCCESS) {
+					/*
+					 * TODO: need to post error to CQ
+					 */
+					GNIX_WARN(FI_LOG_EP_DATA,
+						  "TXD completer failed: %d", ret);
+				}
+			}
+
+			if ((txd[i] == NULL) || ret != FI_SUCCESS) {
+				return ret;
 			}
 		}
-
-		if ((txd == NULL) || ret != FI_SUCCESS)
-			break;
 	} while (1);
-
-	return ret;
 }
 
 int _gnix_nic_progress(struct gnix_nic *nic)


### PR DESCRIPTION
- Only acquire nic->lock once for each call to __nic_tx_progress before attempting to get 64 (GNIX_N_CQES) txds.

_osu-micro-benchmarks-5.0/mpi/pt2pt/osu_latency at_ 37c2af66

```
# OSU MPI Latency Test v5.0
# Size          Latency (us)
0                       2.05
1                       2.07
2                       2.04
4                       2.05
8                       2.05
16                      2.04
32                      2.05
64                      2.06
128                     2.07
256                     2.09
512                     2.13
1024                    2.45
2048                    2.80
4096                    3.57
8192                    5.32
16384                  15.47
32768                  16.97
65536                  20.52
131072                 28.01
262144                 42.37
524288                 72.02
1048576               130.71
2097152               255.17
4194304               515.15
```

With the changes proposed in this PR

```
# OSU MPI Latency Test v5.0
# Size          Latency (us)
0                       1.99
1                       1.99
2                       1.98
4                       1.98
8                       1.99
16                      1.98
32                      1.96
64                      1.95
128                     1.97
256                     2.01
512                     2.06
1024                    2.33
2048                    2.65
4096                    3.37
8192                    4.99
16384                  13.92
32768                  15.66
65536                  18.86
131072                 25.92
262144                 39.97
524288                 67.84
1048576               124.07
2097152               246.69
4194304               492.29
```

Fixes #799 

@hppritcha @ztiffany 
