### PR TITLE
prov/gni: suppress spurious kdreg notifier events

### DIFF
--- a/prov/gni/src/gnix_mr_cache.c
+++ b/prov/gni/src/gnix_mr_cache.c
@@ -441,6 +441,10 @@ __clear_notifier_events(gnix_mr_cache_t *cache)
 	RbtIterator iter;
 	uint64_t cookie;
 
+	if (!cache->attr.notifier) {
+		return;
+	}
+
 	if (!cache->attr.lazy_deregistration) {
 		return;
 	}

--- a/prov/gni/src/gnix_mr_notifier.c
+++ b/prov/gni/src/gnix_mr_notifier.c
@@ -218,7 +218,7 @@ _gnix_notifier_get_event(struct gnix_mr_notifier *mrn, void* buf, size_t len)
 	int ret, ret_errno;
 
 	if ((mrn == NULL) || (buf == NULL) || (len <= 0)) {
-		GNIX_INFO(FI_LOG_MR,
+		GNIX_WARN(FI_LOG_MR,
 			  "Invalid argument to _gnix_notifier_get_event\n");
 		return -FI_EINVAL;
 	}

--- a/prov/gni/src/gnix_xpmem.c
+++ b/prov/gni/src/gnix_xpmem.c
@@ -70,6 +70,9 @@ struct gnix_xpmem_ht_entry {
 
 /*
  * TODO: should be adjustable from domain params
+ * Note notifier is set to NULL since xpmem device driver
+ * handles mmu notifiers internally so we don't need to use
+ * KDREG.
  */
 static gnix_mr_cache_attr_t _gnix_xpmem_default_mr_cache_attr = {
 		.soft_reg_limit      = 128,
@@ -80,6 +83,7 @@ static gnix_mr_cache_attr_t _gnix_xpmem_default_mr_cache_attr = {
 		.dereg_callback      = __gnix_xpmem_detach_seg,
 		.destruct_callback   = __gnix_xpmem_destroy_mr_cache,
 		.elem_size           = sizeof(struct gnix_xpmem_access_handle),
+		.notifier            = NULL,
 };
 
 /*******************************************************************************


### PR DESCRIPTION
The xpmem reg cache doesn't need to use kdreg.
This was confusing the wrapper code around kdreg.

Fixes #937
Fixes #918 

@sungeunchoi 
Signed-off-by: Howard Pritchard howardp@lanl.gov
