### PR TITLE
Fix valgrind conditional jump/move error for AXOR (native) atomic

### DIFF
--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -914,6 +914,7 @@ __gnix_fabric_ops_native_amo(struct fid_ep *ep, const void *buf, size_t count,
 	msg.addr = dest_addr;
 	msg.rma_iov = &rma_iov;
 	msg.datatype = datatype;
+	msg.op = FI_ATOMIC_OP_LAST; /* not FI_ATOMIC_OP */
 	msg.context = context;
 	result_iov.addr = result;
 	result_iov.count = 1;


### PR DESCRIPTION
The fi_op field in fi_msg_atomic must be initialized even when using
AXOR, since it is read in __gnix_amo_txd_complete.

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com

@chuckfossen 
