### PR TITLE
Fix gnix_ep_*_size_left to return -FI_EOPBADSTATE if the endpoint is not enabled

### DIFF
--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -2388,8 +2388,18 @@ DIRECT_FN STATIC int gnix_ep_setopt(fid_t fid, int level, int optname,
 
 DIRECT_FN STATIC ssize_t gnix_ep_rx_size_left(struct fid_ep *ep)
 {
-	if (!ep)
+	if (!ep) {
 		return -FI_EINVAL;
+	}
+
+	struct gnix_fid_ep *ep_priv = container_of(ep,
+						   struct gnix_fid_ep,
+						   ep_fid);
+
+	/* A little arbitrary... */
+	if (ep_priv->htd_pool.enabled == false) {
+		return -FI_EOPBADSTATE;
+	}
 
 	switch (ep->fid.fclass) {
 	case FI_CLASS_EP:
@@ -2408,8 +2418,18 @@ DIRECT_FN STATIC ssize_t gnix_ep_rx_size_left(struct fid_ep *ep)
 
 DIRECT_FN STATIC ssize_t gnix_ep_tx_size_left(struct fid_ep *ep)
 {
-	if (!ep)
+	if (!ep) {
 		return -FI_EINVAL;
+	}
+
+	struct gnix_fid_ep *ep_priv = container_of(ep,
+						   struct gnix_fid_ep,
+						   ep_fid);
+
+	/* A little arbitrary... */
+	if (ep_priv->htd_pool.enabled == false) {
+		return -FI_EOPBADSTATE;
+	}
 
 	switch (ep->fid.fclass) {
 	case FI_CLASS_EP:

--- a/prov/gni/test/ep.c
+++ b/prov/gni/test/ep.c
@@ -218,7 +218,17 @@ Test(endpoint, sizeleft)
 	struct fid_ep *ep = NULL;
 
 	ret = fi_endpoint(dom, fi, &ep, NULL);
-	cr_assert(!ret, "fi_endpoint");
+	cr_assert(ret == FI_SUCCESS, "fi_endpoint");
+
+	/* Test in disabled state. */
+	sz = fi_rx_size_left(ep);
+	cr_assert(sz == -FI_EOPBADSTATE, "fi_rx_size_left");
+
+	sz = fi_tx_size_left(ep);
+	cr_assert(sz == -FI_EOPBADSTATE, "fi_tx_size_left");
+
+	ret = fi_enable(ep);
+	cr_assert(ret == FI_SUCCESS, "fi_enable");
 
 	/* Test default values. */
 	sz = fi_rx_size_left(ep);


### PR DESCRIPTION
Note that this behavior is expected by fabtests, but is not really documented anywhere.

Also, the fabtests fi_size_left_test still fails because it expects the return value to be equal to the tx/rx size.  Perhaps these functions should just return GNIX_TX|RX_SIZE_DEFAULT instead?

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com

Fixes #902 

@ztiffany @hppritcha 
