### PR TITLE
Changed the gnix_vector to use the ops table.

### DIFF
--- a/prov/gni/include/gnix_vector.h
+++ b/prov/gni/include/gnix_vector.h
@@ -59,7 +59,7 @@ typedef enum gnix_vec_lock {
 	GNIX_VEC_LOCKED,
 } gnix_vec_lock_e;
 
-typedef uint64_t gnix_vec_index_t;
+typedef uint32_t gnix_vec_index_t;
 typedef void * gnix_vec_entry_t;
 
 /**
@@ -72,11 +72,11 @@ typedef void * gnix_vec_entry_t;
  * @var creator			fn required to properly alloc the vector element
  */
 typedef struct gnix_vec_attr {
-	uint64_t vec_initial_size;
-	uint64_t cur_size;
-	uint64_t vec_maximum_size;
+	uint32_t vec_initial_size;
+	uint32_t cur_size;
+	uint32_t vec_maximum_size;
 
-	uint64_t vec_increase_step;
+	uint32_t vec_increase_step;
 
 	gnix_vec_increase_e vec_increase_type;
 
@@ -87,7 +87,7 @@ struct gnix_vector;
 
 struct gnix_vector_iter {
 	struct gnix_vector *vec;
-	uint64_t cur_idx;
+	uint32_t cur_idx;
 };
 
 #define GNIX_VECTOR_ITERATOR(_vec, _iter)	\
@@ -110,7 +110,7 @@ struct gnix_vector_iter {
  * @var at		Return the element at the specified index.
  */
 typedef struct gnix_vector_ops {
-	int (*resize)(struct gnix_vector *, uint64_t);
+	int (*resize)(struct gnix_vector *, uint32_t);
 
 	int (*insert_last)(struct gnix_vector *, gnix_vec_entry_t *);
 	int (*insert_at)(struct gnix_vector *, gnix_vec_entry_t *,
@@ -185,7 +185,7 @@ int _gnix_vec_close(gnix_vector_t *vec);
  *			than the maximum vector size
  * @return -FI_ENOMEM	Upon running out of memory
  */
-static inline int _gnix_vec_resize(gnix_vector_t *vec, uint64_t size)
+static inline int _gnix_vec_resize(gnix_vector_t *vec, uint32_t size)
 {
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 

--- a/prov/gni/src/gnix_vector.c
+++ b/prov/gni/src/gnix_vector.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
  *                         All rights reserved.
+ * Copyright (c) 2016 Cray Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -36,7 +37,6 @@
 static gnix_vector_ops_t __gnix_vec_lockless_ops;
 static gnix_vector_ops_t __gnix_vec_locked_ops;
 
-
 /*******************************************************************************
  * INTERNAL HELPER FNS
  ******************************************************************************/
@@ -68,9 +68,24 @@ static inline uint64_t __gnix_vec_get_new_size(gnix_vector_t *vec, uint64_t inde
 	return new_size;
 }
 
+static inline void __gnix_vec_close_entries(gnix_vector_t *vec)
+{
+	memset(vec->vector, 0, (sizeof(gnix_vec_entry_t) * vec->attr.cur_size));
+}
+
+/*******************************************************************************
+ * INTERNAL WORKER FNS
+ ******************************************************************************/
 static inline int __gnix_vec_resize(gnix_vector_t *vec, uint64_t new_size)
 {
-	void *tmp = realloc(vec->vector, new_size * sizeof(gnix_vec_entry_t));
+	void *tmp;
+
+	if (new_size <= vec->attr.cur_size) {
+		GNIX_WARN(FI_LOG_EP_DATA, "In __gnix_vec_resize, the new vector"
+			  "size is less than or equal to the current size.\n");
+	}
+
+	tmp = realloc(vec->vector, new_size * sizeof(gnix_vec_entry_t));
 
 	if (!tmp) {
 		GNIX_WARN(FI_LOG_EP_CTRL, "Insufficient memory in "
@@ -107,39 +122,23 @@ static inline int __gnix_vec_create(gnix_vector_t *vec, gnix_vec_attr_t *attr)
 	return FI_SUCCESS;
 }
 
-static inline void __gnix_vec_close_entries(gnix_vector_t *vec)
-{
-	memset(vec->vector, 0, (sizeof(gnix_vec_entry_t) * vec->attr.cur_size));
-}
-
-static inline void __gnix_vec_close(gnix_vector_t *vec)
+static inline int __gnix_vec_close(gnix_vector_t *vec)
 {
 	free(vec->vector);
 	vec->ops = NULL;
 	vec->attr.cur_size = 0;
 	vec->state = GNIX_VEC_STATE_DEAD;
+
+	return FI_SUCCESS;
 }
 
-/*******************************************************************************
- * INLINE OPS FNS
- ******************************************************************************/
-inline int _gnix_vec_insert_first(gnix_vector_t *vec, gnix_vec_entry_t *entry)
-{
-	return _gnix_vec_insert_at(vec, entry, 0);
-}
-
-inline int _gnix_vec_insert_last(gnix_vector_t *vec, gnix_vec_entry_t *entry)
-{
-	return _gnix_vec_insert_at(vec, entry, vec->attr.cur_size-1);
-}
-
-inline int _gnix_vec_insert_at(gnix_vector_t *vec, gnix_vec_entry_t *entry,
-				      gnix_vec_index_t index)
+static inline int __gnix_vec_insert_at(gnix_vector_t *vec,
+				       gnix_vec_entry_t *entry,
+				       gnix_vec_index_t index)
 {
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
-	if (unlikely(!vec || !entry ||
-		    index >= vec->attr.vec_maximum_size)) {
+	if (unlikely(index >= vec->attr.vec_maximum_size)) {
 		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid parameter to "
 			  "__gnix_vec_insert_at\n");
 		return -FI_EINVAL;
@@ -147,7 +146,7 @@ inline int _gnix_vec_insert_at(gnix_vector_t *vec, gnix_vec_entry_t *entry,
 
 	if (unlikely(vec->state == GNIX_VEC_STATE_DEAD)) {
 		GNIX_FATAL(FI_LOG_EP_CTRL, "gnix_vector_t is in state "
-			   "GNIX_VEC_STATE_DEAD in _gnix_vec_insert_at.\n");
+			   "GNIX_VEC_STATE_DEAD in __gnix_vec_insert_at.\n");
 	}
 
 	if (index >= vec->attr.cur_size) {
@@ -160,7 +159,7 @@ inline int _gnix_vec_insert_at(gnix_vector_t *vec, gnix_vec_entry_t *entry,
 
 	if (vec->vector[index]) {
 		GNIX_WARN(FI_LOG_EP_CTRL, "Existing element found in "
-			  "__gnix_vec_insert_last\n");
+			  "__gnix_vec_insert_at\n");
 		return -FI_ECANCELED;
 	} else {
 		vec->vector[index] = entry;
@@ -168,27 +167,16 @@ inline int _gnix_vec_insert_at(gnix_vector_t *vec, gnix_vec_entry_t *entry,
 	}
 }
 
-inline int _gnix_vec_remove_first(gnix_vector_t *vec)
+static inline int __gnix_vec_remove_at(gnix_vector_t *vec,
+				       gnix_vec_index_t index)
 {
-	return _gnix_vec_remove_at(vec, 0);
-}
-
-inline int _gnix_vec_remove_last(gnix_vector_t *vec)
-{
-	return _gnix_vec_remove_at(vec, vec->attr.cur_size-1);
-}
-
-inline int _gnix_vec_remove_at(gnix_vector_t *vec, gnix_vec_index_t index)
-{
-	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
-
-	if (unlikely(!vec || index >= vec->attr.cur_size)) {
-		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid parameter to "
-			  "__gnix_vec_remove_at\n");
-		return -FI_EINVAL;
-	} else if (unlikely(vec->state == GNIX_VEC_STATE_DEAD)) {
+	if (unlikely(vec->state == GNIX_VEC_STATE_DEAD)) {
 		GNIX_FATAL(FI_LOG_EP_CTRL, "gnix_vector_t is in state "
-			   "GNIX_VEC_STATE_DEAD in _gnix_vec_remove_at.\n");
+			   "GNIX_VEC_STATE_DEAD in __gnix_vec_remove_at.\n");
+	} else if (index >= vec->attr.cur_size) {
+		GNIX_WARN(FI_LOG_EP_CTRL, "Index (%lu) too large in "
+			  "__gnix_vec_remove_at\n", index);
+		return -FI_EINVAL;
 	} else {
 		if (!vec->vector[index]) {
 			GNIX_WARN(FI_LOG_EP_CTRL, "No entry exists in "
@@ -201,49 +189,26 @@ inline int _gnix_vec_remove_at(gnix_vector_t *vec, gnix_vec_index_t index)
 	return FI_SUCCESS;
 }
 
-inline int _gnix_vec_first(gnix_vector_t *vec, void **element)
+static inline int __gnix_vec_at(gnix_vector_t *vec, void **element,
+				gnix_vec_index_t index)
 {
-	return _gnix_vec_at(vec, element, 0);
-}
-
-inline int _gnix_vec_last(gnix_vector_t *vec, void **element)
-{
-	return _gnix_vec_at(vec, element, vec->attr.cur_size-1);
-}
-
-inline int _gnix_vec_at(gnix_vector_t *vec, void **element, gnix_vec_index_t index)
-{
-	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
-
-	if (unlikely(!vec || index >= vec->attr.cur_size || !element)) {
-		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid parameter to "
-			  "_gnix_vec_at\n");
-		return -FI_EINVAL;
-	} else if (unlikely(vec->state == GNIX_VEC_STATE_DEAD)) {
+	if (unlikely(vec->state == GNIX_VEC_STATE_DEAD)) {
 		GNIX_FATAL(FI_LOG_EP_CTRL, "gnix_vector_t is in state "
-			   "GNIX_VEC_STATE_DEAD in _gnix_vec_at.\n");
+			   "GNIX_VEC_STATE_DEAD in __gnix_vec_at.\n");
+	} else if (index >= vec->attr.cur_size) {
+		GNIX_WARN(FI_LOG_EP_CTRL, "Index (%lu) too large in "
+			  "__gnix_vec_at\n", index);
+		return -FI_EINVAL;
 	} else {
 		if (likely((uint64_t) vec->vector[index])) {
 			*element = vec->vector[index];
 		} else {
-			GNIX_INFO(FI_LOG_EP_CTRL, "There is no element at index "
-				  "%lu in _gnix_vec_at\n", index);
+			GNIX_DEBUG(FI_LOG_EP_CTRL, "There is no element at index "
+				   "(%lu) in __gnix_vec_at\n", index);
 			return -FI_ECANCELED;
 		}
-
 	}
 	return FI_SUCCESS;
-}
-
-/**
- * Return next element in the vector iterator
- *
- * @param iter    pointer to the vector iterator
- * @return        pointer to next element in the vector
- */
-gnix_vec_entry_t *_gnix_vec_iterator_next(struct gnix_vector_iter *iter)
-{
-	return iter->vec->ops->iter_next(iter);
 }
 
 /*******************************************************************************
@@ -262,10 +227,12 @@ static int __gnix_vec_lf_init(gnix_vector_t *vec, gnix_vec_attr_t *attr)
 
 static int __gnix_vec_lf_close(gnix_vector_t *vec)
 {
-	__gnix_vec_close_entries(vec);
-	__gnix_vec_close(vec);
+	int ret;
 
-	return FI_SUCCESS;
+	__gnix_vec_close_entries(vec);
+	ret = __gnix_vec_close(vec);
+
+	return ret;
 }
 
 static int __gnix_vec_lf_resize(gnix_vector_t *vec, uint64_t size)
@@ -273,63 +240,47 @@ static int __gnix_vec_lf_resize(gnix_vector_t *vec, uint64_t size)
 	return __gnix_vec_resize(vec, size);
 }
 
-static int __gnix_vec_lf_insert_first(gnix_vector_t *vec,
-				      gnix_vec_entry_t *entry)
-{
-	return _gnix_vec_insert_first(vec, entry);
-}
-
 static int __gnix_vec_lf_insert_last(gnix_vector_t *vec,
 			      gnix_vec_entry_t *entry)
 {
-	return _gnix_vec_insert_last(vec, entry);
+	return __gnix_vec_insert_at(vec, entry, vec->attr.cur_size - 1);
 }
 
 static int __gnix_vec_lf_insert_at(gnix_vector_t *vec,
 				   gnix_vec_entry_t *entry,
 				   gnix_vec_index_t index)
 {
-	return _gnix_vec_insert_at(vec, entry, index);
-}
-
-static int __gnix_vec_lf_remove_first(gnix_vector_t *vec)
-{
-	return _gnix_vec_remove_first(vec);
+	return __gnix_vec_insert_at(vec, entry, index);
 }
 
 static int __gnix_vec_lf_remove_last(gnix_vector_t *vec)
 {
-	return _gnix_vec_remove_last(vec);
+	return __gnix_vec_remove_at(vec, vec->attr.cur_size - 1);
 }
 
 static int __gnix_vec_lf_remove_at(gnix_vector_t *vec,
 				   gnix_vec_index_t index)
 {
-	return _gnix_vec_remove_at(vec, index);
-}
-
-static int __gnix_vec_lf_first(gnix_vector_t *vec, void **element)
-{
-	return _gnix_vec_first(vec, element);
+	return __gnix_vec_remove_at(vec, index);
 }
 
 static int __gnix_vec_lf_last(gnix_vector_t *vec, void **element)
 {
-	return _gnix_vec_last(vec, element);
+	return __gnix_vec_at(vec, element, vec->attr.cur_size - 1);
 }
 
 static int __gnix_vec_lf_at(gnix_vector_t *vec, void **element, gnix_vec_index_t index)
 {
-	return _gnix_vec_at(vec, element, index);
+	return __gnix_vec_at(vec, element, index);
 }
 
-gnix_vec_entry_t *__gnix_vec_lf_iter_first(struct gnix_vector_iter *iter)
+gnix_vec_entry_t *__gnix_vec_lf_iter_next(struct gnix_vector_iter *iter)
 {
-	int i;
+	uint64_t i;
 
 	for (i = iter->cur_idx; i < iter->vec->attr.cur_size; i++) {
 		if (iter->vec->vector[i]) {
-			iter->cur_idx = i;
+			iter->cur_idx = i + 1;
 			return iter->vec->vector[i];
 		}
 	}
@@ -355,16 +306,18 @@ static int __gnix_vec_lk_init(gnix_vector_t *vec, gnix_vec_attr_t *attr)
 
 static int __gnix_vec_lk_close(gnix_vector_t *vec)
 {
+	int ret;
+
 	rwlock_wrlock(&vec->lock);
 
 	__gnix_vec_close_entries(vec);
-	__gnix_vec_close(vec);
+	ret = __gnix_vec_close(vec);
 
 	rwlock_unlock(&vec->lock);
 
 	rwlock_destroy(&vec->lock);
 
-	return FI_SUCCESS;
+	return ret;
 }
 
 static int __gnix_vec_lk_resize(gnix_vector_t *vec, uint64_t size)
@@ -380,20 +333,6 @@ static int __gnix_vec_lk_resize(gnix_vector_t *vec, uint64_t size)
 	return ret;
 }
 
-static int __gnix_vec_lk_insert_first(gnix_vector_t *vec,
-				      gnix_vec_entry_t *entry)
-{
-	int ret;
-
-	rwlock_wrlock(&vec->lock);
-
-	ret = _gnix_vec_insert_first(vec, entry);
-
-	rwlock_unlock(&vec->lock);
-
-	return ret;
-}
-
 static int __gnix_vec_lk_insert_last(gnix_vector_t *vec,
 			      gnix_vec_entry_t *entry)
 {
@@ -401,7 +340,7 @@ static int __gnix_vec_lk_insert_last(gnix_vector_t *vec,
 
 	rwlock_wrlock(&vec->lock);
 
-	ret = _gnix_vec_insert_last(vec, entry);
+	ret = __gnix_vec_insert_at(vec, entry, vec->attr.cur_size - 1);
 
 	rwlock_unlock(&vec->lock);
 
@@ -416,20 +355,7 @@ static int __gnix_vec_lk_insert_at(gnix_vector_t *vec,
 
 	rwlock_wrlock(&vec->lock);
 
-	ret = _gnix_vec_insert_at(vec, entry, index);
-
-	rwlock_unlock(&vec->lock);
-
-	return ret;
-}
-
-static int __gnix_vec_lk_remove_first(gnix_vector_t *vec)
-{
-	int ret;
-
-	rwlock_wrlock(&vec->lock);
-
-	ret = _gnix_vec_remove_first(vec);
+	ret = __gnix_vec_insert_at(vec, entry, index);
 
 	rwlock_unlock(&vec->lock);
 
@@ -442,7 +368,7 @@ static int __gnix_vec_lk_remove_last(gnix_vector_t *vec)
 
 	rwlock_wrlock(&vec->lock);
 
-	ret = _gnix_vec_remove_last(vec);
+	ret = __gnix_vec_remove_at(vec, vec->attr.cur_size - 1);
 
 	rwlock_unlock(&vec->lock);
 
@@ -456,20 +382,7 @@ static int __gnix_vec_lk_remove_at(gnix_vector_t *vec,
 
 	rwlock_wrlock(&vec->lock);
 
-	ret = _gnix_vec_remove_at(vec, index);
-
-	rwlock_unlock(&vec->lock);
-
-	return ret;
-}
-
-static int __gnix_vec_lk_first(gnix_vector_t *vec, void **element)
-{
-	int ret;
-
-	rwlock_rdlock(&vec->lock);
-
-	ret = _gnix_vec_first(vec, element);
+	ret = __gnix_vec_remove_at(vec, index);
 
 	rwlock_unlock(&vec->lock);
 
@@ -482,7 +395,7 @@ static int __gnix_vec_lk_last(gnix_vector_t *vec, void **element)
 
 	rwlock_rdlock(&vec->lock);
 
-	ret = _gnix_vec_last(vec, element);
+	ret = __gnix_vec_at(vec, element, vec->attr.cur_size - 1);
 
 	rwlock_unlock(&vec->lock);
 
@@ -495,25 +408,27 @@ static int __gnix_vec_lk_at(gnix_vector_t *vec, void **element, gnix_vec_index_t
 
 	rwlock_rdlock(&vec->lock);
 
-	ret = _gnix_vec_at(vec, element, index);
+	ret = __gnix_vec_at(vec, element, index);
 
 	rwlock_unlock(&vec->lock);
 
 	return ret;
 }
 
-gnix_vec_entry_t *__gnix_vec_lk_iter_first(struct gnix_vector_iter *iter)
+gnix_vec_entry_t *__gnix_vec_lk_iter_next(struct gnix_vector_iter *iter)
 {
-	int i;
+	uint64_t i;
+	gnix_vec_entry_t *entry;
 
 	rwlock_rdlock(&iter->vec->lock);
 
 	for (i = iter->cur_idx; i < iter->vec->attr.cur_size; i++) {
 		if (iter->vec->vector[i]) {
+			iter->cur_idx = i + 1;
+			entry = iter->vec->vector[i];
 			rwlock_unlock(&iter->vec->lock);
 
-			iter->cur_idx = i;
-			return iter->vec->vector[i];
+			return entry;
 		}
 	}
 
@@ -524,6 +439,9 @@ gnix_vec_entry_t *__gnix_vec_lk_iter_first(struct gnix_vector_iter *iter)
 	return NULL;
 }
 
+/*******************************************************************************
+ * API FNS
+ ******************************************************************************/
 /**
  * Create the initial vector.  The user is responsible for initializing the
  * "attr" parameter prior to calling this function.
@@ -584,51 +502,32 @@ int _gnix_vec_close(gnix_vector_t *vec)
 	}
 }
 
-int _gnix_vec_resize(gnix_vector_t *vec, uint64_t size)
-{
-	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
-
-	if (unlikely(!vec || !size)) {
-		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid parameter to _gnix_vec_resize."
-			  "\n");
-		return -FI_EINVAL;
-	} else {
-		if (vec->attr.vec_internal_locking == GNIX_VEC_LOCKED) {
-			return __gnix_vec_lk_resize(vec, size);
-		} else {
-			return __gnix_vec_lf_resize(vec, size);
-		}
-	}
-}
-
 static gnix_vector_ops_t __gnix_vec_lockless_ops = {
-	.insert_first = __gnix_vec_lf_insert_first,
+	.resize = __gnix_vec_lf_resize,
+
 	.insert_last = __gnix_vec_lf_insert_last,
 	.insert_at = __gnix_vec_lf_insert_at,
 
-	.remove_first = __gnix_vec_lf_remove_first,
 	.remove_last = __gnix_vec_lf_remove_last,
 	.remove_at = __gnix_vec_lf_remove_at,
 
-	.first = __gnix_vec_lf_first,
 	.last = __gnix_vec_lf_last,
 	.at = __gnix_vec_lf_at,
 
-	.iter_next = __gnix_vec_lf_iter_first,
+	.iter_next = __gnix_vec_lf_iter_next,
 };
 
 static gnix_vector_ops_t __gnix_vec_locked_ops = {
-	.insert_first = __gnix_vec_lk_insert_first,
+	.resize = __gnix_vec_lk_resize,
+
 	.insert_last = __gnix_vec_lk_insert_last,
 	.insert_at = __gnix_vec_lk_insert_at,
 
-	.remove_first = __gnix_vec_lk_remove_first,
 	.remove_last = __gnix_vec_lk_remove_last,
 	.remove_at = __gnix_vec_lk_remove_at,
 
-	.first = __gnix_vec_lk_first,
 	.last = __gnix_vec_lk_last,
 	.at = __gnix_vec_lk_at,
 
-	.iter_next = __gnix_vec_lk_iter_first,
+	.iter_next = __gnix_vec_lk_iter_next,
 };

--- a/prov/gni/test/vector.c
+++ b/prov/gni/test/vector.c
@@ -77,15 +77,6 @@ void do_invalid_ops_params()
 	int ret;
 	void *tmp;
 
-	/* ret = _gnix_vec_insert_first(&vec, NULL); */
-	/* cr_assert_eq(ret, -FI_EINVAL); */
-
-	/* ret = _gnix_vec_remove_first(&vec); */
-	/* cr_assert_eq(ret, -FI_EINVAL); */
-
-	/* ret = _gnix_vec_first(&vec, &tmp); */
-	/* cr_assert_eq(ret, -FI_EINVAL); */
-
 	ret = _gnix_vec_insert_first(NULL, NULL);
 	cr_assert_eq(ret, -FI_EINVAL);
 
@@ -102,11 +93,11 @@ void vector_teardown(void)
 
 	ret = _gnix_vec_close(&vec);
 	cr_assert(!ret, "_gnix_vec_close");
+}
 
-	do_invalid_ops_params();
-
-	/* ret = _gnix_vec_close(&vec); */
-	/* cr_assert_eq(ret, -FI_EINVAL); */
+void vector_teardown_error(void)
+{
+	int ret;
 
 	ret = _gnix_vec_close(NULL);
 	cr_assert_eq(ret, -FI_EINVAL);
@@ -137,13 +128,6 @@ void vector_setup_error(void)
 
 	ret = _gnix_vec_init(&vec, &attr);
 	cr_assert_eq(ret, -FI_EINVAL);
-
-	/* attr.vec_initial_size = 64; */
-	/* attr.vec_maximum_size = 128; */
-	/* vec.state = GNIX_VEC_STATE_READY; */
-	/* ret = _gnix_vec_init(&vec, &attr); */
-
-	vector_setup_lockless();
 }
 
 void do_insert_first()
@@ -152,10 +136,10 @@ void do_insert_first()
 	void *tmp = malloc(sizeof(gnix_vec_entry_t));
 	cr_assert(tmp, "do_insert_first");
 
-	ret = vec.ops->insert_first(&vec, tmp);
+	ret = _gnix_vec_insert_first(&vec, tmp);
 	cr_assert(!ret, "_gnix_vec_insert_first");
 
-	ret = vec.ops->insert_first(&vec, tmp);
+	ret = _gnix_vec_insert_first(&vec, tmp);
 	cr_assert_eq(ret, -FI_ECANCELED);
 }
 
@@ -165,10 +149,10 @@ void do_insert_last()
 	void *tmp = malloc(sizeof(gnix_vec_entry_t));
 	cr_assert(tmp, "do_insert_last");
 
-	ret = vec.ops->insert_last(&vec, tmp);
+	ret = _gnix_vec_insert_last(&vec, tmp);
 	cr_assert(!ret, "_gnix_vec_insert_last");
 
-	ret = vec.ops->insert_last(&vec, tmp);
+	ret = _gnix_vec_insert_last(&vec, tmp);
 	cr_assert_eq(ret, -FI_ECANCELED);
 }
 
@@ -181,7 +165,7 @@ void do_fill_insert_at()
 		tmp = malloc(sizeof(gnix_vec_entry_t));
 		cr_assert(tmp, "do_insert_at");
 
-		ret = vec.ops->insert_at(&vec, tmp, i);
+		ret = _gnix_vec_insert_at(&vec, tmp, i);
 		cr_assert(!ret, "_gnix_vec_insert_at");
 	}
 
@@ -189,22 +173,22 @@ void do_fill_insert_at()
 	tmp = malloc(sizeof(gnix_vec_entry_t));
 	cr_assert(tmp, "do_insert_at");
 
-	ret = vec.ops->insert_at(&vec, tmp, VEC_MAX-1);
+	ret = _gnix_vec_insert_at(&vec, tmp, VEC_MAX-1);
 	cr_assert(!ret, "_gnix_vec_insert_at");
 	cr_assert_eq(vec.attr.cur_size, VEC_MAX);
 
-	ret = vec.ops->insert_at(&vec, tmp, VEC_MAX-1);
+	ret = _gnix_vec_insert_at(&vec, tmp, VEC_MAX-1);
 	cr_assert_eq(ret, -FI_ECANCELED);
 
 	for (; i < vec.attr.cur_size - 1; i++) {
 		tmp = malloc(sizeof(gnix_vec_entry_t));
 		cr_assert(tmp, "do_insert_at");
 
-		ret = vec.ops->insert_at(&vec, tmp, i);
+		ret = _gnix_vec_insert_at(&vec, tmp, i);
 		cr_assert(!ret, "_gnix_vec_insert_at");
 	}
 
-	ret = vec.ops->insert_at(&vec, tmp, VEC_MAX);
+	ret = _gnix_vec_insert_at(&vec, tmp, VEC_MAX);
 	cr_assert_eq(ret, -FI_EINVAL);
 }
 
@@ -213,14 +197,14 @@ void do_remove_first()
 	int ret;
 	void *tmp;
 
-	ret = vec.ops->first(&vec, &tmp);
+	ret = _gnix_vec_first(&vec, &tmp);
 	cr_assert(!ret, "_gnix_vec_first");
 	free(tmp);
 
-	ret = vec.ops->remove_first(&vec);
+	ret = _gnix_vec_remove_first(&vec);
 	cr_assert(!ret, "_gnix_vec_remove_first");
 
-	ret = vec.ops->remove_first(&vec);
+	ret = _gnix_vec_remove_first(&vec);
 	cr_assert_eq(ret, -FI_ECANCELED);
 }
 
@@ -229,14 +213,14 @@ void do_remove_last()
 	int ret;
 	void *tmp;
 
-	ret = vec.ops->last(&vec, &tmp);
+	ret = _gnix_vec_last(&vec, &tmp);
 	cr_assert(!ret, "_gnix_vec_last");
 	free(tmp);
 
-	ret = vec.ops->remove_last(&vec);
+	ret = _gnix_vec_remove_last(&vec);
 	cr_assert(!ret, "_gnix_vec_remove_last");
 
-	ret = vec.ops->remove_last(&vec);
+	ret = _gnix_vec_remove_last(&vec);
 	cr_assert_eq(ret, -FI_ECANCELED);
 }
 
@@ -246,15 +230,15 @@ void do_unfill_remove_at()
 	void *tmp;
 
 	for (i = 0; i < vec.attr.cur_size; i++) {
-		ret = vec.ops->at(&vec, &tmp, i);
+		ret = _gnix_vec_at(&vec, &tmp, i);
 		cr_assert(!ret, "_gnix_vec_at");
 		free(tmp);
 
-		ret = vec.ops->remove_at(&vec, i);
+		ret = _gnix_vec_remove_at(&vec, i);
 		cr_assert(!ret, "_gnix_vec_remove_at");
 	}
 
-	ret = vec.ops->remove_at(&vec, vec.attr.cur_size / 2);
+	ret = _gnix_vec_remove_at(&vec, vec.attr.cur_size / 2);
 	cr_assert_eq(ret, -FI_ECANCELED);
 }
 
@@ -263,7 +247,7 @@ void do_first()
 	int ret;
 	void *tmp;
 
-	ret = vec.ops->first(&vec, &tmp);
+	ret = _gnix_vec_first(&vec, &tmp);
 	cr_assert(tmp, "_gnix_vec_first");
 	cr_assert(!ret, "_gnix_vec_first");
 
@@ -271,7 +255,7 @@ void do_first()
 
 	do_remove_first();
 
-	ret = vec.ops->first(&vec, &tmp);
+	ret = _gnix_vec_first(&vec, &tmp);
 	cr_assert_eq(tmp, NULL);
 	cr_assert_eq(ret, -FI_ECANCELED);
 }
@@ -281,7 +265,7 @@ void do_last()
 	int ret;
 	void *tmp;
 
-	ret = vec.ops->last(&vec, &tmp);
+	ret = _gnix_vec_last(&vec, &tmp);
 	cr_assert(tmp, "_gnix_vec_last");
 	cr_assert(!ret, "_gnix_vec_last");
 
@@ -289,7 +273,7 @@ void do_last()
 
 	do_remove_last();
 
-	ret = vec.ops->last(&vec, &tmp);
+	ret = _gnix_vec_last(&vec, &tmp);
 	cr_assert_eq(tmp, NULL);
 	cr_assert_eq(ret, -FI_ECANCELED);
 }
@@ -300,24 +284,39 @@ void do_at()
 	void *tmp;
 
 	for (i = 0; i < vec.attr.cur_size; i++) {
-		ret = vec.ops->at(&vec, &tmp, i);
+		ret = _gnix_vec_at(&vec, &tmp, i);
 		cr_assert(!ret, "_gnix_vec_at");
 
 		cr_assert(!!tmp, "_gnix_vec_at");
 		tmp = NULL;
 	}
+
+	ret = _gnix_vec_at(&vec, &tmp, i);
+	cr_assert(!tmp, "_gnix_vec_at");
+	cr_assert(ret == -FI_EINVAL, "_gnix_vec_at");
 }
 
-void do_tests()
+void do_iterator_next()
 {
-	do_insert_first();
-	do_first();
-
-	do_insert_last();
-	do_last();
+	int ret;
+	void *tmp1, *tmp2;
+	GNIX_VECTOR_ITERATOR(&vec, iter);
 
 	do_fill_insert_at();
-	do_at();
+
+	while (GNIX_VECTOR_ITERATOR_IDX(iter) < vec.attr.cur_size) {
+		tmp1 = _gnix_vec_iterator_next(&iter);
+
+		ret = _gnix_vec_at(&vec, &tmp2, GNIX_VECTOR_ITERATOR_IDX(iter) - 1);
+		cr_assert(!ret, "_gnix_vec_at");
+
+		cr_assert_eq(tmp1, tmp2);
+	}
+
+	tmp1 = _gnix_vec_iterator_next(&iter);
+	cr_assert(tmp1 == NULL, "_gnix_vec_iterator_next");
+	cr_assert_eq(GNIX_VECTOR_ITERATOR_IDX(iter), vec.attr.cur_size);
+
 	do_unfill_remove_at();
 }
 
@@ -343,6 +342,11 @@ Test(vector_lockless, do_at)
 	do_unfill_remove_at();
 }
 
+Test(vector_lockless, do_iterator_next)
+{
+	do_iterator_next();
+}
+
 TestSuite(vector_locked, .init = vector_setup_locked,
 	  .fini = vector_teardown, .disabled = false);
 
@@ -365,10 +369,16 @@ Test(vector_locked, do_at)
 	do_unfill_remove_at();
 }
 
+Test(vector_locked, do_iterator_next)
+{
+	/* TODO: Multithreaded test */
+	do_iterator_next();
+}
+
 TestSuite(vector_error_lockless, .init = vector_setup_error,
-	  .fini = vector_teardown, .disabled = false);
+	  .fini = vector_teardown_error, .disabled = false);
 
 Test(vector_error_lockless, setup_teardown_error)
 {
-
+	do_invalid_ops_params();
 }


### PR DESCRIPTION
- Updated vector tests to check for lookups at an index of the
  current vector size.
- Updated vector tests to test the vec iterator.
- Corrected the vector iterator code to properly update the cursor.
- Expanded the critical section of the iterator code.
- Added a warning to the resize operation to warn the user when they
  are shrinking the vector.
- Moved parameter checking for variables within the vec structure inside
  the critical section.

These changes passed gnitest and cray-tests:rdm_mbw_mr running on two nodes.

Fixes #823 
@ztiffany @jswaro @sungeunchoi 
