### PR TITLE
Uninitialized list error in tag matching code

### DIFF
--- a/prov/gni/include/gnix_ep.h
+++ b/prov/gni/include/gnix_ep.h
@@ -154,6 +154,7 @@ _gnix_fr_alloc(struct gnix_fid_ep *ep)
 		fr = container_of(de, struct gnix_fab_req, dlist);
 		fr->gnix_ep = ep;
 		dlist_init(&fr->dlist);
+		dlist_init(&fr->msg.tle.free);
 	}
 
 	/* reset common fields */

--- a/prov/gni/src/gnix_tags.c
+++ b/prov/gni/src/gnix_tags.c
@@ -608,7 +608,9 @@ static int __gnix_tag_list_insert_tag(
 	struct gnix_tag_list_element *element;
 
 	element = &req->msg.tle;
-	element->free.next = NULL;
+	if (!dlist_empty(&element->free))
+		return -FI_EALREADY;
+
 	element->context = NULL;
 	dlist_insert_tail(&element->free, &ts->list.list);
 
@@ -651,7 +653,6 @@ static struct gnix_fab_req *__gnix_tag_list_remove_tag(
 		return NULL;
 
 	req = __to_gnix_fab_req(element);
-	element->free.next = NULL;
 
 	return req;
 }
@@ -666,7 +667,6 @@ static void __gnix_tag_list_remove_tag_by_req(
 	element = &req->msg.tle;
 	item = (struct dlist_entry *) &element->free;
 	dlist_remove(item);
-	element->free.next = NULL;
 }
 
 static struct gnix_fab_req *__gnix_tag_list_remove_req_by_context(
@@ -684,7 +684,6 @@ static struct gnix_fab_req *__gnix_tag_list_remove_req_by_context(
 			return NULL;
 
 	req = __to_gnix_fab_req(element);
-	element->free.next = NULL;
 
 	return req;
 }
@@ -746,6 +745,9 @@ static int __gnix_tag_hlist_insert_tag(
 	int bucket = get_bucket(ts, tag);
 
 	element = &req->msg.tle;
+	if (!dlist_empty(&element->free))
+		return -FI_EALREADY;
+
 	dlist_init(&element->free);
 	element->context = NULL;
 	element->seq = ++ts->hlist.last_inserted_id;


### PR DESCRIPTION
I removed some direct list manipulations from the
tag matching code that was removed but reintroduced
probably by a git conflict. Additionally, the tag
matcher will now return FI_EALREADY if the request
has already been queued in a tag matcher. This shouldn't
happen during normal operation.

Signed-off-by: James Swaro jswaro@cray.com

closes #856 

@sungeunchoi @hppritcha 
