### PR TITLE
prov/gni: Modified hashtable unit tests

### DIFF
--- a/prov/gni/test/hashtable.c
+++ b/prov/gni/test/hashtable.c
@@ -398,7 +398,7 @@ Test(gnix_hashtable_advanced, insert_1024)
 	srand(time(NULL));
 
 	for (i = 0; i < 1024; ++i) {
-		test_elements[i].key = rand();
+		test_elements[i].key = i;
 		test_elements[i].val = rand() % (1024 * 1024);
 		test_elements[i].magic = __GNIX_MAGIC_VALUE;
 	}


### PR DESCRIPTION
The insert_1024 hash table test seems to be intermittently
failing due to rand() id key collisions which cause ret to
return -FI_ENOSPC. This PR fixes bad test design.

Signed-off-by: James Swaro jswaro@cray.com

@sungeunchoi 
