### PR TITLE
prov/gni: refactor cdm id allocation

### DIFF
--- a/prov/gni/include/gnix_cm_nic.h
+++ b/prov/gni/include/gnix_cm_nic.h
@@ -162,24 +162,20 @@ int _gnix_cm_nic_progress(struct gnix_cm_nic *cm_nic);
  * value previously returned from _gnix_cm_nic_get_cdm_seed_set
  *
  * @param[in]  domain  pointer to previously allocated gnix_fid_domain struct
- * @param[in]  seed    seed value to be used for creating cdm_id
  * @param[out] id      pointer to address where the 32 bit ids will be returned
  * @return FI_SUCCESS upon generation of 32 bit id.
  */
-int _gnix_cm_nic_create_cdm_id(struct gnix_fid_domain *domain, uint32_t seed,
-			       uint32_t *id);
+int _gnix_cm_nic_create_cdm_id(struct gnix_fid_domain *domain, uint32_t *id);
 
 /**
- * @brief generate a set of contiguous, unique 32 bit seed values to supply
- * to _gnix_cm_nic_create_cdm_id to generate cdm_id for calls to GNI_CdmCreate
+ * @brief generate a set of contiguous, unique 32 bit cdm_ids for use with GNI_CdmCreate
  *
- * @param[in]  domain  pointer to previously allocated gnix_fid_domain struct
- * @param[in]  nseeds  number of seeds to be allocated
- * @param[out] seeds   pointer to address where the 32 bit seeds will be
- *                     returned
+ * @param domain  pointer to previously allocated gnix_fid_domain struct
+ * @param nids    number of ids to be allocated
+ * @param id      pointer to address where the 32 bit id will be returned
  * @return FI_SUCCESS upon generate ion of 32 bit id.
  */
-int _gnix_cm_nic_get_cdm_seed_set(struct gnix_fid_domain *domain, int nseeds,
-				  uint32_t *seeds);
+int _gnix_get_new_cdm_id_set(struct gnix_fid_domain *domain, int nids,
+				uint32_t *id);
 
 #endif /* _GNIX_CM_NIC_H_ */

--- a/prov/gni/src/gnix_cm_nic.c
+++ b/prov/gni/src/gnix_cm_nic.c
@@ -192,34 +192,33 @@ err:
  * Internal API functions
  ******************************************************************************/
 
-int _gnix_cm_nic_create_cdm_id(struct gnix_fid_domain *domain, uint32_t seed,
-			       uint32_t *id)
+int _gnix_cm_nic_create_cdm_id(struct gnix_fid_domain *domain, uint32_t *id)
 {
 	uint32_t cdm_id;
+	int v;
 
-	/*
-	 * the format of the cdm_id here is governed
-	 * by the fact that currently the cdm_id_seed
-	 * is the pid of the process/thread that created
-	 * the domain.  So the most likely bits to be
-	 * unique using this method is the 16 LSBs
-	 * hence these are included, upper 16 MSBs are
-	 * masked off and overwritten by the supplied
-	 * seed value.
-	 */
+/*
+ * generate a cdm_id, use the 16 LSB of base_id from domain
+ * with 16 MSBs being obtained from atomic increment of
+ * a local variable.
+ */
+	v = atomic_inc(&gnix_id_counter);
 	cdm_id = (domain->cdm_id_seed & 0x0000FFFF) |
-			((uint32_t)seed << 16);
+			((uint32_t)v << 16);
 	*id = cdm_id;
 	return FI_SUCCESS;
 }
 
-int _gnix_cm_nic_get_cdm_seed_set(struct gnix_fid_domain *domain, int nseeds,
-				  uint32_t *seed)
+int _gnix_get_new_cdm_id_set(struct gnix_fid_domain *domain, int nids,
+			     uint32_t *id)
 {
-	uint32_t seed_base;
+	uint32_t cdm_id;
+	int v;
 
-	seed_base = atomic_add(&gnix_id_counter, nseeds);
-	*seed = seed_base;
+	v = atomic_add(&gnix_id_counter, nids);
+	cdm_id = (domain->cdm_id_seed & 0x0000FFFF) |
+			((uint32_t)v << 16);
+	*id = cdm_id;
 	return FI_SUCCESS;
 }
 
@@ -481,7 +480,7 @@ int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 {
 	int ret = FI_SUCCESS;
 	struct gnix_cm_nic *cm_nic = NULL;
-	uint32_t cdm_id, seed;
+	uint32_t cdm_id;
 	gnix_hashtable_attr_t gnix_ht_attr = {0};
 	struct gnix_ep_name *name;
 	uint32_t name_type = GNIX_EPN_TYPE_UNBOUND;
@@ -510,16 +509,7 @@ int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 	}
 
 	if (name_type == GNIX_EPN_TYPE_UNBOUND) {
-		ret = _gnix_cm_nic_get_cdm_seed_set(domain, 1,
-						    &seed);
-		if (ret != FI_SUCCESS) {
-			GNIX_WARN(FI_LOG_EP_CTRL,
-				"gnix_cm_nic_get_cdm_seed_set returned %s\n",
-				  fi_strerror(-ret));
-			goto err;
-		}
-		ret = _gnix_cm_nic_create_cdm_id(domain, seed,
-						 &cdm_id);
+		ret = _gnix_cm_nic_create_cdm_id(domain, &cdm_id);
 		if (ret != FI_SUCCESS) {
 			GNIX_WARN(FI_LOG_EP_CTRL,
 				"gnix_cm_nic_create_cdm_id returned %s\n",

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -1658,7 +1658,7 @@ DIRECT_FN int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 			   struct fid_ep **ep, void *context)
 {
 	int ret = FI_SUCCESS;
-	uint32_t cdm_id, seed;
+	uint32_t cdm_id;
 	struct gnix_fid_domain *domain_priv;
 	struct gnix_fid_ep *ep_priv;
 	gnix_ht_key_t *key_ptr;
@@ -1777,17 +1777,7 @@ DIRECT_FN int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 			ep_priv->my_name.cm_nic_cdm_id =
 				ep_priv->cm_nic->my_name.gnix_addr.cdm_id;
 
-			ret = _gnix_cm_nic_get_cdm_seed_set(domain_priv, 1,
-							    &seed);
-			if (ret != FI_SUCCESS) {
-				GNIX_WARN(FI_LOG_EP_CTRL,
-					    "gnix_cdm_nic_get_cdm_seed_set returned %s\n",
-					     fi_strerror(-ret));
-				goto err;
-			}
-			ret = _gnix_cm_nic_create_cdm_id(domain_priv,
-							 seed,
-							 &cdm_id);
+			ret = _gnix_cm_nic_create_cdm_id(domain_priv, &cdm_id);
 			if (ret != FI_SUCCESS) {
 				GNIX_WARN(FI_LOG_EP_CTRL,
 					    "gnix_cm_nic_create_cdm_id returned %s\n",

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -915,7 +915,7 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 	struct gnix_nic *nic = NULL;
 	uint32_t device_addr;
 	gni_return_t status;
-	uint32_t fake_cdm_id, seed;
+	uint32_t fake_cdm_id;
 	gni_smsg_attr_t smsg_mbox_attr;
 	struct gnix_nic_attr *nic_attr = &default_attr;
 	bool must_alloc_nic = false;
@@ -982,15 +982,7 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 		}
 
 		if (nic_attr->use_cdm_id == false) {
-			ret = _gnix_cm_nic_get_cdm_seed_set(domain, 1, &seed);
-			if (ret != FI_SUCCESS) {
-				GNIX_WARN(FI_LOG_EP_CTRL,
-					  "_gnix_cm_nic_get_cdm_seed_set returned %s\n",
-					  fi_strerror(-ret));
-				goto err;
-			}
-			ret = _gnix_cm_nic_create_cdm_id(domain, seed,
-							 &fake_cdm_id);
+			ret = _gnix_cm_nic_create_cdm_id(domain, &fake_cdm_id);
 			if (ret != FI_SUCCESS) {
 				GNIX_WARN(FI_LOG_EP_CTRL,
 					  "_gnix_cm_nic_create_cdm_id returned %s\n",


### PR DESCRIPTION
In preparation for SEP work, refactor cdm id allocation code.
@sungeunchoi 
@chuckfossen 

Signed-off-by: Howard Pritchard howardp@lanl.gov
