### PR TITLE
prov/gni: Return the default TX/RX size for the size_left functions

### DIFF
--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -2458,8 +2458,8 @@ DIRECT_FN STATIC ssize_t gnix_ep_rx_size_left(struct fid_ep *ep)
 		return -FI_EINVAL;
 	}
 
-	/* We can queue RXs indefinitely, return an arbitrary low water mark. */
-	return 64;
+	/* We can queue RXs indefinitely, so just return the default size. */
+	return GNIX_RX_SIZE_DEFAULT;
 }
 
 DIRECT_FN STATIC ssize_t gnix_ep_tx_size_left(struct fid_ep *ep)
@@ -2487,8 +2487,8 @@ DIRECT_FN STATIC ssize_t gnix_ep_tx_size_left(struct fid_ep *ep)
 		return -FI_EINVAL;
 	}
 
-	/* We can queue TXs indefinitely, return an arbitrary low water mark. */
-	return 64;
+	/* We can queue TXs indefinitely, so just return the default size. */
+	return GNIX_TX_SIZE_DEFAULT;
 }
 
 __attribute__((unused))

--- a/prov/gni/test/ep.c
+++ b/prov/gni/test/ep.c
@@ -232,10 +232,10 @@ Test(endpoint, sizeleft)
 
 	/* Test default values. */
 	sz = fi_rx_size_left(ep);
-	cr_assert(sz == 64, "fi_rx_size_left");
+	cr_assert(sz == GNIX_RX_SIZE_DEFAULT, "fi_rx_size_left");
 
 	sz = fi_tx_size_left(ep);
-	cr_assert(sz == 64, "fi_tx_size_left");
+	cr_assert(sz == GNIX_TX_SIZE_DEFAULT, "fi_tx_size_left");
 
 	ret = fi_close(&ep->fid);
 	cr_assert(!ret, "fi_close endpoint");


### PR DESCRIPTION
Internally we can queue operations more or less indefinitely, so
rather than returning an arbitrary value, return the default size.

This gets us to pass fi_size_left_test.

@hppritcha @ztiffany 

Fixes #946 

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com
