### PR TITLE
Remove void * pointer arithmetic

### DIFF
--- a/prov/gni/include/gnix_buddy_allocator.h
+++ b/prov/gni/include/gnix_buddy_allocator.h
@@ -68,11 +68,16 @@ static inline uint32_t __gnix_buddy_log2(uint32_t v)
 }
 
 /* Find the bitmap index for block X of size X_LEN */
-static inline size_t __gnix_buddy_bitmap_index(void *x, size_t x_len, void *base,
-					       size_t base_len, size_t min_len)
+static inline size_t __gnix_buddy_bitmap_index(void *_x, size_t x_len,
+					       void *_base, size_t base_len,
+					       size_t min_len)
 {
-	return (size_t) ((x - base) / (size_t) x_len) + base_len / (min_len / 2)
-		- base_len / (x_len / 2);
+	/* arithmetic on void * is not part of the C standard (yet?) */
+	uint8_t *x = _x;
+	uint8_t *base = _base;
+
+	return (size_t) ((x - base) / (size_t) x_len) +
+		base_len / (min_len / 2) - base_len / (x_len / 2);
 }
 
 /* Find the address of X's buddy block:

--- a/prov/gni/src/gnix_buddy_allocator.c
+++ b/prov/gni/src/gnix_buddy_allocator.c
@@ -143,7 +143,8 @@ static inline int __gnix_buddy_create_lists(gnix_buddy_alloc_handle_t
 
 	/* Insert free blocks of size max in sorted order into last list */
 	for (i = 0; i < alloc_handle->len / alloc_handle->max; i++) {
-		dlist_insert_tail(alloc_handle->base + offset,
+		dlist_insert_tail((void *) ((uint8_t *) alloc_handle->base +
+					    offset),
 				  alloc_handle->lists +
 				  alloc_handle->nlists - 1);
 		offset += alloc_handle->max;
@@ -171,7 +172,8 @@ static inline void __gnix_buddy_split(gnix_buddy_alloc_handle_t *alloc_handle,
 							alloc_handle->len,
 							MIN_BLOCK_SIZE));
 
-		dlist_insert_tail(tmp + OFFSET(MIN_BLOCK_SIZE, j - 1),
+		dlist_insert_tail((void *) ((uint8_t *) tmp +
+					    OFFSET(MIN_BLOCK_SIZE, j - 1)),
 				  alloc_handle->lists + j - 1);
 	}
 
@@ -366,7 +368,8 @@ int _gnix_buddy_free(gnix_buddy_alloc_handle_t *alloc_handle, void *ptr,
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
 	if (unlikely(!alloc_handle || !len || len > alloc_handle->max ||
-		     ptr >= alloc_handle->base + alloc_handle->len  ||
+		     ptr >= (void *) ((uint8_t *) alloc_handle->base +
+				      alloc_handle->len) ||
 		     ptr < alloc_handle->base)) {
 
 		GNIX_WARN(FI_LOG_EP_CTRL,

--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -513,7 +513,7 @@ DIRECT_FN STATIC ssize_t gnix_cq_readfrom(struct fid_cq *cq, void *buf,
 
 		_gnix_queue_enqueue_free(cq_priv->events, &event->item);
 
-		buf += cq_priv->entry_size;
+		buf = (void *) ((uint8_t *) buf + cq_priv->entry_size);
 
 		read_count++;
 	}

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -319,7 +319,7 @@ static void __gnix_msg_copy_unaligned_get_data(struct gnix_fab_req *req)
 			GNI_READ_ALIGN_MASK;
 
 	if (head_off) {
-		addr = (void *)&req->msg.rndzv_head + head_off;
+		addr = (uint8_t *)&req->msg.rndzv_head + head_off;
 
 		GNIX_INFO(FI_LOG_EP_DATA,
 			  "writing %d bytes to head (%p, 0x%x)\n",

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -696,7 +696,8 @@ static int __gnix_nic_tx_freelist_init(struct gnix_nic *nic, int n_descs)
 
 	for (i = 0, desc_ptr = desc_base; i < n_descs; i++, desc_ptr++) {
 		desc_ptr->id = i;
-		desc_ptr->int_buf = int_bufs + (i * GNIX_CACHELINE_SIZE);
+		desc_ptr->int_buf = (void *) ((uint8_t *) int_bufs +
+					      (i * GNIX_CACHELINE_SIZE));
 		dlist_insert_tail(&desc_ptr->list,
 				  &nic->tx_desc_free_list);
 	}

--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -129,7 +129,7 @@ static void __gnix_rma_copy_indirect_get_data(struct gnix_tx_descriptor *txd)
 	int head_off = req->rma.rem_addr & GNI_READ_ALIGN_MASK;
 
 	memcpy((void *)req->rma.loc_addr,
-	       txd->int_buf + head_off,
+	       (void *) ((uint8_t *) txd->int_buf + head_off),
 	       req->rma.len);
 }
 
@@ -147,19 +147,19 @@ static void __gnix_rma_copy_chained_get_data(struct gnix_tx_descriptor *txd)
 		GNIX_INFO(FI_LOG_EP_DATA, "writing %d bytes to %p\n",
 			  head_len, req->rma.loc_addr);
 		memcpy((void *)req->rma.loc_addr,
-		       txd->int_buf + head_off,
+		       (void *) ((uint8_t *) txd->int_buf + head_off),
 		       head_len);
 	}
 
 	if (tail_len) {
-		addr = (void *)req->rma.loc_addr +
-			       req->rma.len -
-			       tail_len;
+		addr = (void *) ((uint8_t *) req->rma.loc_addr +
+				 req->rma.len -
+				 tail_len);
 
 		GNIX_INFO(FI_LOG_EP_DATA, "writing %d bytes to %p\n",
 			  tail_len, addr);
 		memcpy((void *)addr,
-		       txd->int_buf + GNI_READ_ALIGN,
+		       (void *) ((uint8_t *) txd->int_buf + GNI_READ_ALIGN),
 		       tail_len);
 	}
 }

--- a/prov/gni/test/mr.c
+++ b/prov/gni/test/mr.c
@@ -543,7 +543,7 @@ static void __simple_register_1024_distinct_regions(HOOK_DECL)
 {
 	int ret;
 	uint64_t **buffers;
-	void *buffer;
+	char *buffer;
 	struct fid_mr **mr_arr;
 	int i;
 
@@ -1125,7 +1125,8 @@ static inline void _single_large_registration(const char *label)
 
 	gettimeofday(&s1, 0);
 	for (i = 0; i < registrations; i++) {
-		ret = fi_mr_reg(dom, (void *) region + (registration_width * i),
+		ret = fi_mr_reg(dom, (void *) (region +
+					       (registration_width * i)),
 				registration_width, default_access,
 				default_offset, default_req_key,
 				default_flags, &f_mr[i], NULL);
@@ -1189,8 +1190,10 @@ static inline void _random_analysis(const char *label)
 	for (i = 0; i < registrations; i++) {
 		ptr = region + rand() % region_len;
 		ptr_len = registration_width;
-		if ((uint64_t) (ptr + ptr_len) > (uint64_t) (region + region_len))
+		if ((uint64_t) ((char *) ptr + ptr_len) >
+		    (uint64_t) (region + region_len)) {
 			ptr_len = ((uint64_t) region + region_len) - (uint64_t) ptr;
+		}
 
 		ret = fi_mr_reg(dom, (void *) ptr,
 				ptr_len, default_access,
@@ -1244,19 +1247,19 @@ Test(mr_internal_cache, regression_615)
 {
 	int ret;
 	struct fid_mr *f_mr;
-	void *buffer = calloc(1 << 19, sizeof(char));
+	char *buffer = calloc(1 << 19, sizeof(char));
 
 	cr_assert(buffer != NULL);
 
 	/* set up stale cache */
-	ret = fi_mr_reg(dom, (void *) buffer + 0x18000, 0x8000,
+	ret = fi_mr_reg(dom, (void *) (buffer + 0x18000), 0x8000,
 			default_access, default_offset, default_req_key,
 			default_flags, &f_mr, NULL);
 	cr_assert(ret == FI_SUCCESS);
 	ret = fi_close(&f_mr->fid);
 	cr_assert(ret == FI_SUCCESS);
 
-	ret = fi_mr_reg(dom, (void *) buffer + 0x0, 0x80000,
+	ret = fi_mr_reg(dom, (void *) (buffer + 0x0), 0x80000,
 			default_access, default_offset, default_req_key,
 			default_flags, &f_mr, NULL);
 	cr_assert(ret == FI_SUCCESS);
@@ -1264,7 +1267,7 @@ Test(mr_internal_cache, regression_615)
 	cr_assert(ret == FI_SUCCESS);
 
 	/* set up inuse */
-	ret = fi_mr_reg(dom, (void *) buffer + 0x28000, 0x4000,
+	ret = fi_mr_reg(dom, (void *) (buffer + 0x28000), 0x4000,
 			default_access, default_offset, default_req_key,
 			default_flags, &f_mr, NULL);
 	cr_assert(ret == FI_SUCCESS);
@@ -1284,7 +1287,7 @@ void simple_register_1024_distinct_regions(void)
 {
 	int ret;
 	uint64_t **buffers;
-	void *buffer;
+	char *buffer;
 	struct fid_mr **mr_arr;
 	int i;
 


### PR DESCRIPTION
Pointer arithmetic on void \* is a GNU extension, not part of the C standard.

@hppritcha @e-harvey @jswaro 

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com
