### PR TITLE
prov/gni: Initial fi_sendv/fi_recvv implementation.

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -140,6 +140,7 @@ extern "C" {
 
 #define GNIX_MSG_RENDEZVOUS		(1ULL << 61)	/* MSG only flag */
 #define GNIX_MSG_GET_TAIL		(1ULL << 62)	/* MSG only flag */
+#define GNIX_MSG_IOV			(1ULL << 63)	/* MSG only flag */
 
 /*
  * Cray gni provider supported flags for fi_getinfo argument for now, needs
@@ -516,6 +517,8 @@ struct gnix_fab_req_msg {
 	size_t                       recv_len;
 	struct gnix_fid_mem_desc     *recv_md;
 	uint64_t                     recv_flags; /* protocol, API info */
+	uint64_t		     recv_iov_addr;
+	size_t			     recv_iov_cnt;
 	uint64_t                     tag;
 	uint64_t                     ignore;
 	uint64_t                     imm;

--- a/prov/gni/include/gnix_msg.h
+++ b/prov/gni/include/gnix_msg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -37,9 +37,17 @@
 ssize_t _gnix_recv(struct gnix_fid_ep *ep, uint64_t buf, size_t len, void *desc,
 		   uint64_t src_addr, void *context, uint64_t flags,
 		   uint64_t tag, uint64_t ignore);
+
 ssize_t _gnix_send(struct gnix_fid_ep *ep, uint64_t loc_addr, size_t len,
 		   void *mdesc, uint64_t dest_addr, void *context,
 		   uint64_t flags, uint64_t data, uint64_t tag);
 
-#endif /* _GNIX_MSG_H_ */
+ssize_t _gnix_recvv(struct gnix_fid_ep *ep, const struct iovec *iov, void *desc,
+		    size_t count, uint64_t src_addr, void *context,
+		    uint64_t flags, uint64_t tag);
 
+ssize_t _gnix_sendv(struct gnix_fid_ep *ep, const struct iovec *iov,
+		    void *mdesc, size_t count, uint64_t dest_addr,
+		    void *context, uint64_t flags, uint64_t tag);
+
+#endif /* _GNIX_MSG_H_ */

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -184,6 +184,7 @@ struct gnix_nic {
 	gnix_bitmap_t vc_id_bitmap;
 	uint32_t mem_per_mbox;
 	struct gnix_mbox_alloc_handle *mbox_hndl;
+	/* TODO: gnix_buddy_alloc_handle_t *alloc_handle */
 	struct gnix_mbox_alloc_handle *s_rdma_buf_hndl;
 	struct gnix_mbox_alloc_handle *r_rdma_buf_hndl;
 	struct gnix_reference ref_cnt;

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -113,21 +113,19 @@ static inline ssize_t __ep_recv(struct fid_ep *ep, void *buf, size_t len,
 
 static inline ssize_t __ep_recvv(struct fid_ep *ep, const struct iovec *iov,
 				 void **desc, size_t count, fi_addr_t src_addr,
-				 void *context, uint64_t flags, uint64_t tag,
-				 uint64_t ignore)
+				 void *context, uint64_t flags, uint64_t tag)
 {
 	struct gnix_fid_ep *ep_priv;
 
-	if (!ep || !iov || count != 1) {
+	if (!ep || !iov || !count) {
 		return -FI_EINVAL;
 	}
 
 	ep_priv = container_of(ep, struct gnix_fid_ep, ep_fid);
 	assert(GNIX_EP_RDM_DGM_MSG(ep_priv->type));
 
-	return _gnix_recv(ep_priv, (uint64_t)iov[0].iov_base, iov[0].iov_len,
-			  desc ? desc[0] : NULL, src_addr, context,
-			  ep_priv->op_flags | flags, tag, ignore);
+	return _gnix_recvv(ep_priv, iov, desc ? desc[0] : NULL, count, src_addr,
+			   context, ep_priv->op_flags | flags, tag);
 }
 
 static inline ssize_t __ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
@@ -181,16 +179,15 @@ static inline ssize_t __ep_sendv(struct fid_ep *ep, const struct iovec *iov,
 {
 	struct gnix_fid_ep *gnix_ep;
 
-	if (!ep || !iov || count != 1) {
+	if (!ep || !iov || !count) {
 		return -FI_EINVAL;
 	}
 
 	gnix_ep = container_of(ep, struct gnix_fid_ep, ep_fid);
 	assert(GNIX_EP_RDM_DGM_MSG(gnix_ep->type));
 
-	return _gnix_send(gnix_ep, (uint64_t)iov[0].iov_base, iov[0].iov_len,
-			  desc ? desc[0] : NULL, dest_addr, context,
-			  gnix_ep->op_flags | flags, 0, tag);
+	return _gnix_sendv(gnix_ep, iov, desc ? desc[0] : NULL, count,
+			   dest_addr, context, gnix_ep->op_flags | flags, tag);
 }
 
 static inline ssize_t __ep_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
@@ -205,6 +202,7 @@ static inline ssize_t __ep_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 	gnix_ep = container_of(ep, struct gnix_fid_ep, ep_fid);
 	assert(GNIX_EP_RDM_DGM_MSG(gnix_ep->type));
 
+	/* TODO: return _gnix_sendnv */
 	return _gnix_send(gnix_ep, (uint64_t)msg->msg_iov[0].iov_base,
 			  msg->msg_iov[0].iov_len,
 			  msg->desc ? msg->desc[0] : NULL, msg->addr,
@@ -407,7 +405,7 @@ DIRECT_FN STATIC ssize_t gnix_ep_recvv(struct fid_ep *ep,
 				       fi_addr_t src_addr,
 				       void *context)
 {
-	return __ep_recvv(ep, iov, desc, count, src_addr, context, 0, 0, 0);
+	return __ep_recvv(ep, iov, desc, count, src_addr, context, 0, 0);
 }
 
 DIRECT_FN STATIC ssize_t gnix_ep_recvmsg(struct fid_ep *ep,
@@ -430,6 +428,7 @@ DIRECT_FN STATIC ssize_t gnix_ep_sendv(struct fid_ep *ep,
 				       fi_addr_t dest_addr,
 				       void *context)
 {
+
 	return __ep_sendv(ep, iov, desc, count, dest_addr, context, 0, 0);
 }
 
@@ -709,7 +708,7 @@ DIRECT_FN STATIC ssize_t gnix_ep_trecvv(struct fid_ep *ep,
 					void *context)
 {
 	return __ep_recvv(ep, iov, desc, count, src_addr, context,
-			FI_TAGGED, tag, ignore);
+			  FI_TAGGED, tag);
 }
 
 DIRECT_FN STATIC ssize_t gnix_ep_trecvmsg(struct fid_ep *ep,

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -456,6 +456,11 @@ static int __gnix_rndzv_req_complete(void *arg, gni_return_t tx_status)
 	}
 
 	if (req->msg.recv_flags & GNIX_MSG_IOV) {
+
+		GNIX_DEBUG(FI_LOG_EP_DATA, "recv_iov_addr = %p, recv_addr = %p,"
+			   " req = %p\n", req->msg.recv_iov_addr,
+			   req->msg.recv_addr, req);
+
 		__gnix_msg_unpack_data_into_iov(req->msg.recv_iov_addr,
 						req->msg.recv_iov_cnt,
 						req->msg.recv_addr,
@@ -1029,12 +1034,14 @@ static int __smsg_rndzv_start(void *data, void *msg)
 			 * iov buffer while the actual buffer written
 			 * to by PostRdma (msg.recv_addr) is temporary, for now.
 			 */
+			/* Is there something wrong with the pipeline here? */
 			req->msg.recv_iov_addr = req->msg.recv_addr;
 			req->msg.recv_addr = (uint64_t) tmp;
 
-			GNIX_DEBUG(FI_LOG_EP_DATA, "req->msg.recv_addr = 0x%x,"
-				   "req->msg.recv_iov_addr = 0x%x\n",
-				   req->msg.recv_addr, req->msg.recv_iov_addr);
+			GNIX_DEBUG(FI_LOG_EP_DATA, "recv_iov_addr = %p,"
+				   "recv_addr = %p,"
+				   " req = %p\n", req->msg.recv_iov_addr,
+				   req->msg.recv_addr, req);
 		}
 
 		GNIX_INFO(FI_LOG_EP_DATA, "Matched req: %p (%p, %u)\n",
@@ -1386,7 +1393,23 @@ retry_match:
 		req->gnix_ep = ep;
 		req->user_context = context;
 
-		req->msg.recv_addr = (uint64_t)buf;
+		if (req->msg.recv_flags & GNIX_MSG_IOV) {
+			void *tmp = malloc(req->msg.send_len);
+
+			assert(tmp != NULL);
+
+			/*
+			 * msg.recv_iov_addr points to the user's
+			 * iov buffer while the actual buffer written
+			 * to by PostRdma (msg.recv_addr) is temporary, for now.
+			 */
+			/* Is there something wrong with the pipeline here? */
+			req->msg.recv_iov_addr = req->msg.recv_addr;
+			req->msg.recv_addr = (uint64_t) tmp;
+		} else {
+			req->msg.recv_addr = (uint64_t)buf;
+		}
+
 		req->msg.recv_len = len;
 		if (mdesc) {
 			md = container_of(mdesc,
@@ -1826,7 +1849,6 @@ ssize_t _gnix_recvv(struct gnix_fid_ep *ep, const struct iovec *iov, void *desc,
 	int i;
 	size_t cum_len = 0;
 
-
 	if (!iov || !count) {
 		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid parameter to _gnix_recvv");
 		return -FI_EINVAL;
@@ -1863,11 +1885,10 @@ ssize_t _gnix_sendv(struct gnix_fid_ep *ep, const struct iovec *iov,
 		cum_len += iov[i].iov_len;
 	}
 
-
 	/*
 	 * TODO: If the cum_len is >= ep->domain->params.msg_rendezvous_thresh
-	 * transfer the iovec entries individually and possibly in order of
-	 * lowest index to largest index.
+	 * transfer the iovec entries individually.
+	 *
 	 * For this case, use CtPostFma for iovec lengths that are smaller than
 	 * the rendezvous thresh. For CtPostFma:
 	 * the sum of the iov lens must be either <= 1GB or <= 1MB if the comm

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -1162,6 +1162,12 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 					  (size_t)nic->mem_per_mbox,
 					  domain->params.mbox_num_per_slab,
 					  &nic->mbox_hndl);
+
+		/*
+		 * TODO: Create a buddy allocator on the nic for iov
+		 * operations
+		 */
+
 		if (ret != FI_SUCCESS) {
 			GNIX_WARN(FI_LOG_EP_CTRL,
 				  "_gnix_mbox_alloc returned %s\n",

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -1300,7 +1300,7 @@ static int __gnix_vc_conn_req_prog_fn(void *data, int *complete_ptr)
 
 	/*
 	 * prep the smsg_mbox_attr
-     */
+	 */
 
 	smsg_mbox_attr.msg_type = GNI_SMSG_TYPE_MBOX_AUTO_RETRANSMIT;
 	smsg_mbox_attr.msg_buffer = mbox->base;


### PR DESCRIPTION
- This _gnix_sendv implementation packs all the iov entries into a temporary buffer and then calls _gnix_send with the temporary buffer.
- _gnix_recv calls _gnix_send and sets the GNIX_MSG_IOV flag to indicate that the incoming data should be scattered into the user's iov buffer.
- The rdm_sr gnitests were updated to reflect these changes.  The rdm_sr/recvv test periodically fails, this appears to be caused by a race condition but that hasn't been confirmed yet.

Going forward, we would like to use chained and rdma transactions if the cumulative length of the vector entries is larger than the rendezvous threshold.  For iovec entries that exceed the rendezvous threshold a rdma get will be used, otherwise the entry will be added to a fma chained get transaction.

@sungeunchoi @ztiffany @hppritcha @jswaro 
Fixes #729 
