### PR TITLE
prov/gni: Adds four byte alignment for sendv/recvv

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -118,7 +118,6 @@ extern "C" {
 #define compiler_barrier() asm volatile ("" ::: "memory")
 #endif
 
-
 #define GNIX_MAX_IOV_LIMIT 8
 
 /*
@@ -127,6 +126,17 @@ extern "C" {
 
 #define GNI_READ_ALIGN		4
 #define GNI_READ_ALIGN_MASK	(GNI_READ_ALIGN - 1)
+
+/*
+ * GNI IOV GET alignment
+ *
+ * We always pull 4byte chucks for unaligned GETs. To prevent stomping on
+ * someone else's head or tail data, each segment must be four bytes
+ * (i.e. GNI_READ_ALIGN bytes).
+ *
+ * Note: "* 2" for head and tail
+ */
+#define GNIX_HTD_BUF_SZ GNIX_MAX_IOV_LIMIT * GNI_READ_ALIGN * 2
 
 /*
  * Flags
@@ -387,6 +397,22 @@ struct gnix_fid_ep_ops_en {
 	uint32_t atomic_write_allowed: 1;
 };
 
+#define GNIX_HTD_POOL_SIZE 128
+
+struct gnix_htd_buf {
+	struct slist_entry e;
+	uint8_t *buf;
+};
+
+struct gnix_htd_pool {
+	bool enabled;
+	fastlock_t lock;
+	struct gnix_fid_mem_desc *md;
+	struct slist sl;
+	void *buf_ptr;
+	void *sl_ptr;
+};
+
 /*
  *   gnix endpoint structure
  *
@@ -445,6 +471,7 @@ struct gnix_fid_ep {
 	int min_multi_recv;
 	/* note this free list will be initialized for thread safe */
 	struct gnix_freelist fr_freelist;
+	struct gnix_htd_pool htd_pool;
 	struct gnix_reference ref_cnt;
 	struct gnix_fid_ep_ops_en ep_ops;
 };
@@ -532,55 +559,46 @@ struct gnix_fab_req_rma {
 	gni_return_t             status;
 };
 
-/**
- * sendv/recvv variable notes.
- *
- * @var send_addr	   For sendv rndzv this is the iov addr.
- * @var send_len	   For sendv this is the cumulative length of the iov
- * entries.
- * @var smsg_iov_hdr_addr  A ptr to the smsg iov hdr address so it can be freed
- * @var send_iov	   For sendv, rndzv, on the remote side, this is a ptr to
- * the addrs and lengths of the sender's iovec entries.
- * @var recv_addr	   For recvv this is the iov addr on the remote side.
- * @var recv_len	   For recvv this is the cumulative length of the iov
- * entries.
- * @var send_iov_md	   The sender's memory descriptors.
- * @var recv_iov_md	   The receiver's memory descriptors.
- * @var rma_iov_mdh	   The sender's gni mem handles on the receivers request.
- * @var multi_recv_iov_idx The previous index into the receive buffer for a
- * subsequent send on a multi_recv req.
- * @var multi_recv_iov_ptr The previous ptr into the recv buffer for a
- * subsequent send on a multi_recv req.
- * @var multi_recv_iov_len The remaining cumulative length of the recv buffer.
- */
 struct gnix_fab_req_msg {
 	struct gnix_tag_list_element tle;
+
 	struct send_info_t {
 		uint64_t	 send_addr;
 		size_t		 send_len;
 		gni_mem_handle_t mem_hndl;
+		uint32_t	 head;
+		uint32_t	 tail;
 	}			     send_info[GNIX_MAX_IOV_LIMIT];
 	struct gnix_fid_mem_desc     *send_md[GNIX_MAX_IOV_LIMIT];
 	size_t                       send_iov_cnt;
 	uint64_t                     send_flags;
 	size_t			     cum_send_len;
+
 	struct recv_info_t {
 		uint64_t	 recv_addr;
 		size_t		 recv_len;
 		gni_mem_handle_t mem_hndl;
+		uint32_t	 tail_len : 2; /* If the send len is > the recv_len, we
+						* need to fetch the unaligned tail into
+						* the txd's int buf
+						*/
+		uint32_t	 head_len : 2;
 	}			     recv_info[GNIX_MAX_IOV_LIMIT];
 	struct gnix_fid_mem_desc     *recv_md[GNIX_MAX_IOV_LIMIT];
 	size_t			     recv_iov_cnt;
 	uint64_t                     recv_flags; /* protocol, API info */
 	size_t			     cum_recv_len;
+
+	/* @var htd_buf->buf "head(H) tail(T) data buf" layout: '[T|T|...|H|H]' */
+	struct slist_entry	     *htd_buf_e;
+	uint8_t			     *htd_buf;
+	gni_mem_handle_t	     htd_mdh;
+
 	uint64_t                     tag;
 	uint64_t                     ignore;
 	uint64_t                     imm;
 	gni_mem_handle_t             rma_mdh;
 	uint64_t                     rma_id;
-	/* TODO: Move head&tail info send_info */
-	uint32_t                     rndzv_head;
-	uint32_t                     rndzv_tail;
 	atomic_t                     outstanding_txds;
 	gni_return_t                 status;
 };
@@ -822,6 +840,8 @@ struct gnix_fab_req {
 	struct gnix_vc            *vc;
 	int                       (*work_fn)(void *);
 	uint64_t                  flags;
+
+	/* TODO: change the size of this for unaligned data? */
 	struct gnix_tx_descriptor *iov_txds[GNIX_MAX_IOV_LIMIT];
 	uint32_t		  tx_failures;
 

--- a/prov/gni/include/gnix_ep.h
+++ b/prov/gni/include/gnix_ep.h
@@ -167,7 +167,7 @@ static inline void _gnix_ep_release_htd_buf(struct gnix_fid_ep *ep, struct slist
 	GNIX_DEBUG(FI_LOG_EP_DATA, "sl.head = %p, sl.tail = %p\n", ep->htd_pool.sl.head,
 		   ep->htd_pool.sl.tail);
 
-	slist_insert_tail(e, &ep->htd_pool.sl);
+	slist_insert_head(e, &ep->htd_pool.sl);
 
 	fastlock_release(&ep->htd_pool.lock);
 }

--- a/prov/gni/include/gnix_ep.h
+++ b/prov/gni/include/gnix_ep.h
@@ -142,6 +142,36 @@ typedef ssize_t (*trecvmsg_func_t)(struct fid_ep *ep,
  * inline functions
  */
 
+static inline struct slist_entry *_gnix_ep_get_htd_buf(struct gnix_fid_ep *ep)
+{
+	struct slist_entry *e;
+
+	fastlock_acquire(&ep->htd_pool.lock);
+
+	e = slist_remove_head(&ep->htd_pool.sl);
+
+	fastlock_release(&ep->htd_pool.lock);
+
+	return e;
+}
+
+static inline gni_mem_handle_t _gnix_ep_get_htd_mdh(struct gnix_fid_ep *ep)
+{
+	return ep->htd_pool.md->mem_hndl;
+}
+
+static inline void _gnix_ep_release_htd_buf(struct gnix_fid_ep *ep, struct slist_entry *e)
+{
+	fastlock_acquire(&ep->htd_pool.lock);
+
+	GNIX_DEBUG(FI_LOG_EP_DATA, "sl.head = %p, sl.tail = %p\n", ep->htd_pool.sl.head,
+		   ep->htd_pool.sl.tail);
+
+	slist_insert_tail(e, &ep->htd_pool.sl);
+
+	fastlock_release(&ep->htd_pool.lock);
+}
+
 static inline struct gnix_fab_req *
 _gnix_fr_alloc(struct gnix_fid_ep *ep)
 {
@@ -170,6 +200,13 @@ static inline void
 _gnix_fr_free(struct gnix_fid_ep *ep, struct gnix_fab_req *fr)
 {
 	assert(fr->gnix_ep == ep);
+
+	if (fr->msg.htd_buf_e != NULL) {
+		_gnix_ep_release_htd_buf(ep, fr->msg.htd_buf_e);
+		fr->msg.htd_buf_e = NULL;
+		fr->msg.htd_buf = NULL;
+	}
+
 	_gnix_fl_free(&fr->dlist, &ep->fr_freelist);
 	_gnix_ref_put(ep);
 }

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -50,6 +50,7 @@ extern "C" {
 #include "gnix_util.h"
 
 #define GNIX_DEF_MAX_NICS_PER_PTAG	4
+#define GNIX_MAX_IOV_LIMIT 8	/* this should have been pulled in from gnix.h.. */
 
 extern uint32_t gnix_max_nics_per_ptag;
 
@@ -267,7 +268,7 @@ struct gnix_smsg_rndzv_iov_start_hdr {
 	uint64_t imm;
 	uint64_t msg_tag;
 	uint64_t req_addr;
-	size_t iov_cnt;
+	size_t   iov_cnt;
 	uint64_t send_len;
 };
 
@@ -319,6 +320,8 @@ struct gnix_smsg_amo_cntr_hdr {
  *                       rma operations
  * @var gnix_smsg_amo_cntr_hdr embedded header for AMO remote counter events.
  * @var req              pointer to fab request associated with this descriptor
+ * @var send_info_idx	 the sender's iov index associated with this descriptor
+ * @var recv_info_idx	 the receiver's iov index associated with this descriptor
  * @var completer_fn     call back to invoke when associated GNI CQE's are
  *                       returned.
  * @var id               the id of this descriptor - the value returned

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -320,8 +320,6 @@ struct gnix_smsg_amo_cntr_hdr {
  *                       rma operations
  * @var gnix_smsg_amo_cntr_hdr embedded header for AMO remote counter events.
  * @var req              pointer to fab request associated with this descriptor
- * @var send_info_idx	 the sender's iov index associated with this descriptor
- * @var recv_info_idx	 the receiver's iov index associated with this descriptor
  * @var completer_fn     call back to invoke when associated GNI CQE's are
  *                       returned.
  * @var id               the id of this descriptor - the value returned

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -1407,7 +1407,7 @@ static int __destruct_tag_storages(struct gnix_fid_ep *ep)
 
 static void __ep_destruct(void *obj)
 {
-	int __attribute__((unused)) ret, i;
+	int ret;
 	struct gnix_fid_domain *domain;
 	struct gnix_nic *nic;
 	struct gnix_fid_av *av;

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -64,19 +64,105 @@
 #define GNIX_FAB_REQ_FL_MIN_SIZE 100
 #define GNIX_FAB_REQ_FL_REFILL_SIZE 10
 
+void _gnix_ep_htd_pool_init(struct gnix_fid_ep *ep)
+{
+	int ret, i;
+	struct fid_mr *auto_mr = NULL;
+	uint8_t *htd_bufs;
+	struct gnix_htd_buf *htd_buf_list;
+
+	assert(ep);
+
+	htd_bufs = malloc(GNIX_HTD_POOL_SIZE * GNIX_HTD_BUF_SZ);
+	if (htd_bufs == NULL) {
+		GNIX_FATAL(FI_LOG_EP_DATA, "\n");
+	}
+
+	htd_buf_list = malloc(GNIX_HTD_POOL_SIZE * sizeof(struct gnix_htd_buf));
+	if (htd_buf_list == NULL) {
+		GNIX_FATAL(FI_LOG_EP_DATA, "\n");
+	}
+
+	ep->htd_pool.buf_ptr = (void *) htd_bufs;
+	ep->htd_pool.sl_ptr = (void *) htd_buf_list;
+
+	ret = gnix_mr_reg(&ep->domain->domain_fid.fid, htd_bufs,
+	      		  GNIX_HTD_BUF_SZ * GNIX_HTD_POOL_SIZE,
+			  FI_READ | FI_WRITE, 0, 0, 0, &auto_mr, NULL);
+
+	if (unlikely(ret != FI_SUCCESS)) {
+		GNIX_DEBUG(FI_LOG_EP_DATA, "gnix_mr_req returned: %s\n",
+			   fi_strerror(-ret));
+	} else {
+		ep->htd_pool.md = container_of(auto_mr, struct gnix_fid_mem_desc, mr_fid);
+	}
+
+	slist_init(&ep->htd_pool.sl);
+
+	for (i = 0; i < GNIX_HTD_POOL_SIZE; i++) {
+		GNIX_DEBUG(FI_LOG_EP_DATA, "htd_bufs + (%d * GNIX_HTD_BUF_SZ) = %p\n",
+			   i, htd_bufs + (i * GNIX_HTD_BUF_SZ));
+		htd_buf_list[i].buf = htd_bufs + (i * GNIX_HTD_BUF_SZ);
+		slist_insert_tail(&htd_buf_list[i].e, &ep->htd_pool.sl);
+	}
+
+	fastlock_init(&ep->htd_pool.lock);
+
+	ep->htd_pool.enabled = true;
+}
+
+void _gnix_ep_htd_pool_fini(struct gnix_fid_ep *ep)
+{
+	int ret;
+
+	assert(ep);
+
+	if (ep->htd_pool.enabled == false)
+		return;
+
+	ret = fi_close(&ep->htd_pool.md->mr_fid.fid);
+
+	if (ret != FI_SUCCESS) {
+		GNIX_DEBUG(FI_LOG_EP_DATA, "fi_close returned: %s\n", fi_strerror(-ret));
+	}
+
+	if (ep->htd_pool.buf_ptr != NULL) {
+		free(ep->htd_pool.buf_ptr);
+		ep->htd_pool.buf_ptr = NULL;
+	}
+
+	if (ep->htd_pool.sl_ptr != NULL) {
+		free(ep->htd_pool.sl_ptr);
+		ep->htd_pool.sl_ptr = NULL;
+	}
+
+	ep->htd_pool.enabled = false;
+}
+
 static int __fr_freelist_init(struct gnix_fid_ep *ep)
 {
+	int ret;
+
 	assert(ep);
-	return _gnix_fl_init_ts(sizeof(struct gnix_fab_req),
-				offsetof(struct gnix_fab_req, dlist),
-				GNIX_FAB_REQ_FL_MIN_SIZE,
-				GNIX_FAB_REQ_FL_REFILL_SIZE,
-				0, 0, &ep->fr_freelist);
+	ret = _gnix_fl_init_ts(sizeof(struct gnix_fab_req),
+			       offsetof(struct gnix_fab_req, dlist),
+			       GNIX_FAB_REQ_FL_MIN_SIZE,
+			       GNIX_FAB_REQ_FL_REFILL_SIZE,
+			       0, 0, &ep->fr_freelist);
+
+	if (ret != FI_SUCCESS) {
+		GNIX_DEBUG(FI_LOG_EP_DATA, "_gnix_fl_init_ts returned: %s\n",
+			   fi_strerror(-ret));
+		return ret;
+	}
+
+	return ret;
 }
 
 static void __fr_freelist_destroy(struct gnix_fid_ep *ep)
 {
 	assert(ep);
+
 	_gnix_fl_destroy(&ep->fr_freelist);
 }
 
@@ -1280,6 +1366,8 @@ DIRECT_FN STATIC int gnix_ep_control(fid_t fid, int command, void *arg)
 			if (ep->recv_cq)
 				ep->rx_enabled = true;
 		}
+
+		_gnix_ep_htd_pool_init(ep);
 		break;
 
 	case FI_GETOPSFLAG:
@@ -1319,7 +1407,7 @@ static int __destruct_tag_storages(struct gnix_fid_ep *ep)
 
 static void __ep_destruct(void *obj)
 {
-	int __attribute__((unused)) ret;
+	int __attribute__((unused)) ret, i;
 	struct gnix_fid_domain *domain;
 	struct gnix_nic *nic;
 	struct gnix_fid_av *av;
@@ -1431,6 +1519,7 @@ static void __ep_destruct(void *obj)
 	 */
 
 	__fr_freelist_destroy(ep);
+	_gnix_ep_htd_pool_fini(ep);
 
 	free(ep);
 }

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -55,6 +55,70 @@
 /*******************************************************************************
  * helper functions
  ******************************************************************************/
+/**
+ * This function return the receiver's address given that we are at offset cur_len
+ * within the send_iov.
+ *
+ * @param req     the fabric request
+ * @param cur_len the current offset at which we found an unaligned head or tail
+ * within the sender's iov entries.
+ */
+static inline uint8_t *__gnix_msg_iov_unaligned_recv_addr(struct gnix_fab_req *req,
+							  size_t cur_len)
+{
+	int i;
+
+	/* Find the recv_address for the given head data */
+	for (i = 0; i < req->msg.recv_iov_cnt; i++) {
+		if ((int64_t) cur_len - (int64_t) req->msg.recv_info[i].recv_len < 0) {
+			return (uint8_t *) (req->msg.recv_info[i].recv_addr + cur_len);
+		} else {
+			cur_len -= req->msg.recv_info[i].recv_len;
+		}
+	}
+
+	return NULL;
+}
+
+static inline void __gnix_msg_send_alignment(struct gnix_fab_req *req)
+{
+	int i;
+
+	/* Ensure all head and tail fields are initialized properly */
+	for (i = 0; i < req->msg.send_iov_cnt; i++) {
+		/* Check head for four byte alignment, if not aligned store
+		 * the unaligned bytes (<=3) in head */
+		if (req->msg.send_info[i].send_addr & GNI_READ_ALIGN_MASK) {
+			req->msg.send_info[i].head =
+				*(uint32_t *)(req->msg.send_info[i].send_addr &
+					      ~GNI_READ_ALIGN_MASK);
+
+			GNIX_INFO(FI_LOG_EP_DATA,
+				  "Sending %d unaligned head bytes (%x)\n",
+				  GNI_READ_ALIGN -
+				  (req->msg.send_info[i].send_addr &
+				   GNI_READ_ALIGN_MASK),
+				  req->msg.send_info[i].head);
+		}
+
+		/* Check tail for four byte alignment. */
+		if ((req->msg.send_info[i].send_addr +
+		     req->msg.send_info[i].send_len) &
+		    GNI_READ_ALIGN_MASK) {
+			req->msg.send_info[i].tail =
+				*(uint32_t *)((req->msg.send_info[i].send_addr +
+					       req->msg.send_info[i].send_len) &
+					      ~GNI_READ_ALIGN_MASK);
+
+			GNIX_INFO(FI_LOG_EP_DATA,
+				  "Sending %d unaligned tail bytes (%x)\n",
+				  (req->msg.send_info[i].send_addr +
+				   req->msg.send_info[i].send_len) &
+				  GNI_READ_ALIGN_MASK,
+				  req->msg.send_info[i].tail);
+		}
+	}
+}
 static inline void __gnix_msg_free_rma_txd(struct gnix_fab_req *req,
 					   struct gnix_tx_descriptor *txd)
 {
@@ -437,10 +501,10 @@ static void __gnix_msg_copy_unaligned_get_data(struct gnix_fab_req *req)
 	head_off = req->msg.send_info[0].send_addr & GNI_READ_ALIGN_MASK;
 	head_len = head_off ? GNI_READ_ALIGN - head_off : 0;
 	tail_len = (req->msg.send_info[0].send_addr + req->msg.send_info[0].send_len) &
-			GNI_READ_ALIGN_MASK;
+		GNI_READ_ALIGN_MASK;
 
 	if (head_off) {
-		addr = (uint8_t *)&req->msg.rndzv_head + head_off;
+		addr = (uint8_t *)&req->msg.send_info[0].head + head_off;
 
 		GNIX_INFO(FI_LOG_EP_DATA,
 			  "writing %d bytes to head (%p, %hxx)\n",
@@ -456,8 +520,107 @@ static void __gnix_msg_copy_unaligned_get_data(struct gnix_fab_req *req)
 
 		GNIX_INFO(FI_LOG_EP_DATA,
 			  "writing %d bytes to tail (%p, %hxx)\n",
-			  tail_len, addr, req->msg.rndzv_tail);
-		memcpy((void *)addr, &req->msg.rndzv_tail, tail_len);
+			  tail_len, addr, req->msg.send_info[0].tail);
+		memcpy((void *)addr, &req->msg.send_info[0].tail, tail_len);
+	}
+}
+
+static inline void __gnix_msg_iov_cpy_unaligned_head_tail_data(struct gnix_fab_req *req)
+{
+	int i, head_off, head_len, tail_len;
+	void *addr, *recv_addr;
+	size_t cur_len = 0;
+
+#if ENABLE_DEBUG
+	for (i = 0; i < req->msg.send_iov_cnt; i++) {
+		GNIX_DEBUG(FI_LOG_EP_DATA, "req->msg.send_info[%d].head = 0x%x\n"
+			   "req->msg.send_info[%d].tail = 0x%x\n", i,
+			   req->msg.send_info[i].head, i, req->msg.send_info[i].tail);
+	}
+#endif
+
+	/* Copy out the original head/tail data sent across in the control message */
+	for (i = 0; i < req->msg.send_iov_cnt; i++) {
+		head_off = req->msg.send_info[i].send_addr & GNI_READ_ALIGN_MASK;
+		head_len = head_off ? GNI_READ_ALIGN - head_off : 0;
+
+		if (head_off) {
+			recv_addr = __gnix_msg_iov_unaligned_recv_addr(req, cur_len);
+
+			if (recv_addr) {
+				addr = (uint8_t *)&req->msg.send_info[i].head + head_off;
+
+				GNIX_INFO(FI_LOG_EP_DATA,
+					  "writing %d bytes to head (%p, 0x%x) for i = %d\n",
+					  head_len, recv_addr,
+					  *(uint32_t *)addr, i);
+				memcpy(recv_addr, addr, head_len);
+			}
+		}
+
+		tail_len = (req->msg.send_info[i].send_addr + req->msg.send_info[i].send_len) &
+			GNI_READ_ALIGN_MASK;
+
+		if (tail_len) {
+			recv_addr = __gnix_msg_iov_unaligned_recv_addr(req,
+								       cur_len +
+								       req->msg.send_info[i].send_len - tail_len);
+
+			if (recv_addr) {
+				GNIX_INFO(FI_LOG_EP_DATA,
+					  "writing %d bytes to tail (%p, 0x%x)\n",
+					  tail_len, recv_addr, req->msg.send_info[i].tail);
+				memcpy((void *)recv_addr, &req->msg.send_info[i].tail, tail_len);
+			}
+		}
+
+		cur_len += req->msg.send_info[i].send_len;
+	}
+
+#if ENABLE_DEBUG
+	for (i = 0; i < req->msg.recv_iov_cnt; i++) {
+		GNIX_DEBUG(FI_LOG_EP_DATA, "req->msg.recv_info[%d].tail_len = %d\n"
+			   "req->msg.recv_info[%d].head_len = %d\n",
+			   i, req->msg.recv_info[i].tail_len,
+			   i, req->msg.recv_info[i].head_len);
+	}
+#endif
+
+	/* Copy out the "middle" head and tail data found when building the iov request */
+	for (i = 0; i < req->msg.recv_iov_cnt; i++) {
+		if (req->msg.recv_info[i].tail_len) {
+			addr = (void *) ((uint8_t *) req->msg.htd_buf + (GNI_READ_ALIGN * i));
+
+			recv_addr = (void *) (req->msg.recv_info[i].recv_addr +
+					      req->msg.recv_info[i].recv_len -
+					      req->msg.recv_info[i].tail_len);
+
+			GNIX_INFO(FI_LOG_EP_DATA,
+				  "writing %d bytes to mid-tail (%p, 0x%x)\n",
+				  req->msg.recv_info[i].tail_len,
+				  recv_addr, *(uint32_t *)addr);
+
+			memcpy(recv_addr, addr, req->msg.recv_info[i].tail_len);
+		}
+
+		if (req->msg.recv_info[i].head_len) {
+			/* Since we move the remote addr backwards to a four
+			 * byte address and read four bytes, ensure that
+			 * what we read from the htd_buf is just the actual head
+			 * data we are interested in.
+			 */
+			addr = (void *) ((uint8_t *) req->msg.htd_buf +
+					 (GNI_READ_ALIGN * (i + GNIX_MAX_IOV_LIMIT)) +
+					 GNI_READ_ALIGN - req->msg.recv_info[i].head_len);
+			recv_addr = (void *) req->msg.recv_info[i].recv_addr;
+
+			GNIX_INFO(FI_LOG_EP_DATA,
+				  "writing %d bytes to mid-head (%p, 0x%x)\n",
+				  req->msg.recv_info[i].head_len,
+				  recv_addr, *(uint32_t *)addr);
+
+			memcpy(recv_addr, addr, req->msg.recv_info[i].head_len);
+		}
 	}
 }
 
@@ -474,7 +637,7 @@ static int __gnix_rndzv_req_complete(void *arg, gni_return_t tx_status)
 		 * unaligned bytes.  Bytes are copied from the request to the
 		 * user buffer once both TXDs arrive. */
 		if (txd->gni_desc.type == GNI_POST_FMA_GET)
-			req->msg.rndzv_tail = *(uint32_t *)txd->int_buf;
+			req->msg.send_info[0].tail = *(uint32_t *)txd->int_buf;
 
 		/* Remember any failure.  Retransmit both TXDs once both are
 		 * complete. */
@@ -548,9 +711,15 @@ static int __gnix_rndzv_iov_req_complete(void *arg, gni_return_t tx_status)
 		   atomic_get(&req->msg.outstanding_txds));
 
 	req->msg.status |= tx_status;
+
 	__gnix_msg_free_rma_txd(req, txd);
 
 	if (atomic_dec(&req->msg.outstanding_txds) == 0) {
+
+		/* All the txd's are complete, we just need our unaligned heads
+		 * and tails now
+		 */
+		__gnix_msg_iov_cpy_unaligned_head_tail_data(req);
 		GNIX_DEBUG(FI_LOG_EP_DATA, "req->msg.recv_flags == FI_LOCAL_MR "
 			   "is %s, req->msg.recv_iov_cnt = %lu\n",
 			   req->msg.recv_flags & FI_LOCAL_MR ? "true" : "false",
@@ -582,6 +751,7 @@ static int __gnix_rndzv_iov_req_complete(void *arg, gni_return_t tx_status)
 				}
 			}
 		}
+
 		/* Generate remote CQE and send fin msg back to sender */
 		req->work_fn = __gnix_rndzv_req_send_fin;
 		return _gnix_vc_queue_work_req(req);
@@ -860,6 +1030,9 @@ static int __gnix_rndzv_iov_req_post(void *arg)
 
 	GNIX_TRACE(FI_LOG_EP_DATA, "\n");
 
+	if (unlikely(iov_txd_cnt == 0))
+		return -FI_EAGAIN;
+
 	COND_ACQUIRE(nic->requires_lock, &nic->lock);
 
 	for (i = 0, txd = req->iov_txds[0];
@@ -901,27 +1074,33 @@ static int __gnix_rndzv_iov_req_build(void *arg)
 	struct gnix_fid_ep *ep = req->gnix_ep;
 	struct gnix_nic *nic = ep->nic;
 	gni_ep_handle_t gni_ep = req->vc->gni_ep;
-	struct gnix_tx_descriptor *txd = NULL;
-	size_t recv_len, get_len, ct_size, send_cnt, recv_cnt, txd_cnt;
-	uint64_t recv_ptr = 0UL;
+	struct gnix_tx_descriptor *txd = NULL, *ct_txd = NULL;
+	size_t recv_len, send_len, get_len, send_cnt, recv_cnt, txd_cnt, ht_len;
+	uint64_t recv_ptr = 0UL, send_ptr = 0UL;
 	/* TODO: Should this be the sender's rndzv thresh instead? */
 	size_t rndzv_thresh = ep->domain->params.msg_rendezvous_thresh;
 	gni_ct_get_post_descriptor_t *cur_ct = NULL;
 	void **next_ct = NULL;
+	int head_off, head_len, tail_len;
 
 	GNIX_TRACE(FI_LOG_EP_DATA, "\n");
 	/*
 	 * TODO: xpmem intercept here
 	 */
 
-	if (req->vc->modes & GNIX_VC_MODE_XPMEM)
-		return  __gnix_rndzv_req_xpmem(req);
+	/* if (req->vc->modes & GNIX_VC_MODE_XPMEM) */
+	/* 	return  __gnix_rndzv_req_xpmem(req); */
 
-	txd_cnt = ct_size = 0;
+	txd_cnt = 0;
 	send_cnt = req->msg.send_iov_cnt;
+
 	recv_ptr = req->msg.recv_info[0].recv_addr;
 	recv_len = req->msg.recv_info[0].recv_len;
 	recv_cnt = req->msg.recv_iov_cnt;
+
+	send_ptr = req->msg.send_info[0].send_addr;
+	send_len = req->msg.send_info[0].send_len;
+
 	use_tx_cq_blk = (ep->domain->data_progress == FI_PROGRESS_AUTO);
 
 	GNIX_DEBUG(FI_LOG_EP_DATA, "send_cnt = %lu, recv_cnt = %lu\n",
@@ -972,11 +1151,231 @@ static int __gnix_rndzv_iov_req_build(void *arg)
 
 	/* Iterate through the buffers and build the Fma and Rdma requests! */
 	while (i < send_cnt) {
-		get_len = MIN(recv_len, req->msg.send_info[i].send_len);
+		get_len = MIN(recv_len, send_len);
+
+		/* Begin alignment checks
+		 *
+		 * Each "middle" head and tail (resulting from the send pointer
+		 * and length being adjusted to match the posted recv buf in
+		 * this loop) will be added to one or more chained transactions
+		 * below.
+		 *
+		 * The original heads and tails (sent across in the control
+		 * message) must be accounted for below in order to GET the
+		 * correct, now four byte aligned, "body" section of the
+		 * message.
+		 */
+		if (send_ptr & GNI_READ_ALIGN_MASK ||
+		    (send_ptr + get_len) & GNI_READ_ALIGN_MASK) {
+			if (req->msg.htd_buf_e == NULL) {
+				req->msg.htd_buf_e = _gnix_ep_get_htd_buf(ep);
+
+				/* There are no available htd bufs */
+				if (req->msg.htd_buf_e == NULL) {
+					atomic_set(&req->msg.outstanding_txds, 0);
+					req->work_fn = __gnix_rndzv_iov_req_post;
+					return _gnix_vc_queue_work_req(req);
+				}
+
+				req->msg.htd_buf = ((struct gnix_htd_buf *) req->msg.htd_buf_e)->buf;
+				req->msg.htd_mdh = _gnix_ep_get_htd_mdh(ep);
+				GNIX_DEBUG(FI_LOG_EP_DATA, "req->msg.htd_buf = %p\n", req->msg.htd_buf);
+			}
+
+			head_off = send_ptr & GNI_READ_ALIGN_MASK;
+			head_len = head_off ? GNI_READ_ALIGN - head_off : 0;
+			tail_len = (send_ptr + get_len) & GNI_READ_ALIGN_MASK;
+
+			ht_len = (size_t) (head_len + tail_len);
+
+			/* TODO: handle this. */
+			if (ht_len > recv_len) {
+				GNIX_FATAL(FI_LOG_EP_DATA, "The head tail data "
+					   "length exceeds the matching receive"
+					   "buffer length.\n");
+			}
+
+			/* found a mid-head? */
+			req->msg.recv_info[j].head_len = (send_ptr != req->msg.send_info[i].send_addr) ?
+				head_len : 0;
+
+			/* found a mid-tail? */
+			req->msg.recv_info[j].tail_len = (send_len > recv_len) ?
+				tail_len : 0;
+
+			/* Update the local and remote addresses */
+			get_len -= ht_len;
+			send_len -= ht_len;
+			recv_len -= ht_len;
+
+			send_ptr += head_len;
+			recv_ptr += head_len;
+
+			/* Add to existing ct */
+			if (ct_txd) {
+				if (req->msg.recv_info[j].tail_len) {
+					cur_ct = *next_ct = malloc(sizeof(gni_ct_get_post_descriptor_t));
+
+					if (cur_ct == NULL) {
+						GNIX_DEBUG(FI_LOG_EP_DATA,
+							   "Failed to allocate "
+							   "gni FMA get chained "
+							   "descriptor.");
+
+						/* +1 to ensure we free the
+						 * current chained txd */
+						__gnix_msg_free_iov_txds(req, txd_cnt + 1);
+						return -FI_ENOSPC;
+					}
+
+					cur_ct->ep_hndl = gni_ep;
+					cur_ct->remote_mem_hndl = req->msg.send_info[i].mem_hndl;
+					cur_ct->local_mem_hndl = req->msg.htd_mdh;
+					cur_ct->length = GNI_READ_ALIGN;
+					cur_ct->remote_addr = (send_ptr + get_len + tail_len) & ~GNI_READ_ALIGN_MASK;
+					cur_ct->local_addr = (uint64_t) (((uint8_t *) req->msg.htd_buf) + (GNI_READ_ALIGN * j));
+					next_ct = &cur_ct->next_descr;
+				}
+
+				if (req->msg.recv_info[j].head_len) {
+					cur_ct = *next_ct = malloc(sizeof(gni_ct_get_post_descriptor_t));
+
+					if (cur_ct == NULL) {
+						GNIX_DEBUG(FI_LOG_EP_DATA,
+							   "Failed to allocate "
+							   "gni FMA get chained "
+							   "descriptor.");
+
+						/* +1 to ensure we free the
+						 * current chained txd */
+						__gnix_msg_free_iov_txds(req, txd_cnt + 1);
+						return -FI_ENOSPC;
+					}
+
+					cur_ct->ep_hndl = gni_ep;
+					cur_ct->remote_mem_hndl = req->msg.send_info[i].mem_hndl;
+					cur_ct->local_mem_hndl = req->msg.htd_mdh;
+					cur_ct->length = GNI_READ_ALIGN;
+					cur_ct->remote_addr = send_ptr - GNI_READ_ALIGN;
+					cur_ct->local_addr = (uint64_t) (((uint8_t *) req->msg.htd_buf) + (GNI_READ_ALIGN * (j + GNIX_MAX_IOV_LIMIT)));
+					next_ct = &cur_ct->next_descr;
+				}
+			} else { 	/* Start a new ct */
+				if (req->msg.recv_info[j].tail_len) {
+					GNIX_DEBUG(FI_LOG_EP_DATA, "New FMA"
+						   " CT\n");
+					ret = _gnix_nic_tx_alloc(nic, &ct_txd);
+
+					if (ret != FI_SUCCESS) {
+						/* We'll try again. */
+						GNIX_INFO(FI_LOG_EP_DATA,
+							  "_gnix_nic_tx_alloc()"
+							  " returned %s\n",
+							  fi_strerror(-ret));
+
+						__gnix_msg_free_iov_txds(req, txd_cnt);
+						return -FI_ENOSPC;
+					}
+
+					ct_txd->completer_fn = __gnix_rndzv_iov_req_complete;
+					ct_txd->req = req;
+
+					ct_txd->gni_desc.type = GNI_POST_FMA_GET;
+					ct_txd->gni_desc.cq_mode = GNI_CQMODE_GLOBAL_EVENT;
+					ct_txd->gni_desc.dlvr_mode = GNI_DLVMODE_PERFORMANCE;
+					ct_txd->gni_desc.rdma_mode = 0;
+					ct_txd->gni_desc.src_cq_hndl = (use_tx_cq_blk) ? nic->tx_cq_blk : nic->tx_cq;
+
+					ct_txd->gni_desc.remote_addr = (send_ptr + get_len + tail_len) & ~GNI_READ_ALIGN_MASK;
+					ct_txd->gni_desc.remote_mem_hndl = req->msg.send_info[i].mem_hndl;
+
+					ct_txd->gni_desc.local_addr = (uint64_t) ((uint8_t *) req->msg.htd_buf + (GNI_READ_ALIGN * j));
+					ct_txd->gni_desc.local_mem_hndl = req->msg.htd_mdh;
+
+					ct_txd->gni_desc.length = GNI_READ_ALIGN;
+
+					next_ct = &ct_txd->gni_desc.next_descr;
+				}
+
+				if (req->msg.recv_info[j].head_len) {
+					if (req->msg.recv_info[j].tail_len) { /* Existing FMA CT */
+						cur_ct = *next_ct = malloc(sizeof(gni_ct_get_post_descriptor_t));
+						if (cur_ct == NULL) {
+							GNIX_DEBUG(FI_LOG_EP_DATA,
+								   "Failed to allocate "
+								   "gni FMA get chained "
+								   "descriptor.");
+
+							/* +1 to ensure we free the
+							 * current chained txd */
+							__gnix_msg_free_iov_txds(req, txd_cnt + 1);
+							return -FI_ENOSPC;
+						}
+
+						cur_ct->ep_hndl = gni_ep;
+						cur_ct->remote_mem_hndl = req->msg.send_info[i].mem_hndl;
+						cur_ct->local_mem_hndl = req->msg.htd_mdh;
+						cur_ct->length = GNI_READ_ALIGN;
+						cur_ct->remote_addr = send_ptr - GNI_READ_ALIGN;
+						cur_ct->local_addr = (uint64_t) (((uint8_t *) req->msg.htd_buf) + (GNI_READ_ALIGN * (j + GNIX_MAX_IOV_LIMIT)));
+						next_ct = &cur_ct->next_descr;
+					} else { /* New FMA ct */
+						GNIX_DEBUG(FI_LOG_EP_DATA, "New FMA"
+							   " CT\n");
+						ret = _gnix_nic_tx_alloc(nic, &ct_txd);
+
+						if (ret != FI_SUCCESS) {
+							/* We'll try again. */
+							GNIX_INFO(FI_LOG_EP_DATA,
+								  "_gnix_nic_tx_alloc()"
+								  " returned %s\n",
+								  fi_strerror(-ret));
+
+							__gnix_msg_free_iov_txds(req, txd_cnt);
+							return -FI_ENOSPC;
+						}
+
+						ct_txd->completer_fn = __gnix_rndzv_iov_req_complete;
+						ct_txd->req = req;
+
+						ct_txd->gni_desc.type = GNI_POST_FMA_GET;
+						ct_txd->gni_desc.cq_mode = GNI_CQMODE_GLOBAL_EVENT;
+						ct_txd->gni_desc.dlvr_mode = GNI_DLVMODE_PERFORMANCE;
+						ct_txd->gni_desc.rdma_mode = 0;
+						ct_txd->gni_desc.src_cq_hndl = (use_tx_cq_blk) ? nic->tx_cq_blk : nic->tx_cq;
+
+						ct_txd->gni_desc.remote_addr = send_ptr - GNI_READ_ALIGN;
+						ct_txd->gni_desc.remote_mem_hndl = req->msg.send_info[i].mem_hndl;
+
+						ct_txd->gni_desc.local_addr = (uint64_t) ((uint8_t *) req->msg.htd_buf + (GNI_READ_ALIGN * (j + GNIX_MAX_IOV_LIMIT)));
+						ct_txd->gni_desc.local_mem_hndl = req->msg.htd_mdh;
+
+						ct_txd->gni_desc.length = GNI_READ_ALIGN;
+
+						next_ct = &ct_txd->gni_desc.next_descr;
+					}
+				}
+			}
+		} else { 	/* no head/tail found */
+			head_len = tail_len = 0;
+			req->msg.recv_info[j].head_len = req->msg.recv_info[j].tail_len = 0;
+		}
+		/* End alignment checks */
 
 		GNIX_DEBUG(FI_LOG_EP_DATA, "send_info[%d].send_len = %lu,"
-			   " recv_len = %lu, get_len = %lu\n", i,
-			   req->msg.send_info[i].send_len, recv_len, get_len);
+			   " recv_len = %lu, get_len = %lu, head_len = %d,"
+			   " tail_len = %d, req->msg.recv_info[%d].tail_len = %u\n"
+			   "req->msg.recv_info[%d].head_len = %u, "
+			   "recv_ptr(head) = %p, recv_ptr(tail) = %p\n", i,
+			   send_len, recv_len, get_len, head_len, tail_len, j,
+			   req->msg.recv_info[j].tail_len, j,
+			   req->msg.recv_info[j].head_len, (void *) (recv_ptr - head_len),
+			   (void *) (recv_ptr + get_len));
+
+		GNIX_DEBUG(FI_LOG_EP_DATA, "txd = %p, send_ptr = %p, "
+			   "send_ptr + get_len = %p, recv_ptr = %p\n",
+			   txd, (void *) send_ptr, (void *)(send_ptr + get_len),
+			   recv_ptr);
 
 		if (get_len >= rndzv_thresh) { /* Build the rdma txd */
 			ret = _gnix_nic_tx_alloc(nic, &txd);
@@ -997,27 +1396,22 @@ static int __gnix_rndzv_iov_req_build(void *arg)
 			txd->gni_desc.type = GNI_POST_RDMA_GET;
 			txd->gni_desc.cq_mode = GNI_CQMODE_GLOBAL_EVENT;
 			txd->gni_desc.dlvr_mode = GNI_DLVMODE_PERFORMANCE;
-			txd->gni_desc.local_mem_hndl =
-				req->msg.recv_info[j].mem_hndl;
+			txd->gni_desc.local_mem_hndl = req->msg.recv_info[j].mem_hndl;
 			txd->gni_desc.remote_mem_hndl = req->msg.send_info[i].mem_hndl;
 			txd->gni_desc.rdma_mode = 0;
-			txd->gni_desc.src_cq_hndl = (use_tx_cq_blk) ?
-				nic->tx_cq_blk : nic->tx_cq;
+			txd->gni_desc.src_cq_hndl = (use_tx_cq_blk) ? nic->tx_cq_blk : nic->tx_cq;
 
-			/* TODO: handle alignment! */
-			txd->gni_desc.local_addr =
-				(uint64_t) recv_ptr;
-			txd->gni_desc.remote_addr =
-				req->msg.send_info[i].send_addr;
+			txd->gni_desc.local_addr = recv_ptr;
+			txd->gni_desc.remote_addr = send_ptr;
 			txd->gni_desc.length = get_len;
 
 			req->iov_txds[txd_cnt++] = txd;
 			txd = NULL;
-		} else {		       /* Build the Ct txd */
-			if (!txd) {
+		} else if (get_len) {		       /* Build the Ct txd */
+			if (!ct_txd) {
 				GNIX_DEBUG(FI_LOG_EP_DATA, "New FMA"
 					   " CT\n");
-				ret = _gnix_nic_tx_alloc(nic, &txd);
+				ret = _gnix_nic_tx_alloc(nic, &ct_txd);
 				if (ret != FI_SUCCESS) {
 					/* We'll try again. */
 					GNIX_INFO(FI_LOG_EP_DATA,
@@ -1029,25 +1423,23 @@ static int __gnix_rndzv_iov_req_build(void *arg)
 					return -FI_ENOSPC;
 				}
 
-				txd->completer_fn = __gnix_rndzv_iov_req_complete;
-				txd->req = req;
+				ct_txd->completer_fn = __gnix_rndzv_iov_req_complete;
+				ct_txd->req = req;
 
-				txd->gni_desc.type = GNI_POST_FMA_GET;
-				txd->gni_desc.cq_mode = GNI_CQMODE_GLOBAL_EVENT;
-				txd->gni_desc.dlvr_mode = GNI_DLVMODE_PERFORMANCE;
-				txd->gni_desc.local_mem_hndl = req->msg.recv_info[j].mem_hndl;
+				ct_txd->gni_desc.type = GNI_POST_FMA_GET;
+				ct_txd->gni_desc.cq_mode = GNI_CQMODE_GLOBAL_EVENT;
+				ct_txd->gni_desc.dlvr_mode = GNI_DLVMODE_PERFORMANCE;
+				ct_txd->gni_desc.local_mem_hndl = req->msg.recv_info[j]. mem_hndl;
 
-				txd->gni_desc.remote_mem_hndl = req->msg.send_info[i].mem_hndl;
-				txd->gni_desc.rdma_mode = 0;
-				txd->gni_desc.src_cq_hndl = (use_tx_cq_blk) ? nic->tx_cq_blk : nic->tx_cq;
+				ct_txd->gni_desc.remote_mem_hndl = req->msg.send_info[i].mem_hndl;
+				ct_txd->gni_desc.rdma_mode = 0;
+				ct_txd->gni_desc.src_cq_hndl = (use_tx_cq_blk) ? nic->tx_cq_blk : nic->tx_cq;
 
-				/* TODO: handle alignment! */
-				txd->gni_desc.local_addr = (uint64_t) recv_ptr;
-				txd->gni_desc.remote_addr = req->msg.send_info[i].send_addr;
-				txd->gni_desc.length = get_len;
-				ct_size += get_len;
+				ct_txd->gni_desc.local_addr = recv_ptr;
+				ct_txd->gni_desc.remote_addr = send_ptr;
+				ct_txd->gni_desc.length = get_len;
 
-				next_ct = &txd->gni_desc.next_descr;
+				next_ct = &ct_txd->gni_desc.next_descr;
 			} else {
 				cur_ct = *next_ct = malloc(sizeof(gni_ct_get_post_descriptor_t));
 
@@ -1065,8 +1457,7 @@ static int __gnix_rndzv_iov_req_build(void *arg)
 
 				cur_ct->ep_hndl = gni_ep;
 				cur_ct->length = get_len;
-				ct_size += get_len;
-				cur_ct->remote_addr = req->msg.send_info[i].send_addr;
+				cur_ct->remote_addr = send_ptr;
 				cur_ct->remote_mem_hndl = req->msg.send_info[i].mem_hndl;
 				cur_ct->local_addr = (uint64_t) recv_ptr;
 				cur_ct->local_mem_hndl = req->msg.recv_info[j].mem_hndl;
@@ -1075,7 +1466,7 @@ static int __gnix_rndzv_iov_req_build(void *arg)
 			}
 		}
 
-		/* Update the local and remote addresses */
+		/* Update the recv len */
 		recv_len -= get_len;
 
 		/* We have exhausted the current recv (and possibly send)
@@ -1091,15 +1482,19 @@ static int __gnix_rndzv_iov_req_build(void *arg)
 			recv_len = req->msg.recv_info[j].recv_len;
 
 			/* Also exhausted send buffer */
-			if (get_len == req->msg.send_info[i].send_len) {
+			if (get_len == send_len) {
 				i++;
+				send_ptr = req->msg.send_info[i].send_addr;
+				send_len = req->msg.send_info[i].send_len;
 			} else {
-				req->msg.send_info[i].send_addr += get_len;
-				req->msg.send_info[i].send_len -= get_len;
+				send_ptr += (get_len + tail_len);
+				send_len -= get_len;
 			}
 		} else {	/* Just exhausted current send buffer. */
 			i++;
-			recv_ptr += get_len;
+			send_ptr = req->msg.send_info[i].send_addr;
+			send_len = req->msg.send_info[i].send_len;
+			recv_ptr += (get_len + tail_len);
 		}
 		GNIX_DEBUG(FI_LOG_EP_DATA, "i = %d, j = %d\n", i, j);
 	}
@@ -1110,11 +1505,12 @@ static int __gnix_rndzv_iov_req_build(void *arg)
 	 * queue. Note that if the last txd built was a rdma txd then the txd
 	 * will have been queued and txd will have a NULL value.
 	 */
-	if (txd) {
+	if (ct_txd) {
 		*next_ct = NULL;
-		req->iov_txds[txd_cnt++] = txd;
+		req->iov_txds[txd_cnt++] = ct_txd;
 	}
 
+	GNIX_DEBUG(FI_LOG_EP_DATA, "txd_cnt = %lu\n", txd_cnt);
 	atomic_set(&req->msg.outstanding_txds, txd_cnt);
 
 	/* All the txd's are built, update the work_fn */
@@ -1506,15 +1902,15 @@ static int __smsg_rndzv_start(void *data, void *msg)
 		req->msg.send_info[0].send_len =
 			MIN(hdr->len, req->msg.cum_recv_len);
 		req->msg.send_info[0].mem_hndl = hdr->mdh;
-		req->msg.cum_send_len = req->msg.send_info[0].send_len;
+		req->msg.cum_send_len = MIN(req->msg.send_info[0].send_len, req->msg.cum_recv_len);
 		req->msg.send_iov_cnt = 1;
 		req->msg.send_flags = hdr->flags;
 		req->msg.tag = hdr->msg_tag;
 		req->msg.imm = hdr->imm;
 		req->msg.rma_mdh = hdr->mdh;
 		req->msg.rma_id = hdr->req_addr;
-		req->msg.rndzv_head = hdr->head;
-		req->msg.rndzv_tail = hdr->tail;
+		req->msg.send_info[0].head = hdr->head;
+		req->msg.send_info[0].tail = hdr->tail;
 
 		if (req->type == GNIX_FAB_RQ_RECV) {
 			/* fi_send is rndzv with recv */
@@ -1591,8 +1987,8 @@ static int __smsg_rndzv_start(void *data, void *msg)
 		req->msg.imm = hdr->imm;
 		req->msg.rma_mdh = hdr->mdh;
 		req->msg.rma_id = hdr->req_addr;
-		req->msg.rndzv_head = hdr->head;
-		req->msg.rndzv_tail = hdr->tail;
+		req->msg.send_info[0].head = hdr->head;
+		req->msg.send_info[0].tail = hdr->tail;
 		atomic_initialize(&req->msg.outstanding_txds, 0);
 
 		_gnix_insert_tag(unexp_queue, req->msg.tag, req, ~0);
@@ -1634,9 +2030,9 @@ static int __smsg_rndzv_iov_start(void *data, void *msg)
 	int i;
 
 	for (i = 0; i < hdr->iov_cnt; i++) {
-		GNIX_DEBUG(FI_LOG_EP_DATA, "base[%d] = %p, len[%d] = %lu\n", i,
-			   ((struct iovec *)data_ptr)[i].iov_base, i,
-			   ((struct iovec *)data_ptr)[i].iov_len);
+		GNIX_DEBUG(FI_LOG_EP_DATA, "send_addr[%d] = %p, send_len[%d] = %lu\n", i,
+			   ((struct send_info_t *)data_ptr)[i].send_addr, i,
+			   ((struct send_info_t *)data_ptr)[i].send_len);
 	}
 #endif
 	ep = vc->ep;
@@ -1653,6 +2049,7 @@ static int __smsg_rndzv_iov_start(void *data, void *msg)
 	if (req) {		/* Found a request in the posted queue */
 		is_req_posted = 1;
 		req->tx_failures = 0;
+		req->msg.cum_send_len = MIN(hdr->send_len, req->msg.cum_recv_len);
 
 		GNIX_INFO(FI_LOG_EP_DATA, "Matched req: %p (%p, %u)\n",
 			  req, req->msg.recv_info[0].recv_addr, hdr->send_len);
@@ -1668,6 +2065,8 @@ static int __smsg_rndzv_iov_start(void *data, void *msg)
 
 		GNIX_INFO(FI_LOG_EP_DATA, "New req: %p (%u)\n",
 			  req, hdr->send_len);
+
+		req->msg.cum_send_len = hdr->send_len;
 	}
 
 	req->addr = vc->peer_addr;
@@ -1680,7 +2079,6 @@ static int __smsg_rndzv_iov_start(void *data, void *msg)
 	req->msg.tag = hdr->msg_tag;
 	req->msg.send_iov_cnt = hdr->iov_cnt;
 	req->msg.rma_id = hdr->req_addr;
-	req->msg.cum_send_len = hdr->send_len;
 	memcpy(req->msg.send_info, data_ptr,
 	       sizeof(struct send_info_t) * hdr->iov_cnt);
 
@@ -1960,6 +2358,7 @@ retry_match:
 		req->msg.recv_info[0].recv_addr = (uint64_t)buf;
 		req->msg.recv_info[0].recv_len = len;
 		req->msg.cum_recv_len = len;
+		req->msg.cum_send_len = MIN(req->msg.cum_send_len, len);
 
 		if (mdesc) {
 			md = container_of(mdesc,
@@ -2232,6 +2631,12 @@ static int _gnix_send_req(void *arg)
 				req->msg.send_iov_cnt;
 			tdesc->rndzv_iov_start_hdr.req_addr = (uint64_t) req;
 			tdesc->rndzv_iov_start_hdr.send_len = req->msg.cum_send_len;
+
+			/* Send data at unaligned bytes in the iov addresses
+			 * within the data section of the control message so
+			 * that the remote peer can pull from four byte aligned
+			 * addresses and still transfer all the data. */
+			__gnix_msg_send_alignment(req);
 
 			data_len = sizeof(struct send_info_t) * req->msg.send_iov_cnt;
 			data = (void *) req->msg.send_info;
@@ -2541,6 +2946,7 @@ ssize_t _gnix_recvv(struct gnix_fid_ep *ep, const struct iovec *iov,
 		req->flags = 0;
 		req->msg.recv_flags = flags;
 		req->msg.recv_iov_cnt = count;
+		req->msg.cum_send_len = MIN(req->msg.cum_send_len, cum_len);
 
 		if (tagged) {
 			req->type = GNIX_FAB_RQ_TRECVV;
@@ -2740,6 +3146,8 @@ ssize_t _gnix_sendv(struct gnix_fid_ep *ep, const struct iovec *iov,
 	struct gnix_fab_req *req = NULL;
 	struct fid_mr *auto_mr;
 
+	GNIX_DEBUG(FI_LOG_EP_DATA, "iov_count = %lu\n", count);
+
 	if (!(flags & FI_TAGGED)) {
 		if (!ep->ep_ops.msg_send_allowed)
 			return -FI_EOPNOTSUPP;
@@ -2764,6 +3172,8 @@ ssize_t _gnix_sendv(struct gnix_fid_ep *ep, const struct iovec *iov,
 	for (i = 0; i < count; i++) {
 		/* TODO: handle possible overflow */
 		cum_len += iov[i].iov_len;
+
+		GNIX_DEBUG(FI_LOG_EP_DATA, "iov[%d].iov_len = %lu\n", i, iov[i].iov_len);
 	}
 
 	/* Fill out fabric request */
@@ -2827,6 +3237,8 @@ ssize_t _gnix_sendv(struct gnix_fid_ep *ep, const struct iovec *iov,
 				req->msg.send_info[i].send_len = iov[i].iov_len;
 				req->msg.send_info[i].mem_hndl =
 					req->msg.send_md[i]->mem_hndl;
+
+				GNIX_DEBUG(FI_LOG_EP_DATA, "iov[%d].iov_len = %lu, req->msg.send_info[%d].send_addr = %p, req->msg.send_info[%d].send_len = %lu\n", i, iov[i].iov_len, i, (void *) req->msg.send_info[i].send_addr, i, req->msg.send_info[i].send_len);
 
 				GNIX_DEBUG(FI_LOG_EP_DATA, "req->msg.send_md[%d] "
 					   "= %p\n", i,


### PR DESCRIPTION
- Each send vector is checked for alignment on the
    client. If unaligned buffers are found, the
    unaligned head and tail sections are sent to the
    remote peer in the control message.
- When the iov txd's are being built, the recv iov
    is checked for alignment. If unaligned recv addrs
    are found, a chained transaction is created to
    GET the head and tail sections.
  - A head tail data buffer pool was added
        to each endpoint for GETting the head and
        tail sections on the remote peer.
  - The heads and tails are finally copied to the
    posted recv buffer just before sending the rndzv
    fin message back to the sender.
- Disabled xpmem changes for sendv/recvv until #905 is resolved.

Note that gnitest "rdm_fi_pdc/peek_event_present_small_buff_provided" fails due to a "CQE length mismatch" since the cqe's now truncate the cum_send_len to the MIN(cum_send_len, cum_recv_len).  The entry->len is smaller than the send length.  I think we need to pass the recv length into `validate_cqe_contents` for peek_event_present_small_buff_provided; please advise.

Edit: "rdm_fi_pdc/peek_event_present_small_buff_provided" now passes with that changes introduced by 42bd4f1.

Fixes #886 

@ztiffany 
Signed-off-by: Evan Harvey eharvey@cray.com
