### PR TITLE
prov/gni: Fix FI_PEEK path.

### DIFF
--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -119,14 +119,14 @@ static inline ssize_t __ep_recvv(struct fid_ep *ep, const struct iovec *iov,
 {
 	struct gnix_fid_ep *ep_priv;
 
-	if (!ep || !iov || !count || count > GNIX_MAX_IOV_LIMIT) {
+	if (!ep || !iov || count > GNIX_MAX_IOV_LIMIT) {
 		return -FI_EINVAL;
 	}
 
 	ep_priv = container_of(ep, struct gnix_fid_ep, ep_fid);
 	assert(GNIX_EP_RDM_DGM_MSG(ep_priv->type));
 
-	if (count == 1) {
+	if (count <= 1) {
 		return _gnix_recv(ep_priv, (uint64_t)iov[0].iov_base,
 				  iov[0].iov_len, desc ? desc[0] : NULL,
 				  src_addr, context,

--- a/prov/gni/test/rdm_sr.c
+++ b/prov/gni/test/rdm_sr.c
@@ -1074,7 +1074,10 @@ void do_recvv(int len)
 	uint64_t s[NUMEPS] = {0}, r[NUMEPS] = {0}, s_e[NUMEPS] = {0};
 	uint64_t r_e[NUMEPS] = {0};
 
-	sz = fi_recvv(ep[1], dest_iov, NULL, 0, gni_addr[0], iov_src_buf);
+	sz = fi_recvv(ep[1], NULL, NULL, IOV_CNT, gni_addr[0], iov_src_buf);
+	cr_assert_eq(sz, -FI_EINVAL);
+
+	sz = fi_recvv(ep[1], dest_iov, NULL, IOV_CNT + 1, gni_addr[0], iov_src_buf);
 	cr_assert_eq(sz, -FI_EINVAL);
 
 	for (iov_cnt = 1; iov_cnt <= IOV_CNT; iov_cnt++) {

--- a/prov/gni/test/rdm_tagged_sr.c
+++ b/prov/gni/test/rdm_tagged_sr.c
@@ -590,7 +590,11 @@ void do_trecvv(int len)
 	int source_done = 0, dest_done = 0;
 	struct fi_cq_tagged_entry s_cqe, d_cqe;
 
-	sz = fi_trecvv(ep[1], dest_iov, NULL, 0, gni_addr[0],
+	sz = fi_trecvv(ep[1], NULL, NULL, IOV_CNT, gni_addr[0],
+		       len * IOV_CNT, 0, iov_src_buf);
+	cr_assert_eq(sz, -FI_EINVAL);
+
+	sz = fi_trecvv(ep[1], dest_iov, NULL, IOV_CNT + 1, gni_addr[0],
 		       len * IOV_CNT, 0, iov_src_buf);
 	cr_assert_eq(sz, -FI_EINVAL);
 


### PR DESCRIPTION
```
  The fi_rdm_tagged_peek test in fabtests was
  failing due to -FI_EINVAL being returned by
  __ep_recvv when the iov count was 0.

  - This commit fixes the error checking in
  __ep_recvv.
```

The fi_rdm_tagged_peek test is now passing at https://github.com/ofiwg/fabtests/commit/ca04ee7d23b44b9c0d39ef45371f8f5d4c57dec3 but we are seeing the `fi_rdm_tagged_peek`  and `fi_dgram` tests killed by SIGTERM at https://github.com/ofiwg/fabtests/commit/add202efdd48bb10146453b337b91e078b98a76d.

Fixes #900, #896.
@sungeunchoi @hppritcha @ztiffany 
