### PR TITLE
prov/gni:  cntr wait performance improvements, etc

### DIFF
--- a/prov/gni/include/gnix_trigger.h
+++ b/prov/gni/include/gnix_trigger.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016 Cray Inc. All rights reserved.
+ * Copyright (c) 2016 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -34,13 +35,19 @@
  * Triggered operations handling.
  */
 
-#ifndef _GNIX_TRIGGER_H_
-#define _GNIX_TRIGGER_H_
+#ifndef GNIX_TRIGGER_H_
+#define GNIX_TRIGGER_H_
 
 #include "gnix.h"
 #include "gnix_cntr.h"
+#include "gnix_vc.h"
 
 int _gnix_trigger_queue_req(struct gnix_fab_req *req);
 void _gnix_trigger_check_cntr(struct gnix_fid_cntr *cntr);
 
-#endif
+static inline int _gnix_trigger_pending(struct gnix_fid_cntr *cntr)
+{
+	return dlist_empty(&cntr->trigger_list) ? 0 : 1;
+}
+
+#endif /* GNIX_TRIGGER_H */

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
+ *                         All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -455,7 +456,7 @@ static void __nic_get_completed_txd(struct gnix_nic *nic,
 	assert(status == GNI_RC_SUCCESS ||
 	       status == GNI_RC_TRANSACTION_ERROR);
 
-	if (status == GNI_RC_TRANSACTION_ERROR) {
+	if (unlikely(status == GNI_RC_TRANSACTION_ERROR)) {
 		status = GNI_CqErrorRecoverable(cqe, &recov);
 		if (status != GNI_RC_SUCCESS || !recov) {
 			char ebuf[512];
@@ -535,11 +536,11 @@ int _gnix_nic_progress(struct gnix_nic *nic)
 	}
 
 	ret = __nic_rx_progress(nic);
-	if (unlikely(ret != FI_SUCCESS))
+	if (ret != FI_SUCCESS)
 		return ret;
 
 	ret = _gnix_vc_nic_progress(nic);
-	if (unlikely(ret != FI_SUCCESS))
+	if (ret != FI_SUCCESS)
 		return ret;
 
 	return ret;

--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
+ *                         All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -935,7 +936,7 @@ ssize_t _gnix_rma(struct gnix_fid_ep *ep, enum gnix_fab_req_type fr_type,
 		req->flags |= GNIX_RMA_RDMA;
 	}
 
-	GNIX_INFO(FI_LOG_EP_DATA, "Queuing (%p %p %d)\n",
+	GNIX_DEBUG(FI_LOG_EP_DATA, "Queuing (%p %p %d)\n",
 		  (void *)loc_addr, (void *)rem_addr, len);
 
 	return _gnix_vc_queue_tx_req(req);

--- a/prov/gni/src/gnix_trigger.c
+++ b/prov/gni/src/gnix_trigger.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016 Cray Inc. All rights reserved.
+ * Copyright (c) 2016 Los Alamos National Security, LLC. All rights reserved.
+ *
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -96,11 +98,13 @@ void _gnix_trigger_check_cntr(struct gnix_fid_cntr *cntr)
 	struct fi_triggered_context *trigger_context;
 	struct fi_trigger_threshold *threshold;
 	struct gnix_fab_req *req, *req2;
-	size_t count = atomic_get(&cntr->cnt);
+	size_t count;
 
-	if (dlist_empty(&cntr->trigger_list)) {
+	if (likely(dlist_empty(&cntr->trigger_list))) {
 		return;
 	}
+
+	 count = atomic_get(&cntr->cnt);
 
 	fastlock_acquire(&cntr->trigger_lock);
 	dlist_for_each_safe(&cntr->trigger_list, req, req2, dlist) {
@@ -122,4 +126,3 @@ void _gnix_trigger_check_cntr(struct gnix_fid_cntr *cntr)
 	}
 	fastlock_release(&cntr->trigger_lock);
 }
-


### PR DESCRIPTION
Performance improvements based on sandia shmem traces.
- add some unlikely's
- remove some unlikely's where not appropriate
- remove the non-wait object based sleeping code from
  GNI provider cntr wait implementation.  If an app really
  needs sleepy wait on cntr, a wait object should be
  associated with the cntr.
- move some code in to inlineable functions in header file

These changes plus others in the pipeline reduce the
sandia shmem overhead for put benchmark to within ~150 nsecs
of native shmem implementation when using the inject path.

@ztiffany 
@sungeunchoi 

Signed-off-by: Howard Pritchard howardp@lanl.gov
