### PR TITLE
prov/gni: Replaced appropriate calls to memcpy.

### DIFF
--- a/prov/gni/src/gnix_av.c
+++ b/prov/gni/src/gnix_av.c
@@ -446,12 +446,12 @@ static int map_insert(struct gnix_fid_av *int_av, const void *addr,
 
 		((struct gnix_address *)fi_addr)[i] = temp.gnix_addr;
 		the_entry =  &blk->base[i];
-		memcpy(&the_entry->gnix_addr, &temp.gnix_addr,
-		       sizeof(struct gnix_address));
+		the_entry->gnix_addr.device_addr = temp.gnix_addr.device_addr;
+		the_entry->gnix_addr.cdm_id = temp.gnix_addr.cdm_id;
 		the_entry->name_type = temp.name_type;
 		the_entry->cm_nic_cdm_id = temp.cm_nic_cdm_id;
 		the_entry->cookie = temp.cookie;
-		memcpy(&key, &temp.gnix_addr, sizeof(gnix_ht_key_t));
+		key = *((gnix_ht_key_t *) &temp.gnix_addr);
 		ret = _gnix_ht_insert(int_av->map_ht,
 				      key,
 				      the_entry);
@@ -663,8 +663,8 @@ DIRECT_FN STATIC int gnix_av_lookup(struct fid_av *av, fi_addr_t fi_addr,
 		return rc;
 	}
 
-	memcpy(&ep_name.gnix_addr, &entry->gnix_addr,
-	       sizeof(struct gnix_address));
+	ep_name.gnix_addr.device_addr = entry->gnix_addr.device_addr;
+	ep_name.gnix_addr.cdm_id = entry->gnix_addr.cdm_id;
 	ep_name.name_type = entry->name_type;
 	ep_name.cm_nic_cdm_id = entry->cm_nic_cdm_id;
 	ep_name.cookie = entry->cookie;

--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -509,7 +509,7 @@ DIRECT_FN STATIC ssize_t gnix_cq_readfrom(struct fid_cq *cq, void *buf,
 		assert(event->the_entry);
 		memcpy(buf, event->the_entry, cq_priv->entry_size);
 		if (src_addr)
-			memcpy(src_addr, &event->src_addr, sizeof(fi_addr_t));
+			*src_addr = event->src_addr;
 
 		_gnix_queue_enqueue_free(cq_priv->events, &event->item);
 
@@ -592,7 +592,7 @@ DIRECT_FN STATIC ssize_t gnix_cq_readerr(struct fid_cq *cq,
 
 	event = container_of(entry, struct gnix_cq_entry, item);
 
-	memcpy(buf, event->the_entry, sizeof(struct fi_cq_err_entry));
+	*buf = *((struct fi_cq_err_entry *) event->the_entry);
 
 	_gnix_queue_enqueue_free(cq_priv->errors, &event->item);
 

--- a/prov/gni/src/gnix_hashtable.c
+++ b/prov/gni/src/gnix_hashtable.c
@@ -623,7 +623,14 @@ int _gnix_ht_init(gnix_hashtable_t *ht, gnix_hashtable_attr_t *attr)
 	if (ht->ht_state == GNIX_HT_STATE_READY)
 		return -FI_EINVAL;
 
-	memcpy(&ht->ht_attr, tbl_attr, sizeof(gnix_hashtable_attr_t));
+	ht->ht_attr.ht_initial_size = tbl_attr->ht_initial_size;
+	ht->ht_attr.ht_maximum_size = tbl_attr->ht_maximum_size;
+	ht->ht_attr.ht_increase_step = tbl_attr->ht_increase_step;
+	ht->ht_attr.ht_increase_type = tbl_attr->ht_increase_type;
+	ht->ht_attr.ht_collision_thresh = tbl_attr->ht_collision_thresh;
+	ht->ht_attr.ht_hash_seed = tbl_attr->ht_hash_seed;
+	ht->ht_attr.ht_internal_locking = tbl_attr->ht_internal_locking;
+	ht->ht_attr.destructor = tbl_attr->destructor;
 	ht->ht_size = ht->ht_attr.ht_initial_size;
 
 	if (ht->ht_attr.ht_internal_locking)

--- a/prov/gni/src/gnix_mr_cache.c
+++ b/prov/gni/src/gnix_mr_cache.c
@@ -637,7 +637,7 @@ int _gnix_mr_cache_init(
 		return -FI_ENOMEM;
 
 	/* save the attribute values */
-	memcpy(&cache_p->attr, cache_attr, sizeof(*cache_attr));
+	cache_p->attr = *cache_attr;
 
 	/* list is used because entries can be removed from the stale list if
 	 *   a user might call register on a stale entry's memory region
@@ -1219,4 +1219,3 @@ int _gnix_mr_cache_deregister(
 
 	return gnixu_to_fi_errno(grc);
 }
-

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -66,7 +66,7 @@ static struct gnix_fab_req *__gnix_msg_dup_req(struct gnix_fab_req *req)
 	}
 
 	/* TODO: selectively copy fields. */
-	memcpy((void *)new_req, (void *)req, sizeof(*req));
+	*new_req = *req;
 
 	return new_req;
 }
@@ -1680,4 +1680,3 @@ err_get_vc:
 	}
 	return ret;
 }
-

--- a/prov/gni/src/gnix_tags.c
+++ b/prov/gni/src/gnix_tags.c
@@ -475,7 +475,8 @@ int _gnix_tag_storage_init(
 
 
 	/* copy attributes */
-	memcpy(&ts->attr, attributes, sizeof(struct gnix_tag_storage_attr));
+	ts->attr.type = attributes->type;
+	ts->attr.use_src_addr_matching = attributes->use_src_addr_matching;
 
 	switch (ts->attr.type) {
 	case GNIX_TAG_AUTOSELECT:

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -254,14 +254,14 @@ err:
  *                  originating EP for this connection)
  * - src_irq_cq_mhdl (GNI memory handle for irq cq for originating EP)
  */
-static void __gnix_vc_pack_conn_req(char *sbuf,
-				    struct gnix_address *target_addr,
-				    struct gnix_address *src_addr,
-				    int src_vc_id,
-				    uint64_t src_vc_vaddr,
-				    gni_smsg_attr_t *src_smsg_attr,
-				    gni_mem_handle_t *src_irq_cq_mhdl,
-				    uint64_t caps)
+static inline void __gnix_vc_pack_conn_req(char *sbuf,
+					   struct gnix_address *target_addr,
+					   struct gnix_address *src_addr,
+					   int src_vc_id,
+					   uint64_t src_vc_vaddr,
+					   gni_smsg_attr_t *src_smsg_attr,
+					   gni_mem_handle_t *src_irq_cq_mhdl,
+					   uint64_t caps)
 {
 	size_t __attribute__((unused)) len;
 	char *cptr = sbuf;
@@ -281,34 +281,34 @@ static void __gnix_vc_pack_conn_req(char *sbuf,
 	      sizeof(gni_mem_handle_t);
 	assert(len <= GNIX_CM_NIC_MAX_MSG_SIZE);
 
-	memcpy(cptr, &rtype, sizeof(rtype));
+	*((uint8_t *)cptr) = rtype;
 	cptr += sizeof(rtype);
-	memcpy(cptr, target_addr, sizeof(struct gnix_address));
+	*((struct gnix_address *) cptr) = *target_addr;
 	cptr += sizeof(struct gnix_address);
-	memcpy(cptr, src_addr, sizeof(struct gnix_address));
+	*((struct gnix_address *) cptr) = *src_addr;
 	cptr += sizeof(struct gnix_address);
-	memcpy(cptr, &src_vc_id, sizeof(int));
+	*((int *) cptr) = src_vc_id;
 	cptr += sizeof(int);
-	memcpy(cptr, &src_vc_vaddr, sizeof(uint64_t));
+	*((uint64_t *) cptr) = src_vc_vaddr;
 	cptr += sizeof(uint64_t);
-	memcpy(cptr, src_smsg_attr, sizeof(gni_smsg_attr_t));
+	*((gni_smsg_attr_t *) cptr) = *src_smsg_attr;
 	cptr += sizeof(gni_smsg_attr_t);
-	memcpy(cptr, src_irq_cq_mhdl, sizeof(gni_mem_handle_t));
+	*((gni_mem_handle_t *) cptr) = *src_irq_cq_mhdl;
 	cptr += sizeof(gni_mem_handle_t);
-	memcpy(cptr, &caps, sizeof(uint64_t));
+	*((uint64_t *) cptr) = caps;
 }
 
 /*
  * unpack a connection request message
  */
-static void __gnix_vc_unpack_conn_req(char *rbuf,
-				      struct gnix_address *target_addr,
-				      struct gnix_address *src_addr,
-				      int *src_vc_id,
-				      uint64_t *src_vc_vaddr,
-				      gni_smsg_attr_t *src_smsg_attr,
-				      gni_mem_handle_t *src_irq_cq_mhndl,
-				      uint64_t *caps)
+static inline void __gnix_vc_unpack_conn_req(char *rbuf,
+					     struct gnix_address *target_addr,
+					     struct gnix_address *src_addr,
+					     int *src_vc_id,
+					     uint64_t *src_vc_vaddr,
+					     gni_smsg_attr_t *src_smsg_attr,
+					     gni_mem_handle_t *src_irq_cq_mhndl,
+					     uint64_t *caps)
 {
 	size_t __attribute__((unused)) len;
 	char *cptr = rbuf;
@@ -320,19 +320,19 @@ static void __gnix_vc_unpack_conn_req(char *rbuf,
 	assert(rbuf);
 
 	cptr += sizeof(uint8_t);
-	memcpy(target_addr, cptr, sizeof(struct gnix_address));
+	*target_addr = 	*((struct gnix_address *) cptr);
 	cptr += sizeof(struct gnix_address);
-	memcpy(src_addr, cptr, sizeof(struct gnix_address));
+	*src_addr = *((struct gnix_address *) cptr);
 	cptr += sizeof(struct gnix_address);
-	memcpy(src_vc_id, cptr, sizeof(int));
+	*src_vc_id = *((int *) cptr);
 	cptr += sizeof(int);
-	memcpy(src_vc_vaddr, cptr, sizeof(uint64_t));
+	*src_vc_vaddr = *((uint64_t *) cptr);
 	cptr += sizeof(uint64_t);
-	memcpy(src_smsg_attr, cptr, sizeof(gni_smsg_attr_t));
+	*src_smsg_attr = *((gni_smsg_attr_t *) cptr);
 	cptr += sizeof(gni_smsg_attr_t);
-	memcpy(src_irq_cq_mhndl, cptr, sizeof(gni_mem_handle_t));
+	*src_irq_cq_mhndl = *((gni_mem_handle_t *) cptr);
 	cptr += sizeof(gni_mem_handle_t);
-	memcpy(caps, cptr, sizeof(uint64_t));
+	*caps = *((uint64_t *) cptr);
 }
 
 /*
@@ -346,13 +346,13 @@ static void __gnix_vc_unpack_conn_req(char *rbuf,
  * - resp_irq_cq_mhndl (GNI memhndl for irq cq of responding EP)
  */
 
-static void __gnix_vc_pack_conn_resp(char *sbuf,
-				     uint64_t src_vc_vaddr,
-				     uint64_t resp_vc_vaddr,
-				     int resp_vc_id,
-				     gni_smsg_attr_t *resp_smsg_attr,
-				     gni_mem_handle_t *resp_irq_cq_mhndl,
-				     uint64_t caps)
+static inline void __gnix_vc_pack_conn_resp(char *sbuf,
+					    uint64_t src_vc_vaddr,
+					    uint64_t resp_vc_vaddr,
+					    int resp_vc_id,
+					    gni_smsg_attr_t *resp_smsg_attr,
+					    gni_mem_handle_t *resp_irq_cq_mhndl,
+					    uint64_t caps)
 {
 	size_t __attribute__((unused)) len;
 	char *cptr = sbuf;
@@ -371,54 +371,53 @@ static void __gnix_vc_pack_conn_resp(char *sbuf,
 	      sizeof(gni_mem_handle_t);
 	assert(len <= GNIX_CM_NIC_MAX_MSG_SIZE);
 
-	memcpy(cptr, &rtype, sizeof(rtype));
+	*((uint8_t *)cptr) = rtype;
 	cptr += sizeof(rtype);
-	memcpy(cptr, &src_vc_vaddr, sizeof(uint64_t));
+	*((uint64_t *) cptr) = src_vc_vaddr;
 	cptr += sizeof(uint64_t);
-	memcpy(cptr, &resp_vc_vaddr, sizeof(uint64_t));
+	*((uint64_t *) cptr) = resp_vc_vaddr;
 	cptr += sizeof(uint64_t);
-	memcpy(cptr, &resp_vc_id, sizeof(int));
+	*((int *) cptr) = resp_vc_id;
 	cptr += sizeof(int);
-	memcpy(cptr, resp_smsg_attr, sizeof(gni_smsg_attr_t));
+	*((gni_smsg_attr_t *) cptr) = *resp_smsg_attr;
 	cptr += sizeof(gni_smsg_attr_t);
-	memcpy(cptr, resp_irq_cq_mhndl, sizeof(gni_mem_handle_t));
+	*((gni_mem_handle_t *) cptr) = *resp_irq_cq_mhndl;
 	cptr += sizeof(gni_mem_handle_t);
-	memcpy(cptr, &caps, sizeof(uint64_t));
+	*((uint64_t *) cptr) = caps;
 }
 
 /*
  * unpack a connection request response
  */
-static void __gnix_vc_unpack_resp(char *rbuf,
-				  uint64_t *src_vc_vaddr,
-				  uint64_t *resp_vc_vaddr,
-				  int *resp_vc_id,
-				  gni_smsg_attr_t *resp_smsg_attr,
-				  gni_mem_handle_t *resp_irq_cq_mhndl,
-				  uint64_t *caps)
+static inline void __gnix_vc_unpack_resp(char *rbuf,
+					 uint64_t *src_vc_vaddr,
+					 uint64_t *resp_vc_vaddr,
+					 int *resp_vc_id,
+					 gni_smsg_attr_t *resp_smsg_attr,
+					 gni_mem_handle_t *resp_irq_cq_mhndl,
+					 uint64_t *caps)
 {
 	char *cptr = rbuf;
 
 	cptr += sizeof(uint8_t);
-
-	memcpy(src_vc_vaddr, cptr, sizeof(uint64_t));
+	*src_vc_vaddr = *((uint64_t *) cptr);
 	cptr += sizeof(uint64_t);
-	memcpy(resp_vc_vaddr, cptr, sizeof(uint64_t));
+	*resp_vc_vaddr = *((uint64_t *) cptr);
 	cptr += sizeof(uint64_t);
-	memcpy(resp_vc_id, cptr, sizeof(int));
+	*resp_vc_id = *((int *) cptr);
 	cptr += sizeof(int);
-	memcpy(resp_smsg_attr, cptr, sizeof(gni_smsg_attr_t));
+	*resp_smsg_attr = *((gni_smsg_attr_t *) cptr);
 	cptr += sizeof(gni_smsg_attr_t);
-	memcpy(resp_irq_cq_mhndl, cptr, sizeof(gni_mem_handle_t));
+	*resp_irq_cq_mhndl = *((gni_mem_handle_t *) cptr);
 	cptr += sizeof(gni_mem_handle_t);
-	memcpy(caps, cptr, sizeof(uint64_t));
+	*caps = *((uint64_t *) cptr);
 }
 
-static void __gnix_vc_get_msg_type(char *rbuf,
-				  uint8_t *rtype)
+static inline void __gnix_vc_get_msg_type(char *rbuf,
+					  uint8_t *rtype)
 {
 	assert(rtype);
-	memcpy(rtype, rbuf, sizeof(uint8_t));
+	*rtype = *((uint8_t *) rbuf);
 }
 
 /*
@@ -955,9 +954,11 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 			ret = -FI_ENOMEM;
 			goto err;
 		}
+
 		memcpy(&data->src_smsg_attr,
 		       &src_smsg_attr,
 		       sizeof(src_smsg_attr));
+		/* data->src_smsg_attr = src_smsg_attr; */
 		data->vc = vc;
 		data->src_vc_id = src_vc_id;
 		data->src_vc_ptr = src_vc_ptr;
@@ -1398,9 +1399,9 @@ int _gnix_vc_alloc(struct gnix_fid_ep *ep_priv,
 
 	vc_ptr->conn_state = GNIX_VC_CONN_NONE;
 	if (entry) {
-		memcpy(&vc_ptr->peer_addr,
-			&entry->gnix_addr,
-			sizeof(struct gnix_address));
+		vc_ptr->peer_addr.device_addr = entry->gnix_addr.device_addr;
+		vc_ptr->peer_addr.cdm_id = entry->gnix_addr.cdm_id;
+
 		vc_ptr->peer_cm_nic_addr.device_addr =
 			entry->gnix_addr.device_addr;
 		vc_ptr->peer_cm_nic_addr.cdm_id =

--- a/prov/gni/src/gnix_vector.c
+++ b/prov/gni/src/gnix_vector.c
@@ -102,7 +102,12 @@ static inline int __gnix_vec_create(gnix_vector_t *vec, gnix_vec_attr_t *attr)
 		attr->cur_size = attr->vec_initial_size;
 	}
 
-	memcpy(&vec->attr, attr, sizeof(gnix_vec_attr_t));
+	vec->attr.vec_initial_size = attr->vec_initial_size;
+	vec->attr.cur_size = attr->cur_size;
+	vec->attr.vec_maximum_size = attr->vec_maximum_size;
+	vec->attr.vec_increase_step = attr->vec_increase_step;
+	vec->attr.vec_increase_type = attr->vec_increase_type;
+	vec->attr.vec_internal_locking = attr->vec_internal_locking;
 
 	return FI_SUCCESS;
 }


### PR DESCRIPTION
- During profiling the gni provider it was found that ~1% of the time spent for the osu_mbw_mr tests were spent in calls to memcpy.
- Replacing memcpy calls with assignments has reduced the latency in the osu_latency tests by ~35ns.
- During testing this change it was found that, when possible, initilizing individual structure members one at a time is faster than assigning the entire structure to another, entire, structure.
- The pack/unpack functions in gnix_vc.c have been marked with the inline keyword.

At c0c2288a

```
# OSU MPI Latency Test v5.0
# Size          Latency (us)
0                       2.84
1                       2.85
2                       2.85
4                       2.84
8                       2.84
16                      2.84
32                      2.85
64                      2.85
128                     2.85
256                     2.88
512                     2.91
1024                    3.21
2048                    3.55
4096                    4.33
8192                    5.96
16384                  17.85
32768                  19.44
65536                  22.73
131072                 29.31
262144                 42.60
524288                 69.08
1048576               122.28
2097152               247.01
4194304               487.29
```

With the changed proposed in this PR

```
# OSU MPI Latency Test v5.0
# Size          Latency (us)
0                       2.81
1                       2.81
2                       2.80
4                       2.80
8                       2.81
16                      2.80
32                      2.81
64                      2.81
128                     2.81
256                     2.84
512                     2.87
1024                    3.19
2048                    3.52
4096                    4.23
8192                    5.88
16384                  17.72
32768                  19.17
65536                  22.42
131072                 28.99
262144                 42.30
524288                 68.80
1048576               121.70
2097152               245.91
4194304               487.22
```

Fixes #800 
@ztiffany @hppritcha 
