### PR TITLE
VC look up preformance optimization

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -382,8 +382,10 @@ struct gnix_fid_ep {
 	struct gnix_cm_nic *cm_nic;
 	struct gnix_nic *nic;
 	fastlock_t vc_lock;
-	struct gnix_hashtable *vc_ht;
-	struct gnix_vector *vc_table;   /* used for FI_AV_TABLE */
+	union {
+		struct gnix_hashtable *vc_ht;	/* FI_AV_MAP */
+		struct gnix_vector *vc_table;	/* FI_AV_TABLE */
+	};
 	struct gnix_vc *vc;		/* used for FI_EP_MSG */
 	/* lock for unexp and posted recv queue */
 	fastlock_t recv_queue_lock;

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -387,6 +387,7 @@ struct gnix_fid_ep {
 		struct gnix_vector *vc_table;	/* FI_AV_TABLE */
 	};
 	struct gnix_vc *vc;		/* used for FI_EP_MSG */
+	struct dlist_entry unmapped_vcs;
 	/* lock for unexp and posted recv queue */
 	fastlock_t recv_queue_lock;
 	/* used for unexpected receives */

--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -128,7 +128,7 @@ struct gnix_vc {
 	fastlock_t tx_queue_lock;	/* TX reqs lock */
 	struct dlist_entry tx_list;	/* TX VC list entry */
 
-	struct dlist_entry entry;
+	struct dlist_entry list;	/* General purpose list */
 	fi_addr_t peer_fi_addr;
 	struct gnix_address peer_addr;
 	struct gnix_address peer_cm_nic_addr;

--- a/prov/gni/include/gnix_vector.h
+++ b/prov/gni/include/gnix_vector.h
@@ -84,6 +84,18 @@ typedef struct gnix_vec_attr {
 
 struct gnix_vector;
 
+struct gnix_vector_iter {
+	struct gnix_vector *vec;
+	int cur_idx;
+};
+
+#define GNIX_VECTOR_ITERATOR(_vec, _iter)	\
+	struct gnix_vector_iter _iter = {	\
+		.vec = (_vec),			\
+		.cur_idx = 0,			\
+	}
+#define GNIX_VECTOR_ITERATOR_IDX(_iter)	((_iter).cur_idx)
+
 /**
  * Vector operations
  *
@@ -112,7 +124,7 @@ typedef struct gnix_vector_ops {
 	int (*first)(struct gnix_vector *, void **);
 	int (*last)(struct gnix_vector *, void **);
 	int (*at)(struct gnix_vector *, void **, gnix_vec_index_t);
-	/* TODO: void *(*iter_next)(struct gnix_vector_iter *); */
+	gnix_vec_entry_t *(*iter_next)(struct gnix_vector_iter *);
 } gnix_vector_ops_t;
 
 /**
@@ -303,5 +315,13 @@ int _gnix_vec_insert_last(gnix_vector_t *vec, gnix_vec_entry_t *entry);
  * @return -FI_ECANCELED Upon an existing non-empty entry being found at index 0
  */
 int _gnix_vec_insert_first(gnix_vector_t *vec, gnix_vec_entry_t *entry);
+
+/**
+ * Return next element in the vector iterator
+ *
+ * @param iter    pointer to the vector iterator
+ * @return        pointer to next element in the vector
+ */
+gnix_vec_entry_t *_gnix_vec_iterator_next(struct gnix_vector_iter *iter);
 
 #endif /* GNIX_VECTOR_H_ */

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -263,6 +263,7 @@ static void __gnix_vc_destroy_ht_entry(void *val)
 /*******************************************************************************
  * EP vc initialization helper
  ******************************************************************************/
+
 static inline int __gnix_ep_init_vc(struct gnix_fid_ep *ep_priv)
 {
 	int ret;
@@ -272,53 +273,52 @@ static inline int __gnix_ep_init_vc(struct gnix_fid_ep *ep_priv)
 
 	type = ep_priv->av->type;
 
-	/*
-	 *Initialize VC hashtable - this is always used
-	 * regardless of AV type associated with the EP
-	 */
-
-	ep_priv->vc_ht = calloc(1, sizeof(struct gnix_hashtable));
-	if (ep_priv->vc_ht == NULL)
-		goto err;
-
-	gnix_ht_attr.ht_initial_size = ep_priv->domain->params.ct_init_size;
-	gnix_ht_attr.ht_maximum_size = ep_priv->domain->params.ct_max_size;
-	gnix_ht_attr.ht_increase_step = ep_priv->domain->params.ct_step;
-	gnix_ht_attr.ht_increase_type = GNIX_HT_INCREASE_MULT;
-	gnix_ht_attr.ht_collision_thresh = 500;
-	gnix_ht_attr.ht_hash_seed = 0xdeadbeefbeefdead;
-	gnix_ht_attr.ht_internal_locking = 0;
-	gnix_ht_attr.destructor = __gnix_vc_destroy_ht_entry;
-
-	ret = _gnix_ht_init(ep_priv->vc_ht, &gnix_ht_attr);
-	if (ret != FI_SUCCESS) {
-		GNIX_WARN(FI_LOG_EP_CTRL,
-			  "_gnix_ht_init returned %s\n",
-			  fi_strerror(-ret));
-
-		goto err;
-	}
-
 	if (type == FI_AV_TABLE) {
-		/* Initialize VC vector for FI_AV_TABLE */
+		/* Use array to store EP VCs when using FI_AV_TABLE. */
 		ep_priv->vc_table = calloc(1, sizeof(struct gnix_vector));
 		if(ep_priv->vc_table == NULL)
-			goto err;
+			return -FI_ENOMEM;
 
-		gnix_vec_attr.vec_initial_size = ep_priv->domain->params.ct_init_size;
-		gnix_vec_attr.vec_maximum_size = ep_priv->domain->params.ct_max_size;
+		gnix_vec_attr.vec_initial_size =
+				ep_priv->domain->params.ct_init_size;
+		/* TODO: ep_priv->domain->params.ct_max_size; */
+		gnix_vec_attr.vec_maximum_size = 1024*1024;
 		gnix_vec_attr.vec_increase_step = ep_priv->domain->params.ct_step;
 		gnix_vec_attr.vec_increase_type = GNIX_VEC_INCREASE_MULT;
 		gnix_vec_attr.vec_internal_locking = GNIX_VEC_UNLOCKED;
 
 		ret = _gnix_vec_init(ep_priv->vc_table, &gnix_vec_attr);
-                GNIX_DEBUG(
-			FI_LOG_EP_CTRL,
-			"ep_priv->vc_table = %p, ep_priv->vc_table->vector = %p\n",
-			ep_priv->vc_table, ep_priv->vc_table->vector);
+		GNIX_DEBUG(FI_LOG_EP_CTRL,
+			   "ep_priv->vc_table = %p, ep_priv->vc_table->vector = %p\n",
+			   ep_priv->vc_table, ep_priv->vc_table->vector);
                 if (ret != FI_SUCCESS) {
 			GNIX_WARN(FI_LOG_EP_CTRL, "_gnix_vec_init returned %s\n",
 				  fi_strerror(ret));
+			goto err;
+		}
+	} else {
+		/* Use hash table to store EP VCs when using FI_AV_MAP. */
+		ep_priv->vc_ht = calloc(1, sizeof(struct gnix_hashtable));
+		if (ep_priv->vc_ht == NULL)
+			return -FI_ENOMEM;
+
+		gnix_ht_attr.ht_initial_size =
+				ep_priv->domain->params.ct_init_size;
+		gnix_ht_attr.ht_maximum_size =
+				ep_priv->domain->params.ct_max_size;
+		gnix_ht_attr.ht_increase_step = ep_priv->domain->params.ct_step;
+		gnix_ht_attr.ht_increase_type = GNIX_HT_INCREASE_MULT;
+		gnix_ht_attr.ht_collision_thresh = 500;
+		gnix_ht_attr.ht_hash_seed = 0xdeadbeefbeefdead;
+		gnix_ht_attr.ht_internal_locking = 0;
+		gnix_ht_attr.destructor = __gnix_vc_destroy_ht_entry;
+
+		ret = _gnix_ht_init(ep_priv->vc_ht, &gnix_ht_attr);
+		if (ret != FI_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "_gnix_ht_init returned %s\n",
+				  fi_strerror(-ret));
+
 			goto err;
 		}
 	}
@@ -326,21 +326,49 @@ static inline int __gnix_ep_init_vc(struct gnix_fid_ep *ep_priv)
 	return FI_SUCCESS;
 
 err:
-	if (ep_priv->vc_table != NULL) {
-		_gnix_vec_close(ep_priv->vc_table);
-
+	if (type == FI_AV_TABLE) {
 		free(ep_priv->vc_table);
 		ep_priv->vc_table = NULL;
-	}
-
-	if (ep_priv->vc_ht != NULL) {
-		_gnix_ht_destroy(ep_priv->vc_ht); /* may not be initialized but
-						     okay */
+	} else {
 		free(ep_priv->vc_ht);
 		ep_priv->vc_ht = NULL;
 	}
 
 	return ret;
+}
+
+static inline int __gnix_ep_fini_vc(struct gnix_fid_ep *ep)
+{
+	int ret;
+
+	if (!ep->av) {
+		/* No AV bound, no VC storage to clean up. */
+		return FI_SUCCESS;
+	}
+
+	if (ep->av->type == FI_AV_TABLE) {
+		ret = _gnix_vec_close(ep->vc_table);
+		if (ret == FI_SUCCESS) {
+			free(ep->vc_table);
+			ep->vc_table = NULL;
+		} else {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "_gnix_vec_close returned %s\n",
+				  fi_strerror(-ret));
+		}
+	} else {
+		ret = _gnix_ht_destroy(ep->vc_ht);
+		if (ret == FI_SUCCESS) {
+			free(ep->vc_ht);
+			ep->vc_ht = NULL;
+		} else {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				"_gnix_ht_destroy returned %s\n",
+				  fi_strerror(-ret));
+		}
+	}
+
+	return FI_SUCCESS;
 }
 
 /*******************************************************************************
@@ -1272,41 +1300,23 @@ static void __ep_destruct(void *obj)
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
-	/*
-	 * clean up any vc hash table or vector,
-	 * remove entry from addr_to_ep ht.
-	 * any outstanding GNI internal requests on
-	 * the VC's will be completed prior to
-	 * destroying the VC entries in the ht.
-	 */
-
-	if (GNIX_EP_RDM_DGM(ep->type)) {
-
+	if (ep->av) {
+		/* Remove EP from CM NIC lookup list. */
 		key_ptr = (gnix_ht_key_t *)&ep->my_name.gnix_addr;
 		ret =  _gnix_ht_remove(ep->cm_nic->addr_to_ep_ht,
 				       *key_ptr);
-		if (ep->vc_ht != NULL) {
-			ret = _gnix_ht_destroy(ep->vc_ht);
-			if (ret == FI_SUCCESS) {
-				free(ep->vc_ht);
-				ep->vc_ht = NULL;
-			} else {
-				GNIX_WARN(FI_LOG_EP_CTRL,
-					"_gnix_ht_destroy returned %s\n",
-					  fi_strerror(-ret));
-			}
+		if (ret != FI_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "_gnix_ht_remove returned %s\n",
+				  fi_strerror(-ret));
 		}
 
-		if (ep->vc_table != NULL) {
-			ret = _gnix_vec_close(ep->vc_table);
-			if (ret == FI_SUCCESS) {
-				free(ep->vc_table);
-				ep->vc_table = NULL;
-			} else {
-				GNIX_WARN(FI_LOG_EP_CTRL,
-					  "_gnix_vec_close returned %s\n",
-					  fi_strerror(-ret));
-			}
+		/* Destroy EP VC storage. */
+		ret = __gnix_ep_fini_vc(ep);
+		if (ret != FI_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "_gnix_ht_remove returned %s\n",
+				  fi_strerror(-ret));
 		}
 	}
 

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -323,6 +323,8 @@ static inline int __gnix_ep_init_vc(struct gnix_fid_ep *ep_priv)
 		}
 	}
 
+	dlist_init(&ep_priv->unmapped_vcs);
+
 	return FI_SUCCESS;
 
 err:
@@ -340,13 +342,29 @@ err:
 static inline int __gnix_ep_fini_vc(struct gnix_fid_ep *ep)
 {
 	int ret;
+	GNIX_VECTOR_ITERATOR(ep->vc_table, iter);
+	struct gnix_vc *vc;
+
+	/* Free unmapped VCs. */
+	dlist_for_each(&ep->unmapped_vcs, vc, list) {
+		_gnix_vc_destroy(vc);
+	}
 
 	if (!ep->av) {
-		/* No AV bound, no VC storage to clean up. */
+		/* No AV bound, no mapped VCs clean up. */
 		return FI_SUCCESS;
 	}
 
 	if (ep->av->type == FI_AV_TABLE) {
+		/* Destroy all VCs */
+		while ((vc = (struct gnix_vc *)
+				_gnix_vec_iterator_next(&iter))) {
+			_gnix_vec_remove_at(ep->vc_table,
+					    GNIX_VECTOR_ITERATOR_IDX(iter));
+			_gnix_vc_destroy(vc);
+		}
+
+		/* Destroy vector storage */
 		ret = _gnix_vec_close(ep->vc_table);
 		if (ret == FI_SUCCESS) {
 			free(ep->vc_table);
@@ -357,6 +375,7 @@ static inline int __gnix_ep_fini_vc(struct gnix_fid_ep *ep)
 				  fi_strerror(-ret));
 		}
 	} else {
+		/* Destroy VC storage, it automatically tears down VCs */
 		ret = _gnix_ht_destroy(ep->vc_ht);
 		if (ret == FI_SUCCESS) {
 			free(ep->vc_ht);
@@ -1889,24 +1908,53 @@ static inline struct gnix_fab_req *__find_tx_req(
 	struct gnix_fab_req *req = NULL;
 	struct dlist_entry *entry;
 	struct gnix_vc *vc;
-	GNIX_HASHTABLE_ITERATOR(ep->vc_ht, iter);
 
 	GNIX_DEBUG(FI_LOG_EP_CTRL, "searching VCs for the correct context to"
 		   " cancel, context=%p", context);
 
 	COND_ACQUIRE(ep->requires_lock, &ep->vc_lock);
-	while ((vc = _gnix_ht_iterator_next(&iter))) {
-		COND_ACQUIRE(vc->ep->requires_lock, &vc->tx_queue_lock);
-		entry = dlist_remove_first_match(&vc->tx_queue,
-						 __match_context,
-						 context);
-		COND_RELEASE(vc->ep->requires_lock, &vc->tx_queue_lock);
 
-		if (entry) {
-			req = container_of(entry, struct gnix_fab_req, dlist);
-			break;
+	if (ep->av->type == FI_AV_TABLE) {
+		GNIX_VECTOR_ITERATOR(ep->vc_table, iter);
+
+		while ((vc = (struct gnix_vc *)
+				_gnix_vec_iterator_next(&iter))) {
+			COND_ACQUIRE(vc->ep->requires_lock,
+				     &vc->tx_queue_lock);
+			entry = dlist_remove_first_match(&vc->tx_queue,
+							 __match_context,
+							 context);
+			COND_RELEASE(vc->ep->requires_lock,
+				     &vc->tx_queue_lock);
+
+			if (entry) {
+				req = container_of(entry,
+						   struct gnix_fab_req,
+						   dlist);
+				break;
+			}
+		}
+	} else {
+		GNIX_HASHTABLE_ITERATOR(ep->vc_ht, iter);
+
+		while ((vc = _gnix_ht_iterator_next(&iter))) {
+			COND_ACQUIRE(vc->ep->requires_lock,
+				     &vc->tx_queue_lock);
+			entry = dlist_remove_first_match(&vc->tx_queue,
+							 __match_context,
+							 context);
+			COND_RELEASE(vc->ep->requires_lock,
+				     &vc->tx_queue_lock);
+
+			if (entry) {
+				req = container_of(entry,
+						   struct gnix_fab_req,
+						   dlist);
+				break;
+			}
 		}
 	}
+
 	COND_RELEASE(ep->requires_lock, &ep->vc_lock);
 
 	return req;

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -86,7 +86,7 @@ static inline void __gnix_vc_set_ht_key(void *gnix_addr,
 	*key = *((gnix_ht_key_t *)gnix_addr);
 }
 
-struct gnix_vc *_gnix_ep_vc_lookup(struct gnix_fid_ep *ep, uint64_t key)
+static struct gnix_vc *_gnix_ep_vc_lookup(struct gnix_fid_ep *ep, uint64_t key)
 {
 	struct gnix_vc *vc;
 	int ret;
@@ -105,7 +105,8 @@ struct gnix_vc *_gnix_ep_vc_lookup(struct gnix_fid_ep *ep, uint64_t key)
 	return vc;
 }
 
-int _gnix_ep_vc_store(struct gnix_fid_ep *ep, struct gnix_vc *vc, uint64_t key)
+static int _gnix_ep_vc_store(struct gnix_fid_ep *ep, struct gnix_vc *vc,
+			     uint64_t key)
 {
 	int ret;
 
@@ -118,6 +119,60 @@ int _gnix_ep_vc_store(struct gnix_fid_ep *ep, struct gnix_vc *vc, uint64_t key)
 	}
 
 	return ret;
+}
+
+static int __gnix_vc_gnix_addr_equal(struct dlist_entry *item, const void *arg)
+{
+	struct gnix_vc *vc = dlist_entry(item, struct gnix_vc, list);
+
+	return GNIX_ADDR_EQUAL(vc->peer_addr, *(struct gnix_address *)arg);
+}
+
+/* Find an unmapped VC that matches 'dest_addr' and map it into the EP's VC
+ * look up table.  VC lock must be held. */
+static struct gnix_vc *__gnix_vc_lookup_unmapped(struct gnix_fid_ep *ep,
+						 fi_addr_t dest_addr)
+{
+	struct gnix_av_addr_entry *av_entry;
+	struct dlist_entry *entry;
+	struct gnix_vc *vc;
+	int ret;
+
+	/* Determine if the fi_addr now exists in the AV. */
+	ret = _gnix_av_lookup(ep->av, dest_addr, &av_entry);
+	if (ret != FI_SUCCESS) {
+		GNIX_WARN(FI_LOG_EP_DATA,
+			  "_gnix_av_lookup for addr 0x%lx returned %s\n",
+			  dest_addr, fi_strerror(-ret));
+		return NULL;
+	}
+
+	/* Find a pre-existing, unmapped VC that matches the gnix_address
+	 * mapped by dest_addr. */
+	entry = dlist_remove_first_match(&ep->unmapped_vcs,
+					 __gnix_vc_gnix_addr_equal,
+					 (void *)&av_entry->gnix_addr);
+	if (entry) {
+		/* Found a matching, unmapped VC.  Map dest_addr to the VC in
+		 * the EP's VC look up table. */
+		vc = dlist_entry(entry, struct gnix_vc, list);
+		GNIX_INFO(FI_LOG_EP_CTRL,
+			  "Found unmapped VC: %p gnix_addr: 0x%lx fi_addr: 0x%lx\n",
+			  vc, vc->peer_addr, vc->peer_fi_addr);
+
+		ret = _gnix_ep_vc_store(ep, vc, dest_addr);
+		if (unlikely(ret != FI_SUCCESS)) {
+			GNIX_WARN(FI_LOG_EP_DATA,
+				  "_gnix_ep_vc_store returned %s\n",
+				  fi_strerror(-ret));
+			dlist_insert_tail(&vc->list, &ep->unmapped_vcs);
+			return NULL;
+		}
+
+		return vc;
+	}
+
+	return NULL;
 }
 
 /**
@@ -135,7 +190,7 @@ static int __gnix_vc_get_vc_by_fi_addr(struct gnix_fid_ep *ep, fi_addr_t dest_ad
 	struct gnix_fid_av *av;
 	int ret = FI_SUCCESS;
 	struct gnix_av_addr_entry *av_entry;
-	struct gnix_vc *vc = NULL, *vc_tmp = NULL;
+	struct gnix_vc *vc;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
@@ -149,10 +204,22 @@ static int __gnix_vc_get_vc_by_fi_addr(struct gnix_fid_ep *ep, fi_addr_t dest_ad
 		return -FI_EINVAL;
 	}
 
-	fastlock_acquire(&ep->vc_lock);
+	COND_ACQUIRE(ep->requires_lock, &ep->vc_lock);
 
 	/* Use FI address to lookup in EP VC table. */
 	vc = _gnix_ep_vc_lookup(ep, dest_addr);
+
+	if (vc == NULL) {
+		/* We can receive a connection request from a remote peer
+		 * before the target EP has bound to an AV or before the remote
+		 * peer has had it's address inserted into the target EP's AV.
+		 * Those requests will result in a connection as usual, but the
+		 * VC will not be mapped into an EP's AV until the EP attempts
+		 * to send to the remote peer.  Check the 'unmapped VC' list to
+		 * see if such a VC exists and map it into the AV here. */
+		 vc = __gnix_vc_lookup_unmapped(ep, dest_addr);
+	}
+
 	if (vc == NULL) {
 		/* Look up full AV entry for the destination address. */
 		ret = _gnix_av_lookup(av, dest_addr, &av_entry);
@@ -164,7 +231,7 @@ static int __gnix_vc_get_vc_by_fi_addr(struct gnix_fid_ep *ep, fi_addr_t dest_ad
 		}
 
 		/* Initiate a connection to the endpoint. */
-		ret = _gnix_vc_alloc(ep, av_entry, &vc_tmp);
+		ret = _gnix_vc_alloc(ep, av_entry, &vc);
 		if (ret != FI_SUCCESS) {
 			GNIX_WARN(FI_LOG_EP_DATA,
 				  "_gnix_vc_alloc returned %s\n",
@@ -173,16 +240,13 @@ static int __gnix_vc_get_vc_by_fi_addr(struct gnix_fid_ep *ep, fi_addr_t dest_ad
 		}
 
 		/* Store new VC in EP connection table. */
-		ret = _gnix_ep_vc_store(ep, vc_tmp, dest_addr);
+		ret = _gnix_ep_vc_store(ep, vc, dest_addr);
 		if (unlikely(ret != FI_SUCCESS)) {
 			GNIX_WARN(FI_LOG_EP_DATA,
 				  "_gnix_ep_vc_store returned %s\n",
 				  fi_strerror(-ret));
 			goto err_w_lock;
 		}
-
-		vc = vc_tmp;
-		vc->modes |= GNIX_VC_MODE_IN_HT;
 
 		ret = _gnix_vc_connect(vc);
 		if (ret != FI_SUCCESS) {
@@ -193,13 +257,13 @@ static int __gnix_vc_get_vc_by_fi_addr(struct gnix_fid_ep *ep, fi_addr_t dest_ad
 		}
 	}
 
-	fastlock_release(&ep->vc_lock);
+	COND_RELEASE(ep->requires_lock, &ep->vc_lock);
 
 	*vc_ptr = vc;
 	return ret;
 
 err_w_lock:
-	fastlock_release(&ep->vc_lock);
+	COND_RELEASE(ep->requires_lock, &ep->vc_lock);
 	if (vc != NULL)
 		_gnix_vc_destroy(vc);
 	return ret;
@@ -524,22 +588,16 @@ static int __gnix_vc_connect_to_same_cm_nic(struct gnix_vc *vc)
 		goto exit;
 	}
 
-	COND_ACQUIRE(ep->requires_lock, &ep->vc_lock);
 	if ((vc->conn_state == GNIX_VC_CONNECTING) ||
 	    (vc->conn_state == GNIX_VC_CONNECTED)) {
-		COND_RELEASE(ep->requires_lock, &ep->vc_lock);
 		return FI_SUCCESS;
 	} else
 		vc->conn_state = GNIX_VC_CONNECTING;
 
-	COND_RELEASE(ep->requires_lock, &ep->vc_lock);
-
 	GNIX_DEBUG(FI_LOG_EP_CTRL, "moving vc %p state to connecting\n", vc);
 
-
 	if (vc->smsg_mbox == NULL) {
-		ret = _gnix_mbox_alloc(vc->ep->nic->mbox_hndl,
-				       &mbox);
+		ret = _gnix_mbox_alloc(vc->ep->nic->mbox_hndl, &mbox);
 		if (ret != FI_SUCCESS) {
 			GNIX_WARN(FI_LOG_EP_DATA,
 				  "_gnix_mbox_alloc returned %s\n",
@@ -569,22 +627,16 @@ static int __gnix_vc_connect_to_same_cm_nic(struct gnix_vc *vc)
 	}
 
 	__gnix_vc_set_ht_key(&ep->my_name.gnix_addr, &key);
+	vc_peer = _gnix_ep_vc_lookup(ep_peer, key);
 
-	COND_ACQUIRE(ep_peer->requires_lock, &ep_peer->vc_lock);
-	vc_peer = (struct gnix_vc *)_gnix_ht_lookup(ep_peer->vc_ht,
-						    key);
-
-	/*
-	 * handle the special case of connecting to self
-	 */
-
+	/* Loopback VC.  EP wants to send to itself. */
 	if (vc_peer == vc) {
 		ret = __gnix_vc_smsg_init(vc, vc->vc_id, &smsg_mbox_attr, NULL);
 		if (ret != FI_SUCCESS) {
 			GNIX_WARN(FI_LOG_EP_DATA,
 				  "_gnix_vc_smsg_init returned %s\n",
 				  fi_strerror(-ret));
-			goto exit_w_lock;
+			goto exit;
 		}
 		vc->conn_state = GNIX_VC_CONNECTED;
 		vc->peer_id = vc->vc_id;
@@ -597,7 +649,7 @@ static int __gnix_vc_connect_to_same_cm_nic(struct gnix_vc *vc)
 
 		GNIX_DEBUG(FI_LOG_EP_CTRL, "moving vc %p state to connected\n",
 			   vc);
-		goto exit_w_lock;
+		goto exit;
 	}
 
 	if ((vc_peer != NULL) &&
@@ -605,46 +657,44 @@ static int __gnix_vc_connect_to_same_cm_nic(struct gnix_vc *vc)
 		GNIX_WARN(FI_LOG_EP_CTRL,
 			  "_gnix_vc_connect self, vc_peer in inconsistent state\n");
 		ret = -FI_ENOSPC;
-		goto exit_w_lock;
+		goto exit;
 	}
 
+	/* Inter-CM VC,  Connect this EP to another EP using the same CM (same
+	 * process, likely different threads). */
 	if (vc_peer == NULL) {
 		entry.gnix_addr = ep->my_name.gnix_addr;
 		entry.cm_nic_cdm_id = ep->my_name.cm_nic_cdm_id;
-		ret = _gnix_vc_alloc(ep_peer,
-				     &entry,
-				     &vc_peer);
+
+		ret = _gnix_vc_alloc(ep_peer, &entry, &vc_peer);
 		if (ret != FI_SUCCESS) {
 			GNIX_WARN(FI_LOG_EP_CTRL,
-				"_gnix_vc_alloc returned %s\n",
-				fi_strerror(-ret));
-			goto exit_w_lock;
+				  "_gnix_vc_alloc returned %s\n",
+				  fi_strerror(-ret));
+			goto exit;
 		}
 
-		ret = _gnix_ht_insert(ep_peer->vc_ht,
-				      key,
-				      vc_peer);
+		ret = _gnix_ep_vc_store(ep_peer, vc_peer, key);
 		if (ret != FI_SUCCESS) {
 			GNIX_WARN(FI_LOG_EP_CTRL,
 				  "_gnix_ht_insert returned %s\n",
 				  fi_strerror(-ret));
-			goto exit_w_lock;
+			goto exit;
 		}
-		vc_peer->modes |= GNIX_VC_MODE_IN_HT;
 	}
 
 	vc_peer->conn_state = GNIX_VC_CONNECTING;
+
 	GNIX_DEBUG(FI_LOG_EP_CTRL, "moving vc %p state to connecting\n",
 		   vc_peer);
 
 	if (vc_peer->smsg_mbox == NULL) {
-		ret = _gnix_mbox_alloc(vc_peer->ep->nic->mbox_hndl,
-				       &mbox_peer);
+		ret = _gnix_mbox_alloc(vc_peer->ep->nic->mbox_hndl, &mbox_peer);
 		if (ret != FI_SUCCESS) {
 			GNIX_WARN(FI_LOG_EP_DATA,
 				  "_gnix_mbox_alloc returned %s\n",
 				  fi_strerror(-ret));
-			goto exit_w_lock;
+			goto exit;
 		}
 		vc_peer->smsg_mbox = mbox_peer;
 	} else
@@ -661,39 +711,34 @@ static int __gnix_vc_connect_to_same_cm_nic(struct gnix_vc *vc)
 	ret = __gnix_vc_smsg_init(vc, vc_peer->vc_id, &smsg_mbox_attr_peer,
 				  &ep_peer->nic->irq_mem_hndl);
 	if (ret != FI_SUCCESS) {
-		GNIX_WARN(FI_LOG_EP_DATA,
-			  "_gnix_vc_smsg_init returned %s\n",
+		GNIX_WARN(FI_LOG_EP_DATA, "_gnix_vc_smsg_init returned %s\n",
 			  fi_strerror(-ret));
-		goto exit_w_lock;
+		goto exit;
 	}
 
 	ret = __gnix_vc_smsg_init(vc_peer, vc->vc_id, &smsg_mbox_attr,
 				  &ep->nic->irq_mem_hndl);
 	if (ret != FI_SUCCESS) {
-		GNIX_WARN(FI_LOG_EP_DATA,
-			  "_gnix_vc_smsg_init returned %s\n",
+		GNIX_WARN(FI_LOG_EP_DATA, "_gnix_vc_smsg_init returned %s\n",
 			  fi_strerror(-ret));
-		goto exit_w_lock;
+		goto exit;
 	}
 
 	vc->conn_state = GNIX_VC_CONNECTED;
 	vc->peer_id = vc_peer->vc_id;
 	vc->peer_caps = ep->caps;
-	GNIX_DEBUG(FI_LOG_EP_CTRL, "moving vc %p state to connected\n",
-		   vc);
+	GNIX_DEBUG(FI_LOG_EP_CTRL, "moving vc %p state to connected\n", vc);
+
 	vc_peer->conn_state = GNIX_VC_CONNECTED;
 	vc_peer->peer_id = vc->vc_id;
 	ret = _gnix_vc_schedule(vc_peer);
 	if (ret != FI_SUCCESS)
-		GNIX_WARN(FI_LOG_EP_DATA,
-			  "_gnix_vc_schedule returned %s\n",
+		GNIX_WARN(FI_LOG_EP_DATA, "_gnix_vc_schedule returned %s\n",
 			  fi_strerror(-ret));
 
 	GNIX_DEBUG(FI_LOG_EP_CTRL, "moving vc %p state to connected\n",
 		   vc_peer);
 
-exit_w_lock:
-	COND_RELEASE(ep_peer->requires_lock, &ep_peer->vc_lock);
 exit:
 	return ret;
 }
@@ -804,7 +849,6 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 	struct gnix_av_addr_entry entry;
 	struct gnix_address src_addr, target_addr;
 	struct gnix_vc *vc = NULL;
-	struct gnix_vc *vc_try = NULL;
 	struct gnix_work_req *work_req;
 	int src_vc_id;
 	gni_smsg_attr_t src_smsg_attr;
@@ -812,6 +856,9 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 	uint64_t peer_caps;
 	struct wq_hndl_conn_req *data = NULL;
 	gni_mem_handle_t tmp_mem_hndl;
+	int src_mapped = 0;
+	fi_addr_t fi_addr;
+
 
 	ssize_t __attribute__((unused)) len;
 
@@ -860,12 +907,17 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 	 * address of the connecting EP.
 	 */
 
-	__gnix_vc_set_ht_key(&src_addr, &key);
-
-
 	COND_ACQUIRE(ep->requires_lock, &ep->vc_lock);
-	vc = (struct gnix_vc *)_gnix_ht_lookup(ep->vc_ht,
-					       key);
+
+	/* If we already have an AV bound, see if sender's address is already
+	 * mapped. */
+	if (ep->av) {
+		ret = _gnix_av_reverse_lookup(ep->av, src_addr, &fi_addr);
+		if (ret == FI_SUCCESS) {
+			src_mapped = 1;
+			vc = _gnix_ep_vc_lookup(ep, fi_addr);
+		}
+	}
 
 	/*
 	 * if there is no corresponding vc in the hash,
@@ -879,7 +931,7 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 			entry.cm_nic_cdm_id = src_cm_nic_addr.cdm_id;
 			ret = _gnix_vc_alloc(ep,
 					     &entry,
-					     &vc_try);
+					     &vc);
 			if (ret != FI_SUCCESS) {
 				GNIX_WARN(FI_LOG_EP_CTRL,
 					  "_gnix_vc_alloc returned %s\n",
@@ -887,21 +939,29 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 				goto err;
 			}
 
-			vc_try->conn_state = GNIX_VC_CONNECTING;
-			ret = _gnix_ht_insert(ep->vc_ht,
-					      key,
-					      vc_try);
+			vc->conn_state = GNIX_VC_CONNECTING;
 
-			if (likely(ret == FI_SUCCESS)) {
-				vc = vc_try;
-				vc->modes |= GNIX_VC_MODE_IN_HT;
+			if (src_mapped) {
+				/* We have an AV which maps the incoming
+				 * address.  Store the new VC in our VC lookup
+				 * table. */
+				ret = _gnix_ep_vc_store(ep, vc, fi_addr);
+				if (unlikely(ret != FI_SUCCESS)) {
+					_gnix_vc_destroy(vc);
+					GNIX_WARN(FI_LOG_EP_DATA,
+						  "_gnix_ep_vc_store returned %s\n",
+						  fi_strerror(-ret));
+					goto err;
+				}
 			} else {
-				if (ret == -FI_ENOSPC)
-					_gnix_vc_destroy(vc_try);
-				GNIX_WARN(FI_LOG_EP_DATA,
-				  "__gnix_ht_insert returned %s\n",
-				   fi_strerror(-ret));
-				goto err;
+				/* We lack an AV and/or the entry to map the
+				 * incoming address.  Keep VC in special table
+				 * until it is mapped for a TX operation. */
+				GNIX_INFO(FI_LOG_EP_CTRL,
+					  "Received conn. request from unmapped peer EP, vc: %p addr: 0x%lx\n",
+					  vc, src_addr);
+
+				dlist_insert_tail(&vc->list, &ep->unmapped_vcs);
 			}
 		} else
 			vc->conn_state = GNIX_VC_CONNECTING;
@@ -1224,17 +1284,6 @@ static int __gnix_vc_conn_req_prog_fn(void *data, int *complete_ptr)
 	}
 
 	/*
-	 * sanity check that the vc is in the hash table
-	 */
-
-	if (!(vc->modes & GNIX_VC_MODE_IN_HT)) {
-		GNIX_WARN(FI_LOG_EP_CTRL, "vc not in hashtable\n");
-		assert(vc->modes & GNIX_VC_MODE_IN_HT);
-		ret = -FI_EINVAL;
-		goto err;
-	}
-
-	/*
 	 * first see if we still need a mailbox
 	 */
 
@@ -1388,6 +1437,8 @@ int _gnix_vc_alloc(struct gnix_fid_ep *ep_priv,
 	dlist_init(&vc_ptr->work_list);
 	dlist_init(&vc_ptr->tx_list);
 	vc_ptr->peer_fi_addr = FI_ADDR_NOTAVAIL;
+
+	dlist_init(&vc_ptr->list);
 
 	atomic_initialize(&vc_ptr->outstanding_tx_reqs, 0);
 	ret = _gnix_alloc_bitmap(&vc_ptr->flags, 1);

--- a/prov/gni/test/av.c
+++ b/prov/gni/test/av.c
@@ -336,8 +336,6 @@ static void straddr_test(void)
 	cr_assert_eq(buf, addrstr);
 	cr_assert_eq(addrstr_len, GNIX_AV_MAX_STR_ADDR_LEN);
 
-	fprintf(stderr, "string is: %s\n", buf);
-
 	/* extract the first component */
 	buf = strtok(addrstr, ":");
 	cr_assert_not_null(buf, "version not found");

--- a/prov/gni/test/vc_lookup.c
+++ b/prov/gni/test/vc_lookup.c
@@ -139,6 +139,7 @@ int _do_vc_lookup_perf(int av_type, int niters, int npeers, int naddrs)
 
 	for (i = 0; i < npeers; i++) {
 		/* insert fake addresses into AV */
+		tmp_name.gnix_addr.cdm_id++;
 		tmp_name.cm_nic_cdm_id++;
 		addrs[i] = tmp_name;
 	}
@@ -147,9 +148,9 @@ int _do_vc_lookup_perf(int av_type, int niters, int npeers, int naddrs)
 			   (void *)fi_addrs, 0, NULL);
 	cr_assert(ret == npeers);
 
-	for (i = 0; i < niters; i++) {
+	for (i = 0; i < npeers; i++) {
 		/* do warump */
-		ret = _gnix_vc_ep_get_vc(gnix_ep, fi_addrs[(i * inc)%npeers],
+		ret = _gnix_vc_ep_get_vc(gnix_ep, fi_addrs[i],
 					 &vc);
 		cr_assert(ret == FI_SUCCESS);
 	}
@@ -188,22 +189,24 @@ int do_vc_lookup_perf(int av_type, int niters, int naddrs, int npeers)
 	return 0;
 }
 
-#define NITERS	100000
+#define NITERS	10000
+#define EXP_INC	4
+#define TESTS	5
 Test(vc_lookup, perf, .disabled = true)
 {
 	int i, j;
 
-	for (i = 0; i < 5; i++) {
+	for (i = 0; i < TESTS; i++) {
 		for (j = 0; j <= i; j++) {
 			do_vc_lookup_perf(FI_AV_MAP, NITERS,
-					  2<<(i*5), 2<<(j*5));
+					  2<<(i*EXP_INC), 2<<(j*EXP_INC));
 		}
 	}
 
-	for (i = 0; i < 5; i++) {
+	for (i = 0; i < TESTS; i++) {
 		for (j = 0; j <= i; j++) {
 			do_vc_lookup_perf(FI_AV_TABLE, NITERS,
-					  2<<(i*5), 2<<(j*5));
+					  2<<(i*EXP_INC), 2<<(j*EXP_INC));
 		}
 	}
 }


### PR DESCRIPTION
Improve VC lookup performance. 

@hppritcha @sungeunchoi @e-harvey 

Updated vc_lookup criterion test results without performance changes:

tiger$ cat test.out.novcperf
type: MAP   npeers:       2 naddrs:       2 ns: 118.400000
type: MAP   npeers:      32 naddrs:       2 ns: 121.600000
type: MAP   npeers:      32 naddrs:      32 ns: 107.400000
type: MAP   npeers:     512 naddrs:       2 ns: 116.600000
type: MAP   npeers:     512 naddrs:      32 ns: 138.700000
type: MAP   npeers:     512 naddrs:     512 ns: 158.100000
type: MAP   npeers:    8192 naddrs:       2 ns: 108.300000
type: MAP   npeers:    8192 naddrs:      32 ns: 127.300000
type: MAP   npeers:    8192 naddrs:     512 ns: 215.400000
type: MAP   npeers:    8192 naddrs:    8192 ns: 194.500000
type: MAP   npeers:  131072 naddrs:       2 ns: 106.800000
type: MAP   npeers:  131072 naddrs:      32 ns: 221.900000
type: MAP   npeers:  131072 naddrs:     512 ns: 416.400000
type: MAP   npeers:  131072 naddrs:    8192 ns: 543.200000
type: MAP   npeers:  131072 naddrs:  131072 ns: 255.500000
type: TABLE npeers:       2 naddrs:       2 ns: 20.100000
type: TABLE npeers:      32 naddrs:       2 ns: 21.900000
type: TABLE npeers:      32 naddrs:      32 ns: 21.300000
type: TABLE npeers:     512 naddrs:       2 ns: 19.500000
type: TABLE npeers:     512 naddrs:      32 ns: 19.600000
type: TABLE npeers:     512 naddrs:     512 ns: 19.600000
type: TABLE npeers:    8192 naddrs:       2 ns: 19.400000
type: TABLE npeers:    8192 naddrs:      32 ns: 20.200000
type: TABLE npeers:    8192 naddrs:     512 ns: 20.000000
type: TABLE npeers:    8192 naddrs:    8192 ns: 20.200000
type: TABLE npeers:  131072 naddrs:       2 ns: 44.600000
type: TABLE npeers:  131072 naddrs:      32 ns: 104.300000
type: TABLE npeers:  131072 naddrs:     512 ns: 262.400000
type: TABLE npeers:  131072 naddrs:    8192 ns: 292.700000
type: TABLE npeers:  131072 naddrs:  131072 ns: 20.500000

With performance changes:

tiger$ cat test.out.vcperf
type: MAP   npeers:       2 naddrs:       2 ns: 47.800000
type: MAP   npeers:      32 naddrs:       2 ns: 41.100000
type: MAP   npeers:      32 naddrs:      32 ns: 42.100000
type: MAP   npeers:     512 naddrs:       2 ns: 37.800000
type: MAP   npeers:     512 naddrs:      32 ns: 46.000000
type: MAP   npeers:     512 naddrs:     512 ns: 69.100000
type: MAP   npeers:    8192 naddrs:       2 ns: 34.100000
type: MAP   npeers:    8192 naddrs:      32 ns: 44.300000
type: MAP   npeers:    8192 naddrs:     512 ns: 77.700000
type: MAP   npeers:    8192 naddrs:    8192 ns: 84.200000
type: MAP   npeers:  131072 naddrs:       2 ns: 36.400000
type: MAP   npeers:  131072 naddrs:      32 ns: 66.200000
type: MAP   npeers:  131072 naddrs:     512 ns: 175.500000
type: MAP   npeers:  131072 naddrs:    8192 ns: 236.700000
type: MAP   npeers:  131072 naddrs:  131072 ns: 103.600000
type: TABLE npeers:       2 naddrs:       2 ns: 25.800000
type: TABLE npeers:      32 naddrs:       2 ns: 26.900000
type: TABLE npeers:      32 naddrs:      32 ns: 26.900000
type: TABLE npeers:     512 naddrs:       2 ns: 25.000000
type: TABLE npeers:     512 naddrs:      32 ns: 25.000000
type: TABLE npeers:     512 naddrs:     512 ns: 25.300000
type: TABLE npeers:    8192 naddrs:       2 ns: 25.100000
type: TABLE npeers:    8192 naddrs:      32 ns: 27.200000
type: TABLE npeers:    8192 naddrs:     512 ns: 25.700000
type: TABLE npeers:    8192 naddrs:    8192 ns: 27.200000
type: TABLE npeers:  131072 naddrs:       2 ns: 25.000000
type: TABLE npeers:  131072 naddrs:      32 ns: 30.500000
type: TABLE npeers:  131072 naddrs:     512 ns: 38.300000
type: TABLE npeers:  131072 naddrs:    8192 ns: 45.600000
type: TABLE npeers:  131072 naddrs:  131072 ns: 26.200000
[====] Synthesis: Tested: 1 | Passing: 1 | Failing: 0 | Crashing: 0 
