### PR TITLE
prov/gni: Changed GNIX_INFO to GNIX_DEBUG in critical functions.

### DIFF
--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -308,7 +308,7 @@ ssize_t _gnix_cq_add_event(struct gnix_fid_cq *cq, void *op_context,
 	event->src_addr = src_addr;
 
 	_gnix_queue_enqueue(cq->events, &event->item);
-	GNIX_INFO(FI_LOG_CQ, "Added event: %lx\n", op_context);
+	GNIX_DEBUG(FI_LOG_CQ, "Added event: %lx\n", op_context);
 
 	if (cq->wait)
 		_gnix_signal_wait_obj(cq->wait);

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -752,7 +752,7 @@ static int __smsg_eager_msg_w_data(void *data, void *msg)
 		req->msg.tag = hdr->msg_tag;
 		req->msg.imm = hdr->imm;
 
-		GNIX_INFO(FI_LOG_EP_DATA, "Matched req: %p (%p, %u)\n",
+		GNIX_DEBUG(FI_LOG_EP_DATA, "Matched req: %p (%p, %u)\n",
 			  req, req->msg.recv_addr, req->msg.send_len);
 
 		memcpy((void *)req->msg.recv_addr, data_ptr, req->msg.send_len);
@@ -763,13 +763,13 @@ static int __smsg_eager_msg_w_data(void *data, void *msg)
 		if ((req->msg.recv_flags & FI_MULTI_RECV) &&
 		    ((req->msg.recv_len - req->msg.send_len) >=
 		     ep->min_multi_recv)) {
-			GNIX_INFO(FI_LOG_EP_DATA, "Re-using req: %p\n", req);
+			GNIX_DEBUG(FI_LOG_EP_DATA, "Re-using req: %p\n", req);
 
 			/* Adjust receive buffer for the next match. */
 			req->msg.recv_addr += req->msg.send_len;
 			req->msg.recv_len -= req->msg.send_len;
 		} else {
-			GNIX_INFO(FI_LOG_EP_DATA, "Freeing req: %p\n", req);
+			GNIX_DEBUG(FI_LOG_EP_DATA, "Freeing req: %p\n", req);
 
 			/* Dequeue and free the request. */
 			_gnix_remove_tag(posted_queue, req);
@@ -805,7 +805,7 @@ static int __smsg_eager_msg_w_data(void *data, void *msg)
 
 		_gnix_insert_tag(unexp_queue, req->msg.tag, req, ~0);
 
-		GNIX_INFO(FI_LOG_EP_DATA, "New req: %p (%u)\n",
+		GNIX_DEBUG(FI_LOG_EP_DATA, "New req: %p (%u)\n",
 			  req, req->msg.send_len);
 	}
 
@@ -1289,7 +1289,7 @@ retry_match:
 
 		if (req->msg.send_flags & GNIX_MSG_RENDEZVOUS) {
 			/* Matched rendezvous request.  Start data movement. */
-			GNIX_INFO(FI_LOG_EP_DATA, "matched RNDZV, req: %p\n",
+			GNIX_DEBUG(FI_LOG_EP_DATA, "matched RNDZV, req: %p\n",
 				  req);
 
 			/*
@@ -1323,7 +1323,7 @@ retry_match:
 				buf += req->msg.send_len;
 				len -= req->msg.send_len;
 
-				GNIX_INFO(FI_LOG_EP_DATA,
+				GNIX_DEBUG(FI_LOG_EP_DATA,
 					  "Attempting additional matches, "
 					  "req: %p (%p %u)\n",
 					  req, buf, len);
@@ -1332,7 +1332,7 @@ retry_match:
 		} else {
 			/* Matched eager request.  Copy data and generate
 			 * completions. */
-			GNIX_INFO(FI_LOG_EP_DATA, "Matched recv, req: %p\n",
+			GNIX_DEBUG(FI_LOG_EP_DATA, "Matched recv, req: %p\n",
 				  req);
 
 			/* Send length is truncated to receive buffer size. */
@@ -1354,7 +1354,7 @@ retry_match:
 				buf += req->msg.send_len;
 				len -= req->msg.send_len;
 
-				GNIX_INFO(FI_LOG_EP_DATA,
+				GNIX_DEBUG(FI_LOG_EP_DATA,
 					  "Attempting additional matches, "
 					  "req: %p (%p %u)\n",
 					  req, buf, len);
@@ -1386,7 +1386,7 @@ retry_match:
 			goto err;
 		}
 
-		GNIX_INFO(FI_LOG_EP_DATA, "New recv, req: %p\n", req);
+		GNIX_DEBUG(FI_LOG_EP_DATA, "New recv, req: %p\n", req);
 
 		req->type = GNIX_FAB_RQ_RECV;
 
@@ -1599,14 +1599,14 @@ ssize_t _gnix_send(struct gnix_fid_ep *ep, uint64_t loc_addr, size_t len,
 				 len, FI_READ | FI_WRITE, 0, 0, 0,
 				 &auto_mr, NULL);
 		if (ret != FI_SUCCESS) {
-			GNIX_INFO(FI_LOG_EP_DATA,
+			GNIX_DEBUG(FI_LOG_EP_DATA,
 				  "Failed to auto-register local buffer: %d\n",
 				  ret);
 			return ret;
 		}
 		flags |= FI_LOCAL_MR;
 		mdesc = (void *)auto_mr;
-		GNIX_INFO(FI_LOG_EP_DATA, "auto-reg MR: %p\n", auto_mr);
+		GNIX_DEBUG(FI_LOG_EP_DATA, "auto-reg MR: %p\n", auto_mr);
 	}
 
 	ret = _gnix_vc_ep_get_vc(ep, dest_addr, &vc);
@@ -1668,7 +1668,7 @@ ssize_t _gnix_send(struct gnix_fid_ep *ep, uint64_t loc_addr, size_t len,
 		req->msg.send_flags |= GNIX_MSG_RENDEZVOUS;
 	}
 
-	GNIX_INFO(FI_LOG_EP_DATA, "Queuing (%p %d)\n",
+	GNIX_DEBUG(FI_LOG_EP_DATA, "Queuing (%p %d)\n",
 		  (void *)loc_addr, len);
 
 	return _gnix_vc_queue_tx_req(req);
@@ -1680,4 +1680,3 @@ err_get_vc:
 	}
 	return ret;
 }
-

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -332,13 +332,13 @@ static int __process_rx_cqe(struct gnix_nic *nic, gni_cq_entry_t cqe)
 
 #if 1 /* Process RX inline with arrival of an RX CQE. */
 	if (unlikely(vc->conn_state != GNIX_VC_CONNECTED)) {
-		GNIX_INFO(FI_LOG_EP_DATA,
+		GNIX_DEBUG(FI_LOG_EP_DATA,
 			  "Scheduling VC for RX processing (%p)\n",
 			  vc);
 		ret = _gnix_vc_rx_schedule(vc);
 		assert(ret == FI_SUCCESS);
 	} else {
-		GNIX_INFO(FI_LOG_EP_DATA,
+		GNIX_DEBUG(FI_LOG_EP_DATA,
 			  "Processing VC RX (%p)\n",
 			  vc);
 		ret = _gnix_vc_dequeue_smsg(vc);

--- a/prov/gni/src/gnix_tags.c
+++ b/prov/gni/src/gnix_tags.c
@@ -836,7 +836,7 @@ int _gnix_insert_tag(
 {
 	int ret;
 
-	GNIX_INFO(FI_LOG_EP_CTRL, "inserting a message by tag, "
+	GNIX_DEBUG(FI_LOG_EP_CTRL, "inserting a message by tag, "
 				"ts=%p tag=%llx req=%p\n", ts, tag, req);
 	req->msg.tag = tag;
 	if (ts->match_func == _gnix_match_posted_tag) {
@@ -845,7 +845,7 @@ int _gnix_insert_tag(
 
 	ret = ts->ops->insert_tag(ts, tag, req);
 
-	GNIX_INFO(FI_LOG_EP_CTRL, "ret=%i\n", ret);
+	GNIX_DEBUG(FI_LOG_EP_CTRL, "ret=%i\n", ret);
 
 	return ret;
 }
@@ -864,12 +864,12 @@ static struct gnix_fab_req *__remove_by_tag_and_addr(
 	struct gnix_fab_req *ret;
 
 	/* assuming that flags and context are correct */
-	GNIX_INFO(FI_LOG_EP_CTRL, "removing a message by tag, "
+	GNIX_DEBUG(FI_LOG_EP_CTRL, "removing a message by tag, "
 			"ts=%p tag=%llx ignore=%llx flags=%llx context=%p "
 			"addr=%p\n",
 			ts, tag, ignore, flags, context, addr);
 	ret = ts->ops->remove_tag(ts, tag, ignore, flags, context, addr);
-	GNIX_INFO(FI_LOG_EP_CTRL, "ret=%p\n", ret);
+	GNIX_DEBUG(FI_LOG_EP_CTRL, "ret=%p\n", ret);
 
 	return ret;
 }
@@ -885,7 +885,7 @@ static struct gnix_fab_req *__peek_by_tag_and_addr(
 	struct gnix_fab_req *ret;
 
 	/* assuming that flags and context are correct */
-	GNIX_INFO(FI_LOG_EP_CTRL, "peeking a message by tag, "
+	GNIX_DEBUG(FI_LOG_EP_CTRL, "peeking a message by tag, "
 			"ts=%p tag=%llx ignore=%llx flags=%llx context=%p "
 			"addr=%p\n",
 			ts, tag, ignore, flags, context, addr);
@@ -896,7 +896,7 @@ static struct gnix_fab_req *__peek_by_tag_and_addr(
 		ret->msg.tle.context = context;
 	}
 
-	GNIX_INFO(FI_LOG_EP_CTRL, "ret=%p\n", ret);
+	GNIX_DEBUG(FI_LOG_EP_CTRL, "ret=%p\n", ret);
 
 	return ret;
 }

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -1751,7 +1751,7 @@ int _gnix_vc_dequeue_smsg(struct gnix_vc *vc)
 					     &tag);
 
 		if (status == GNI_RC_SUCCESS) {
-			GNIX_INFO(FI_LOG_EP_DATA, "Found RX (%p)\n", vc);
+			GNIX_DEBUG(FI_LOG_EP_DATA, "Found RX (%p)\n", vc);
 			ret = nic->smsg_callbacks[tag](vc, msg_ptr);
 			if (ret != FI_SUCCESS) {
 				/* Stalled, reschedule */
@@ -2018,7 +2018,7 @@ int _gnix_vc_queue_tx_req(struct gnix_fab_req *req)
 		 * requests are completed.  Subsequent requests will be queued
 		 * due to non-empty tx_queue. */
 		queue_tx = 1;
-		GNIX_INFO(FI_LOG_EP_DATA,
+		GNIX_DEBUG(FI_LOG_EP_DATA,
 			  "Queued FI_FENCE request (%p) on VC\n",
 			  req);
 	} else if (connected && dlist_empty(&vc->tx_queue)) {
@@ -2027,19 +2027,19 @@ int _gnix_vc_queue_tx_req(struct gnix_fab_req *req)
 		/* try to initiate request */
 		rc = req->work_fn(req);
 		if (rc == FI_SUCCESS) {
-			GNIX_INFO(FI_LOG_EP_DATA,
+			GNIX_DEBUG(FI_LOG_EP_DATA,
 				  "TX request processed: %p (OTX: %d)\n",
 				  req, atomic_get(&vc->outstanding_tx_reqs));
 		} else if (rc != -FI_ECANCELED) {
 			atomic_dec(&vc->outstanding_tx_reqs);
 			queue_tx = 1;
-			GNIX_INFO(FI_LOG_EP_DATA,
+			GNIX_DEBUG(FI_LOG_EP_DATA,
 				  "Queued request (%p) on full VC\n",
 				  req);
 		}
 	} else {
 		queue_tx = 1;
-		GNIX_INFO(FI_LOG_EP_DATA,
+		GNIX_DEBUG(FI_LOG_EP_DATA,
 			  "Queued request (%p) on busy VC\n",
 			  req);
 	}
@@ -2112,7 +2112,7 @@ static int __gnix_vc_push_tx_reqs(struct gnix_vc *vc)
 	while (req) {
 		if ((req->flags & FI_FENCE) &&
 		    atomic_get(&vc->outstanding_tx_reqs)) {
-			GNIX_INFO(FI_LOG_EP_DATA,
+			GNIX_DEBUG(FI_LOG_EP_DATA,
 				  "TX request queue stalled on FI_FENCE request: %p (%d)\n",
 				  req, atomic_get(&vc->outstanding_tx_reqs));
 			/* Success is returned to allow processing of more VCs.
@@ -2126,7 +2126,7 @@ static int __gnix_vc_push_tx_reqs(struct gnix_vc *vc)
 
 		ret = req->work_fn(req);
 		if (ret == FI_SUCCESS) {
-			GNIX_INFO(FI_LOG_EP_DATA,
+			GNIX_DEBUG(FI_LOG_EP_DATA,
 				  "TX request processed: %p (OTX: %d)\n",
 				  req, atomic_get(&vc->outstanding_tx_reqs));
 		} else if (ret != -FI_ECANCELED) {
@@ -2134,7 +2134,7 @@ static int __gnix_vc_push_tx_reqs(struct gnix_vc *vc)
 			 * back on the end of the list and return
 			 * -FI_EAGAIN. */
 
-			GNIX_INFO(FI_LOG_EP_DATA,
+			GNIX_DEBUG(FI_LOG_EP_DATA,
 				  "Failed to push TX request %p: %s\n",
 				  req, fi_strerror(-ret));
 			fi_rc = -FI_EAGAIN;


### PR DESCRIPTION
Profiling data collected using gperftools revealed that a significant amount of time is being spent in GNIX_INFO.  Using the call graphs, the "critical" functions that call GNIX_INFO frequently were found.
- This change reduces latency by ~80ns for the osu_latency tests.

At c0c2288a

```
# OSU MPI Latency Test v5.0
# Size          Latency (us)
0                       1.86
1                       1.87
2                       1.87
4                       1.86
8                       1.86
16                      1.87
32                      1.87
64                      1.87
128                     1.87
256                     1.89
512                     1.92
1024                    2.21
2048                    2.51
4096                    3.19
8192                    4.76
16384                  13.07
32768                  14.54
65536                  17.77
131072                 24.37
262144                 37.61
524288                 64.03
1048576               116.91
2097152               240.48
4194304               479.65
```

After the changes in this PR

```
# OSU MPI Latency Test v5.0
# Size          Latency (us)
0                       1.78
1                       1.79
2                       1.78
4                       1.77
8                       1.77
16                      1.78
32                      1.78
64                      1.78
128                     1.79
256                     1.81
512                     1.86
1024                    2.13
2048                    2.44
4096                    3.13
8192                    4.67
16384                  13.04
32768                  14.52
65536                  17.84
131072                 24.42
262144                 37.69
524288                 64.24
1048576               116.99
2097152               239.81
4194304               478.69
```

Fixes #801 

@sungeunchoi @ztiffany 
