### PR TITLE
prov/gni: Fix gnix writemsg error checking.

### DIFF
--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -609,7 +609,7 @@ DIRECT_FN STATIC ssize_t gnix_ep_writemsg(struct fid_ep *ep, const struct fi_msg
 {
 	struct gnix_fid_ep *gnix_ep;
 
-	if (!ep || !msg || !msg->msg_iov || !msg->rma_iov || !msg->desc ||
+	if (!ep || !msg || !msg->msg_iov || !msg->rma_iov ||
 	    msg->iov_count != 1 || msg->rma_iov_count != 1 ||
 	    msg->rma_iov[0].len > msg->msg_iov[0].iov_len) {
 		return -FI_EINVAL;
@@ -622,7 +622,7 @@ DIRECT_FN STATIC ssize_t gnix_ep_writemsg(struct fid_ep *ep, const struct fi_msg
 
 	return _gnix_rma(gnix_ep, GNIX_FAB_RQ_RDMA_WRITE,
 			 (uint64_t)msg->msg_iov[0].iov_base,
-			 msg->msg_iov[0].iov_len, msg->desc[0],
+			 msg->msg_iov[0].iov_len, msg->desc ? msg->desc[0] : NULL,
 			 msg->addr, msg->rma_iov[0].addr, msg->rma_iov[0].key,
 			 msg->context, flags, msg->data);
 }


### PR DESCRIPTION
- Ensure that a null memory descriptor doesn't
    trigger the parameter checks.  If the descriptor
    is null, let the gni provider register the memory
    and record that it did so by setting the FI_LOCAL_MR
    bit in the request's send/recv flags.

@hppritcha 
Fixes #906 
