### PR TITLE
prov/gni: swat issue 967

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -118,8 +118,9 @@ extern "C" {
 #define compiler_barrier() asm volatile ("" ::: "memory")
 #endif
 
-#define GNIX_MAX_IOV_LIMIT 8
+#define GNIX_MAX_MSG_IOV_LIMIT 8
 #define GNIX_MAX_RMA_IOV_LIMIT 1
+#define GNIX_MAX_ATOMIC_IOV_LIMIT 1
 #define GNIX_ADDR_CACHE_SIZE 5
 
 /*
@@ -138,7 +139,7 @@ extern "C" {
  *
  * Note: "* 2" for head and tail
  */
-#define GNIX_HTD_BUF_SZ GNIX_MAX_IOV_LIMIT * GNI_READ_ALIGN * 2
+#define GNIX_HTD_BUF_SZ (GNIX_MAX_MSG_IOV_LIMIT * GNI_READ_ALIGN * 2)
 
 /*
  * Flags
@@ -580,8 +581,8 @@ struct gnix_fab_req_msg {
 		gni_mem_handle_t mem_hndl;
 		uint32_t	 head;
 		uint32_t	 tail;
-	}			     send_info[GNIX_MAX_IOV_LIMIT];
-	struct gnix_fid_mem_desc     *send_md[GNIX_MAX_IOV_LIMIT];
+	}			     send_info[GNIX_MAX_MSG_IOV_LIMIT];
+	struct gnix_fid_mem_desc     *send_md[GNIX_MAX_MSG_IOV_LIMIT];
 	size_t                       send_iov_cnt;
 	uint64_t                     send_flags;
 	size_t			     cum_send_len;
@@ -595,8 +596,8 @@ struct gnix_fab_req_msg {
 						* the txd's int buf
 						*/
 		uint32_t	 head_len : 2;
-	}			     recv_info[GNIX_MAX_IOV_LIMIT];
-	struct gnix_fid_mem_desc     *recv_md[GNIX_MAX_IOV_LIMIT];
+	}			     recv_info[GNIX_MAX_MSG_IOV_LIMIT];
+	struct gnix_fid_mem_desc     *recv_md[GNIX_MAX_MSG_IOV_LIMIT];
 	size_t			     recv_iov_cnt;
 	uint64_t                     recv_flags; /* protocol, API info */
 	size_t			     cum_recv_len;
@@ -854,7 +855,7 @@ struct gnix_fab_req {
 	uint64_t                  flags;
 
 	/* TODO: change the size of this for unaligned data? */
-	struct gnix_tx_descriptor *iov_txds[GNIX_MAX_IOV_LIMIT];
+	struct gnix_tx_descriptor *iov_txds[GNIX_MAX_MSG_IOV_LIMIT];
 	/*
 	 * special value of UINT_MAX is used to indicate
 	 * an unrecoverable (aka non-transient) error has occurred

--- a/prov/gni/src/gnix_atomic.c
+++ b/prov/gni/src/gnix_atomic.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -526,7 +526,7 @@ ssize_t _gnix_atomic(struct gnix_fid_ep *ep,
 	if (!ep || !msg || !msg->msg_iov ||
 	    !msg->msg_iov[0].addr ||
 	    msg->msg_iov[0].count != 1 ||
-	    msg->iov_count != 1 ||
+	    msg->iov_count != GNIX_MAX_ATOMIC_IOV_LIMIT ||
 	    !msg->rma_iov || !msg->rma_iov[0].addr)
 		return -FI_EINVAL;
 

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -205,7 +205,7 @@ static inline ssize_t __ep_recvv(struct fid_ep *ep, const struct iovec *iov,
 {
 	struct gnix_fid_ep *ep_priv;
 
-	if (!ep || !iov || count > GNIX_MAX_IOV_LIMIT) {
+	if (!ep || !iov || count > GNIX_MAX_MSG_IOV_LIMIT) {
 		return -FI_EINVAL;
 	}
 
@@ -265,7 +265,7 @@ static inline ssize_t __ep_sendv(struct fid_ep *ep, const struct iovec *iov,
 {
 	struct gnix_fid_ep *gnix_ep;
 
-	if (!ep || !iov || !count || count > GNIX_MAX_IOV_LIMIT) {
+	if (!ep || !iov || !count || count > GNIX_MAX_MSG_IOV_LIMIT) {
 		return -FI_EINVAL;
 	}
 
@@ -1064,7 +1064,7 @@ gnix_ep_atomic_writev(struct fid_ep *ep, const struct fi_ioc *iov, void **desc,
 		      uint64_t key, enum fi_datatype datatype, enum fi_op op,
 		      void *context)
 {
-	if (!iov || count > GNIX_MAX_RMA_IOV_LIMIT) {
+	if (!iov || count > 1) {
 		return -FI_EINVAL;
 	}
 
@@ -1190,7 +1190,7 @@ gnix_ep_atomic_readwritev(struct fid_ep *ep, const struct fi_ioc *iov,
 			  enum fi_datatype datatype, enum fi_op op,
 			  void *context)
 {
-	if (!iov || count > GNIX_MAX_RMA_IOV_LIMIT || !resultv)
+	if (!iov || count > 1 || !resultv)
 		return -FI_EINVAL;
 
 	return gnix_ep_atomic_readwrite(ep, iov[0].addr, iov[0].count,
@@ -1291,7 +1291,7 @@ DIRECT_FN STATIC ssize_t gnix_ep_atomic_compwritev(struct fid_ep *ep,
 						   enum fi_op op,
 						   void *context)
 {
-	if (!iov || count > GNIX_MAX_RMA_IOV_LIMIT || !resultv || !comparev)
+	if (!iov || count > 1 || !resultv || !comparev)
 		return -FI_EINVAL;
 
 	return gnix_ep_atomic_compwrite(ep, iov[0].addr, iov[0].count,

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -280,13 +280,13 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 	gnix_info->tx_attr->msg_order = FI_ORDER_SAS;
 	gnix_info->tx_attr->comp_order = FI_ORDER_NONE;
 	gnix_info->tx_attr->size = GNIX_TX_SIZE_DEFAULT;
-	gnix_info->tx_attr->iov_limit = GNIX_MAX_IOV_LIMIT;
+	gnix_info->tx_attr->iov_limit = GNIX_MAX_MSG_IOV_LIMIT;
 	gnix_info->tx_attr->inject_size = GNIX_INJECT_SIZE;
 	gnix_info->tx_attr->rma_iov_limit = GNIX_MAX_RMA_IOV_LIMIT;
 	gnix_info->rx_attr->msg_order = FI_ORDER_SAS;
 	gnix_info->rx_attr->comp_order = FI_ORDER_NONE;
 	gnix_info->rx_attr->size = GNIX_RX_SIZE_DEFAULT;
-	gnix_info->rx_attr->iov_limit = GNIX_MAX_IOV_LIMIT;
+	gnix_info->rx_attr->iov_limit = GNIX_MAX_MSG_IOV_LIMIT;
 
 	if (hints) {
 		if (hints->ep_attr) {

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -610,8 +610,8 @@ static inline void __gnix_msg_iov_cpy_unaligned_head_tail_data(struct gnix_fab_r
 			 * data we are interested in.
 			 */
 			addr = (void *) ((uint8_t *) req->msg.htd_buf +
-					 (GNI_READ_ALIGN * (i + GNIX_MAX_IOV_LIMIT)) +
-					 GNI_READ_ALIGN - req->msg.recv_info[i].head_len);
+			     (GNI_READ_ALIGN * (i + GNIX_MAX_MSG_IOV_LIMIT)) +
+			     GNI_READ_ALIGN - req->msg.recv_info[i].head_len);
 			recv_addr = (void *) req->msg.recv_info[i].recv_addr;
 
 			GNIX_INFO(FI_LOG_EP_DATA,
@@ -1270,7 +1270,8 @@ static int __gnix_rndzv_iov_req_build(void *arg)
 					cur_ct->local_mem_hndl = req->msg.htd_mdh;
 					cur_ct->length = GNI_READ_ALIGN;
 					cur_ct->remote_addr = send_ptr - GNI_READ_ALIGN;
-					cur_ct->local_addr = (uint64_t) (((uint8_t *) req->msg.htd_buf) + (GNI_READ_ALIGN * (recv_idx + GNIX_MAX_IOV_LIMIT)));
+					cur_ct->local_addr = (uint64_t) (((uint8_t *) req->msg.htd_buf) +
+						(GNI_READ_ALIGN * (recv_idx + GNIX_MAX_MSG_IOV_LIMIT)));
 					next_ct = &cur_ct->next_descr;
 				}
 			} else { 	/* Start a new ct */
@@ -1330,7 +1331,8 @@ static int __gnix_rndzv_iov_req_build(void *arg)
 						cur_ct->local_mem_hndl = req->msg.htd_mdh;
 						cur_ct->length = GNI_READ_ALIGN;
 						cur_ct->remote_addr = send_ptr - GNI_READ_ALIGN;
-						cur_ct->local_addr = (uint64_t) (((uint8_t *) req->msg.htd_buf) + (GNI_READ_ALIGN * (recv_idx + GNIX_MAX_IOV_LIMIT)));
+						cur_ct->local_addr = (uint64_t) (((uint8_t *) req->msg.htd_buf) +
+								(GNI_READ_ALIGN * (recv_idx + GNIX_MAX_MSG_IOV_LIMIT)));
 						next_ct = &cur_ct->next_descr;
 					} else { /* New FMA ct */
 						GNIX_DEBUG(FI_LOG_EP_DATA, "New FMA"
@@ -1360,7 +1362,8 @@ static int __gnix_rndzv_iov_req_build(void *arg)
 						ct_txd->gni_desc.remote_addr = send_ptr - GNI_READ_ALIGN;
 						ct_txd->gni_desc.remote_mem_hndl = req->msg.send_info[send_idx].mem_hndl;
 
-						ct_txd->gni_desc.local_addr = (uint64_t) ((uint8_t *) req->msg.htd_buf + (GNI_READ_ALIGN * (recv_idx + GNIX_MAX_IOV_LIMIT)));
+						ct_txd->gni_desc.local_addr = (uint64_t) ((uint8_t *) req->msg.htd_buf +
+								(GNI_READ_ALIGN * (recv_idx + GNIX_MAX_MSG_IOV_LIMIT)));
 						ct_txd->gni_desc.local_mem_hndl = req->msg.htd_mdh;
 
 						ct_txd->gni_desc.length = GNI_READ_ALIGN;


### PR DESCRIPTION
fix ofi-cray/libfabric-cray#967

Note I had to battle the linux code style checker with > 80 char lines, hence
the messy whitespace.

Marking this as a bug since it was originally part of a PR that fixed a problem.

@sungeunchoi 

Signed-off-by: Howard Pritchard howardp@lanl.gov
