### PR TITLE
prov/gni: fix iov limit setting for fi_getinfo

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -119,7 +119,9 @@ extern "C" {
 #endif
 
 #define GNIX_MAX_IOV_LIMIT 8
+#define GNIX_MAX_RMA_IOV_LIMIT 1
 #define GNIX_ADDR_CACHE_SIZE 5
+
 /*
  * GNI GET alignment
  */

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -50,7 +50,6 @@ extern "C" {
 #include "gnix_util.h"
 
 #define GNIX_DEF_MAX_NICS_PER_PTAG	4
-#define GNIX_MAX_IOV_LIMIT 8	/* this should have been pulled in from gnix.h.. */
 
 extern uint32_t gnix_max_nics_per_ptag;
 

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -609,7 +609,7 @@ gnix_ep_readv(struct fid_ep *ep, const struct iovec *iov, void **desc,
 	struct gnix_fid_ep *gnix_ep;
 	uint64_t flags;
 
-	if (!ep || !iov || !desc || count != 1) {
+	if (!ep || !iov || !desc || count > GNIX_MAX_RMA_IOV_LIMIT) {
 		return -FI_EINVAL;
 	}
 
@@ -676,7 +676,7 @@ gnix_ep_writev(struct fid_ep *ep, const struct iovec *iov, void **desc,
 	struct gnix_fid_ep *gnix_ep;
 	uint64_t flags;
 
-	if (!ep || !iov || !desc || count != 1) {
+	if (!ep || !iov || !desc || count > GNIX_MAX_RMA_IOV_LIMIT) {
 		return -FI_EINVAL;
 	}
 
@@ -696,7 +696,8 @@ DIRECT_FN STATIC ssize_t gnix_ep_writemsg(struct fid_ep *ep, const struct fi_msg
 	struct gnix_fid_ep *gnix_ep;
 
 	if (!ep || !msg || !msg->msg_iov || !msg->rma_iov ||
-	    msg->iov_count != 1 || msg->rma_iov_count != 1 ||
+	    msg->iov_count != 1 ||
+		msg->rma_iov_count > GNIX_MAX_RMA_IOV_LIMIT ||
 	    msg->rma_iov[0].len > msg->msg_iov[0].iov_len) {
 		return -FI_EINVAL;
 	}
@@ -1059,7 +1060,7 @@ gnix_ep_atomic_writev(struct fid_ep *ep, const struct fi_ioc *iov, void **desc,
 		      uint64_t key, enum fi_datatype datatype, enum fi_op op,
 		      void *context)
 {
-	if (!iov || count != 1) {
+	if (!iov || count > GNIX_MAX_RMA_IOV_LIMIT) {
 		return -FI_EINVAL;
 	}
 
@@ -1185,7 +1186,7 @@ gnix_ep_atomic_readwritev(struct fid_ep *ep, const struct fi_ioc *iov,
 			  enum fi_datatype datatype, enum fi_op op,
 			  void *context)
 {
-	if (!iov || count != 1 || !resultv)
+	if (!iov || count > GNIX_MAX_RMA_IOV_LIMIT || !resultv)
 		return -FI_EINVAL;
 
 	return gnix_ep_atomic_readwrite(ep, iov[0].addr, iov[0].count,
@@ -1286,7 +1287,7 @@ DIRECT_FN STATIC ssize_t gnix_ep_atomic_compwritev(struct fid_ep *ep,
 						   enum fi_op op,
 						   void *context)
 {
-	if (!iov || count != 1 || !resultv || !comparev)
+	if (!iov || count > GNIX_MAX_RMA_IOV_LIMIT || !resultv || !comparev)
 		return -FI_EINVAL;
 
 	return gnix_ep_atomic_compwrite(ep, iov[0].addr, iov[0].count,

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -280,13 +280,13 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 	gnix_info->tx_attr->msg_order = FI_ORDER_SAS;
 	gnix_info->tx_attr->comp_order = FI_ORDER_NONE;
 	gnix_info->tx_attr->size = GNIX_TX_SIZE_DEFAULT;
-	gnix_info->tx_attr->iov_limit = 1;
+	gnix_info->tx_attr->iov_limit = GNIX_MAX_IOV_LIMIT;
 	gnix_info->tx_attr->inject_size = GNIX_INJECT_SIZE;
-	gnix_info->tx_attr->rma_iov_limit = 1;
+	gnix_info->tx_attr->rma_iov_limit = GNIX_MAX_RMA_IOV_LIMIT;
 	gnix_info->rx_attr->msg_order = FI_ORDER_SAS;
 	gnix_info->rx_attr->comp_order = FI_ORDER_NONE;
 	gnix_info->rx_attr->size = GNIX_RX_SIZE_DEFAULT;
-	gnix_info->rx_attr->iov_limit = 1;
+	gnix_info->rx_attr->iov_limit = GNIX_MAX_IOV_LIMIT;
 
 	if (hints) {
 		if (hints->ep_attr) {


### PR DESCRIPTION
GNI provider wasn't properly setting iov_limit in
the gnix_info struct.

Signed-off-by: Howard Pritchard howardp@lanl.gov
