### PR TITLE
prov/gni: don't abort on non-recoverable CQE

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -843,6 +843,11 @@ struct gnix_fab_req {
 
 	/* TODO: change the size of this for unaligned data? */
 	struct gnix_tx_descriptor *iov_txds[GNIX_MAX_IOV_LIMIT];
+	/*
+	 * special value of UINT_MAX is used to indicate
+	 * an unrecoverable (aka non-transient) error has occurred
+	 * in one of the underlying GNI transactions
+	 */
 	uint32_t		  tx_failures;
 
 	/* common to rma/amo/msg */
@@ -853,6 +858,15 @@ struct gnix_fab_req {
 	};
 	char inject_buf[GNIX_INJECT_SIZE];
 };
+
+/*
+ * macro to test whether a request is replayable
+ * or not based on the value of the tx_failures field
+ */
+#define GNIX_REQ_REPLAYABLE(req)                                            \
+	(((req)->tx_failures != UINT_MAX) &&                                 \
+	 (++(req)->tx_failures <                                            \
+		(req)->gnix_ep->domain->params.max_retransmits))
 
 static inline int _gnix_req_inject_err(struct gnix_fab_req *req)
 {

--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -196,15 +196,14 @@ static int __gnix_rma_post_err_no_retrans(struct gnix_fab_req *req, int error)
 
 static int __gnix_rma_post_err(struct gnix_fab_req *req, int error)
 {
-	req->tx_failures++;
 	if (GNIX_EP_RDM(req->gnix_ep->type) &&
-	    req->tx_failures < req->gnix_ep->domain->params.max_retransmits) {
+		GNIX_REQ_REPLAYABLE(req)) {
 		GNIX_INFO(FI_LOG_EP_DATA,
 			  "Requeueing failed request: %p\n", req);
 		return _gnix_vc_queue_work_req(req);
 	}
 
-	GNIX_INFO(FI_LOG_EP_DATA, "Failed %d transmits: %p error: %d\n",
+	GNIX_WARN(FI_LOG_EP_DATA, "Failed %u transmits: %p error: %d\n",
 		  req->tx_failures, req, error);
 
 	__gnix_rma_post_err_no_retrans(req, error);


### PR DESCRIPTION
Don't abort when a GNI transaction is non-recoverable,
let app figure out how to do that.  Turn off retry
by setting retry count(tx_failures) to UINT_MAX.

introduce a new macro to simplify replay
encapsulate logic for deciding whether a request
can be replayed based on tx_failures field

Fixes #891
@sungeunchoi 
@ztiffany 

Signed-off-by: Howard Pritchard howardp@lanl.gov
