### PR TITLE
Add cache flush function to the GNIX domain ops

### DIFF
--- a/prov/gni/include/fi_ext_gni.h
+++ b/prov/gni/include/fi_ext_gni.h
@@ -72,6 +72,7 @@ typedef enum ep_ops_val {
 struct fi_gni_ops_domain {
 	int (*set_val)(struct fid *fid, dom_ops_val_t t, void *val);
 	int (*get_val)(struct fid *fid, dom_ops_val_t t, void *val);
+	int (*flush_cache)(struct fid *fid);
 };
 
 enum gnix_fab_req_type;

--- a/prov/gni/include/gnix_mr.h
+++ b/prov/gni/include/gnix_mr.h
@@ -128,6 +128,8 @@ struct gnix_mr_ops {
 			void **handle);
 	int (*dereg_mr)(struct gnix_fid_domain *domain,
 			struct gnix_fid_mem_desc *md);
+	int (*destroy_cache)(struct gnix_fid_domain *domain);
+	int (*flush_cache)(struct gnix_fid_domain *domain);
 };
 
 
@@ -165,6 +167,10 @@ int _gnix_open_cache(struct gnix_fid_domain *domain, int type);
 
 /* destroys mr cache for a given domain */
 int _gnix_close_cache(struct gnix_fid_domain *domain);
+
+/* flushes the memory registration cache for a given domain */
+int _gnix_flush_registration_cache(struct gnix_fid_domain *domain);
+
 
 extern gnix_mr_cache_attr_t _gnix_default_mr_cache_attr;
 


### PR DESCRIPTION
The cache can be flushed manually by user applications by
calling the domain_ops->flush_cache function by providing the
struct fid as an argument to the function.

Signed-off-by: James Swaro jswaro@cray.com

closes #830 

@sungeunchoi @hppritcha 
