### PR TITLE
Extend modifications for running in CCM mode to the rest of the ALPS calls

### DIFF
--- a/prov/gni/include/gnix_util.h
+++ b/prov/gni/include/gnix_util.h
@@ -227,7 +227,7 @@ int _gnix_job_disable_unassigned_cpus(void);
 int _gnix_job_enable_affinity_apply(void);
 int _gnix_job_disable_affinity_apply(void);
 
-void _gnix_alps_cleanup(void);
+void _gnix_app_cleanup(void);
 int _gnix_job_fma_limit(uint32_t dev_id, uint8_t ptag, uint32_t *limit);
 int _gnix_job_cq_limit(uint32_t dev_id, uint8_t ptag, uint32_t *limit);
 int _gnix_pes_on_node(uint32_t *num_pes);

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -106,7 +106,7 @@ static void __fabric_destruct(void *obj)
 	 */
 	(void) _gnix_notifier_close(&fab->mr_notifier);
 
-	_gnix_alps_cleanup();
+	_gnix_app_cleanup();
 
 	free(fab);
 }

--- a/prov/gni/test/utils.c
+++ b/prov/gni/test/utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -86,7 +86,7 @@ Test(utils, alps)
 	uint32_t cookie, fmas, cqs, npes, npr;
 	void *addr = NULL;
 
-	_gnix_alps_cleanup();
+	_gnix_app_cleanup();
 
 	rc = gnixu_get_rdma_credentials(addr, &ptag, &cookie);
 	cr_expect(!rc);
@@ -106,7 +106,7 @@ Test(utils, alps)
 	cqs /= GNIX_CQS_PER_EP;
 	cr_expect(((fmas > cqs ? cqs : fmas) / npes) == npr);
 
-	_gnix_alps_cleanup();
+	_gnix_app_cleanup();
 }
 
 static void test_destruct(void *obj)


### PR DESCRIPTION
- Wrap all such calls in a more generally named function (_gnix_app_XXX)
- Use the CCM nodelist file to determine PEs per node
- Update test to use new filename

TODOs:
- Add option for specifying nodefile name (general cluster
  compatibility)
- Better default for when jobid environment variable is not defined or
  nodefile is not found

@tonyzinger @jshimek @hppritcha 

Fixes #888 

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com
