### PR TITLE
prov/gni: add support for unassigned cpus

### DIFF
--- a/prov/gni/include/gnix_util.h
+++ b/prov/gni/include/gnix_util.h
@@ -235,6 +235,7 @@ int _gnix_job_cq_limit(uint32_t dev_id, uint8_t ptag, uint32_t *limit);
 int _gnix_pes_on_node(uint32_t *num_pes);
 int _gnix_nics_per_rank(uint32_t *nics_per_rank);
 void _gnix_dump_gni_res(uint8_t ptag);
+int _gnix_get_num_corespec_cpus(uint32_t *num_core_spec_cpus);
 
 struct gnix_reference {
 	atomic_t references;

--- a/prov/gni/src/gnix_datagram.c
+++ b/prov/gni/src/gnix_datagram.c
@@ -560,6 +560,7 @@ int _gnix_dgram_hndl_alloc(const struct gnix_fid_fabric *fabric,
 	struct gnix_dgram_hndl *the_hndl = NULL;
 	struct gnix_nic *nic;
 	gni_return_t status;
+	uint32_t num_corespec_cpus = 0;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
@@ -656,10 +657,21 @@ int _gnix_dgram_hndl_alloc(const struct gnix_fid_fabric *fabric,
 		 * though...
 		 */
 
-		ret = _gnix_job_disable_affinity_apply();
+		ret = _gnix_get_num_corespec_cpus(&num_corespec_cpus);
+		if (ret != FI_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "failed to get num corespec cpus\n");
+		}
+
+		if (num_corespec_cpus > 0) {
+			ret = _gnix_job_disable_affinity_apply();
+		} else {
+			ret = _gnix_job_enable_unassigned_cpus();
+		}
 		if (ret != 0)
 			GNIX_WARN(FI_LOG_EP_CTRL,
-			"_gnix_job_disable call returned %d\n", ret);
+			"disable_affinity/unassigned_cpus call returned %d\n",
+			ret);
 
 		ret = pthread_create(&the_hndl->progress_thread,
 				     NULL,

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -919,6 +919,7 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 	uint32_t fake_cdm_id;
 	gni_smsg_attr_t smsg_mbox_attr;
 	struct gnix_nic_attr *nic_attr = &default_attr;
+	uint32_t num_corespec_cpus = 0;
 	bool must_alloc_nic = false;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
@@ -1242,10 +1243,20 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 			 * though...
 			 */
 
-			ret = _gnix_job_disable_affinity_apply();
+			ret = _gnix_get_num_corespec_cpus(&num_corespec_cpus);
+			if (ret != FI_SUCCESS) {
+				GNIX_WARN(FI_LOG_EP_CTRL,
+				  "failed to get num corespec cpus\n");
+			}
+			if (num_corespec_cpus > 0) {
+				ret = _gnix_job_disable_affinity_apply();
+			} else {
+				ret = _gnix_job_enable_unassigned_cpus();
+			}
 			if (ret != 0)
 				GNIX_WARN(FI_LOG_EP_CTRL,
-				"_gnix_job_disable call returned %d\n", ret);
+				"job_disable/unassigned cpus returned %d\n",
+					 ret);
 
 			ret = pthread_create(&nic->progress_thread,
 					     NULL,

--- a/prov/gni/test/utils.c
+++ b/prov/gni/test/utils.c
@@ -64,12 +64,11 @@ Test(utils, proc)
 	rc = _gnix_task_is_not_app();
 	cr_expect(rc == 0);
 
-	/* *_unassigned_cpus flags don't work on tiger */
 	rc = _gnix_job_enable_unassigned_cpus();
-	cr_expect(rc != 0);
+	cr_expect(rc == 0);
 
 	rc = _gnix_job_disable_unassigned_cpus();
-	cr_expect(rc != 0);
+	cr_expect(rc == 0);
 
 	rc = _gnix_job_enable_affinity_apply();
 	cr_expect(rc == 0);


### PR DESCRIPTION
add option to place progress threads on unused
cpus (aka hyperthreads) if user is not using corespec
feature.  This helps modestly with progress thread
interference with application threads.

@sungeunchoi 
@ztiffany 

Signed-off-by: Howard Pritchard howardp@lanl.gov
