### PR TITLE
prov/gni: Check for both appropriate cq and counters for data transfer operations

### DIFF
--- a/prov/gni/src/gnix_atomic.c
+++ b/prov/gni/src/gnix_atomic.c
@@ -509,6 +509,20 @@ ssize_t _gnix_atomic(struct gnix_fid_ep *ep,
 	void *loc_addr = NULL;
 	int dt_len, dt_align;
 
+	if (!(flags & FI_INJECT) && !ep->send_cq &&
+	    (((fr_type == GNIX_FAB_RQ_AMO ||
+	      fr_type == GNIX_FAB_RQ_NAMO_AX ||
+	      fr_type == GNIX_FAB_RQ_NAMO_AX_S) &&
+	      !ep->write_cntr) ||
+	     ((fr_type == GNIX_FAB_RQ_FAMO ||
+	      fr_type == GNIX_FAB_RQ_CAMO ||
+	      fr_type == GNIX_FAB_RQ_NAMO_FAX ||
+	      fr_type == GNIX_FAB_RQ_NAMO_FAX_S) &&
+	      !ep->read_cntr))) {
+		return -FI_ENOCQ;
+	}
+
+
 	if (!ep || !msg || !msg->msg_iov ||
 	    !msg->msg_iov[0].addr ||
 	    msg->msg_iov[0].count != 1 ||
@@ -523,10 +537,6 @@ ssize_t _gnix_atomic(struct gnix_fid_ep *ep,
 		    (flags & FI_INJECT)) {
 			return -FI_EINVAL;
 		}
-	}
-
-	if (!ep->send_cq && !(flags & FI_INJECT)) {
-		return -FI_ENOCQ;
 	}
 
 	if (fr_type == GNIX_FAB_RQ_CAMO) {

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -2353,7 +2353,7 @@ ssize_t _gnix_recv(struct gnix_fid_ep *ep, uint64_t buf, size_t len,
 	struct gnix_fid_mem_desc *md = NULL;
 	int tagged = !!(flags & FI_TAGGED);
 
-	if (!ep->recv_cq) {
+	if (!ep->recv_cq && !ep->recv_cntr) {
 		return -FI_ENOCQ;
 	}
 
@@ -2764,8 +2764,8 @@ ssize_t _gnix_send(struct gnix_fid_ep *ep, uint64_t loc_addr, size_t len,
 	int rendezvous;
 	struct fid_mr *auto_mr = NULL;
 
-	if (!ep) {
-		return -FI_EINVAL;
+	if (!ep->send_cq && !ep->send_cntr) {
+		return -FI_ENOCQ;
 	}
 
 	if (flags & FI_TRIGGER) {
@@ -2775,10 +2775,6 @@ ssize_t _gnix_send(struct gnix_fid_ep *ep, uint64_t loc_addr, size_t len,
 		    (flags & FI_INJECT)) {
 			return -FI_EINVAL;
 		}
-	}
-
-	if (!ep->send_cq) {
-		return -FI_ENOCQ;
 	}
 
 	if ((flags & FI_INJECT) && (len > GNIX_INJECT_SIZE)) {
@@ -2904,7 +2900,7 @@ ssize_t _gnix_recvv(struct gnix_fid_ep *ep, const struct iovec *iov,
 	int tagged = flags & FI_TAGGED;
 	struct fid_mr *auto_mr;
 
-	if (!ep->recv_cq) {
+	if (!ep->recv_cq && !ep->recv_cntr) {
 		return -FI_ENOCQ;
 	}
 
@@ -3182,6 +3178,10 @@ ssize_t _gnix_sendv(struct gnix_fid_ep *ep, const struct iovec *iov,
 	struct fid_mr *auto_mr;
 
 	GNIX_DEBUG(FI_LOG_EP_DATA, "iov_count = %lu\n", count);
+
+	if (!ep->send_cq && !ep->send_cntr) {
+		return -FI_ENOCQ;
+	}
 
 	if (!(flags & FI_TAGGED)) {
 		if (!ep->ep_ops.msg_send_allowed)

--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -882,8 +882,10 @@ ssize_t _gnix_rma(struct gnix_fid_ep *ep, enum gnix_fab_req_type fr_type,
 	int rdma;
 	struct fid_mr *auto_mr = NULL;
 
-	if (!ep) {
-		return -FI_EINVAL;
+	if (!(flags & FI_INJECT) && !ep->send_cq &&
+	    (((fr_type == GNIX_FAB_RQ_RDMA_WRITE) && !ep->write_cntr) ||
+	     ((fr_type == GNIX_FAB_RQ_RDMA_READ) && !ep->read_cntr))) {
+		return -FI_ENOCQ;
 	}
 
 	if (flags & FI_TRIGGER) {
@@ -893,10 +895,6 @@ ssize_t _gnix_rma(struct gnix_fid_ep *ep, enum gnix_fab_req_type fr_type,
 		    (flags & FI_INJECT)) {
 			return -FI_EINVAL;
 		}
-	}
-
-	if (!ep->send_cq && !(flags & FI_INJECT)) {
-		return -FI_ENOCQ;
 	}
 
 	if ((flags & FI_INJECT) && (len > GNIX_INJECT_SIZE)) {

--- a/prov/gni/test/api_cq.c
+++ b/prov/gni/test/api_cq.c
@@ -84,12 +84,6 @@ struct fid_mr *rem_mr[NUMEPS], *loc_mr[NUMEPS];
 uint64_t mr_key[NUMEPS];
 uint64_t cq_bind_flags;
 
-static struct fid_cntr *send_cntr[NUMEPS], *recv_cntr[NUMEPS];
-static struct fi_cntr_attr cntr_attr = {
-	.events = FI_CNTR_EVENTS_COMP,
-	.flags = 0
-};
-
 void api_cq_bind(uint64_t flags)
 {
 	int ret, i;
@@ -185,18 +179,6 @@ void api_cq_setup(void)
 		ret = fi_ep_bind(ep[i], &av[i]->fid, 0);
 		cr_assert(!ret, "fi_ep_bind");
 
-
-		ret = fi_cntr_open(dom[i], &cntr_attr, send_cntr + i, 0);
-		cr_assert(!ret, "fi_cntr_open");
-
-		ret = fi_ep_bind(ep[i], &send_cntr[i]->fid, FI_SEND);
-		cr_assert(!ret, "fi_ep_bind");
-
-		ret = fi_cntr_open(dom[i], &cntr_attr, recv_cntr + i, 0);
-		cr_assert(!ret, "fi_cntr_open");
-
-		ret = fi_ep_bind(ep[i], &recv_cntr[i]->fid, FI_RECV);
-		cr_assert(!ret, "fi_ep_bind");
 	}
 
 	for (i = 0; i < NUMEPS; i++) {
@@ -217,9 +199,6 @@ static void api_cq_teardown_common(bool unreg)
 	int ret = 0, i = 0;
 
 	for (; i < NUMEPS; i++) {
-		fi_close(&recv_cntr[i]->fid);
-		fi_close(&send_cntr[i]->fid);
-
 		if (unreg) {
 			fi_close(&loc_mr[i]->fid);
 			fi_close(&rem_mr[i]->fid);


### PR DESCRIPTION
- Correct the check that returns -ENOCQ for all data transfer operations
- Small cleanup (remove redundant ep check)
- Remove counters from the api_cq tests (they are not needed, and with
  this change, cause unexpected behavior)

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com

Fixes #945 

@chuckfossen 
