### PR TITLE
Added an extended set of tunables for MR cache

### DIFF
--- a/prov/gni/include/fi_ext_gni.h
+++ b/prov/gni/include/fi_ext_gni.h
@@ -59,6 +59,9 @@ typedef enum dom_ops_val { GNI_MSG_RENDEZVOUS_THRESHOLD,
 			   GNI_MR_CACHE_LAZY_DEREG,
 			   GNI_MR_CACHE,
 			   GNI_MR_UDREG_REG_LIMIT,
+			   GNI_MR_SOFT_REG_LIMIT,
+			   GNI_MR_HARD_REG_LIMIT,
+			   GNI_MR_HARD_STALE_REG_LIMIT,
 			   GNI_NUM_DOM_OPS
 } dom_ops_val_t;
 

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -328,6 +328,15 @@ __gnix_dom_ops_get_val(struct fid *fid, dom_ops_val_t t, void *val)
 	case GNI_MR_UDREG_REG_LIMIT:
 		*(int32_t *)val = domain->udreg_reg_limit;
 		break;
+	case GNI_MR_HARD_REG_LIMIT:
+		*(int32_t *)val = domain->mr_cache_attr.hard_reg_limit;
+		break;
+	case GNI_MR_SOFT_REG_LIMIT:
+		*(int32_t *)val = domain->mr_cache_attr.soft_reg_limit;
+		break;
+	case GNI_MR_HARD_STALE_REG_LIMIT:
+		*(int32_t *)val = domain->mr_cache_attr.hard_stale_limit;
+		break;
 	default:
 		GNIX_WARN(FI_LOG_DOMAIN, ("Invalid dom_ops_val\n"));
 		return -FI_EINVAL;
@@ -431,6 +440,15 @@ __gnix_dom_ops_set_val(struct fid *fid, dom_ops_val_t t, void *val)
 			if (ret != FI_SUCCESS)
 				return -FI_EINVAL;
 		}
+		break;
+	case GNI_MR_HARD_REG_LIMIT:
+		domain->mr_cache_attr.hard_reg_limit = *(int32_t *) val;
+		break;
+	case GNI_MR_SOFT_REG_LIMIT:
+		domain->mr_cache_attr.soft_reg_limit = *(int32_t *) val;
+		break;
+	case GNI_MR_HARD_STALE_REG_LIMIT:
+		domain->mr_cache_attr.hard_stale_limit = *(int32_t *) val;
 		break;
 	case GNI_MR_UDREG_REG_LIMIT:
 		if (*(int32_t *) val < 0)


### PR DESCRIPTION
Added new values to be set/get via the get/set ops
for the domain. This allows users to tune hard and soft
registration limits related to memory registration to
help conserve node resources such as memory.

Signed-off-by: James Swaro jswaro@cray.com

closes #831 

@sungeunchoi @hppritcha 
