### PR TITLE
prov/gni: Fix bug in __gnix_ep_fini_vc.

### DIFF
--- a/prov/gni/include/gnix_vector.h
+++ b/prov/gni/include/gnix_vector.h
@@ -95,6 +95,8 @@ struct gnix_vector_iter {
 		.vec = (_vec),			\
 		.cur_idx = 0,			\
 	}
+
+/* Returns the current index of the iterator */
 #define GNIX_VECTOR_ITERATOR_IDX(_iter)	((_iter).cur_idx)
 
 /**
@@ -108,6 +110,9 @@ struct gnix_vector_iter {
  *
  * @var last		Return the last element of the vector.
  * @var at		Return the element at the specified index.
+ *
+ * @var iter_next	Return the element at the current index and move them
+ *			index to the next element.
  */
 typedef struct gnix_vector_ops {
 	int (*resize)(struct gnix_vector *, uint32_t);
@@ -401,10 +406,11 @@ static inline int _gnix_vec_insert_first(gnix_vector_t *vec,
 }
 
 /**
- * Return next element in the vector iterator
+ * Return the current element in the vector iterator and move
+ * the iterator to the next element.
  *
  * @param iter    pointer to the vector iterator
- * @return        pointer to next element in the vector
+ * @return        pointer to current element in the vector
  */
 static inline
 gnix_vec_entry_t *_gnix_vec_iterator_next(struct gnix_vector_iter *iter)

--- a/prov/gni/include/gnix_vector.h
+++ b/prov/gni/include/gnix_vector.h
@@ -97,7 +97,7 @@ struct gnix_vector_iter {
 	}
 
 /* Returns the current index of the iterator */
-#define GNIX_VECTOR_ITERATOR_IDX(_iter)	((_iter).cur_idx)
+#define GNIX_VECTOR_ITERATOR_IDX(_iter)	((_iter).cur_idx - 1)
 
 /**
  * Vector operations

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -361,7 +361,7 @@ static inline int __gnix_ep_fini_vc(struct gnix_fid_ep *ep)
 		while ((vc = (struct gnix_vc *)
 				_gnix_vec_iterator_next(&iter))) {
 			_gnix_vec_remove_at(ep->vc_table,
-					    GNIX_VECTOR_ITERATOR_IDX(iter));
+					    GNIX_VECTOR_ITERATOR_IDX(iter) - 1);
 			_gnix_vc_destroy(vc);
 		}
 

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -361,7 +361,7 @@ static inline int __gnix_ep_fini_vc(struct gnix_fid_ep *ep)
 		while ((vc = (struct gnix_vc *)
 				_gnix_vec_iterator_next(&iter))) {
 			_gnix_vec_remove_at(ep->vc_table,
-					    GNIX_VECTOR_ITERATOR_IDX(iter) - 1);
+					    GNIX_VECTOR_ITERATOR_IDX(iter));
 			_gnix_vc_destroy(vc);
 		}
 

--- a/prov/gni/test/vector.c
+++ b/prov/gni/test/vector.c
@@ -304,10 +304,10 @@ void do_iterator_next()
 
 	do_fill_insert_at();
 
-	while (GNIX_VECTOR_ITERATOR_IDX(iter) < vec.attr.cur_size) {
+	while (GNIX_VECTOR_ITERATOR_IDX(iter) + 1 < vec.attr.cur_size) {
 		tmp1 = _gnix_vec_iterator_next(&iter);
 
-		ret = _gnix_vec_at(&vec, &tmp2, GNIX_VECTOR_ITERATOR_IDX(iter) - 1);
+		ret = _gnix_vec_at(&vec, &tmp2, GNIX_VECTOR_ITERATOR_IDX(iter));
 		cr_assert(!ret, "_gnix_vec_at");
 
 		cr_assert_eq(tmp1, tmp2);
@@ -315,7 +315,7 @@ void do_iterator_next()
 
 	tmp1 = _gnix_vec_iterator_next(&iter);
 	cr_assert(tmp1 == NULL, "_gnix_vec_iterator_next");
-	cr_assert_eq(GNIX_VECTOR_ITERATOR_IDX(iter), vec.attr.cur_size);
+	cr_assert_eq(GNIX_VECTOR_ITERATOR_IDX(iter) + 1, vec.attr.cur_size);
 
 	do_unfill_remove_at();
 }


### PR DESCRIPTION
- The vector changes in #887 modified the iterator to move the current index forward after calling _gnix_vec_iter_next causing __gnix_ep_fini_vc to attempt removal of an out-of-bounds entry.
- Updated comments in gnix_vector.h to reflect the gnix_vector api changes.
- Updated __gnix_ep_fini_vc to remove elements at the correct index.

@sungeunchoi @ztiffany 
Fixes #893 
