### PR TITLE
cm_nic alloc changes to facilitate scalable ep

### DIFF
--- a/prov/gni/include/gnix_cm_nic.h
+++ b/prov/gni/include/gnix_cm_nic.h
@@ -136,6 +136,7 @@ int _gnix_cm_nic_free(struct gnix_cm_nic *cm_nic);
  */
 int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 		       struct fi_info *info,
+		       uint32_t cdm_id,
 		       struct gnix_cm_nic **cm_nic);
 
 /**


### PR DESCRIPTION
Pass cdm_id to _gnix_cm_nic_alloc().
Change how cdm_id's are formed to allow a range of values that will not
collide with multiple processes on one node.

Fixes #939

Signed-off-by: Chuck Fossen chuckf@cray.com
@hppritcha @ztiffany 
