### PR TITLE
prov/gni: Fix C++ compilation

### DIFF
--- a/prov/gni/include/fi_ext_gni.h
+++ b/prov/gni/include/fi_ext_gni.h
@@ -81,6 +81,7 @@ struct fi_gni_ops_domain {
 	int (*flush_cache)(struct fid *fid);
 };
 
+#include <rdma/fi_atomic.h>
 enum gnix_native_amo_types {
 	GNIX_NAMO_AX = 0x20,
 	GNIX_NAMO_AX_S,
@@ -117,5 +118,9 @@ struct gnix_ops_domain {
 	int32_t err_inject_count;
 	bool xpmem_enabled;
 };
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FI_EXT_GNI_H_ */

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -36,10 +36,6 @@
 #ifndef _GNIX_H_
 #define _GNIX_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if HAVE_CONFIG_H
 #include <config.h>
 #endif /* HAVE_CONFIG_H */
@@ -982,10 +978,6 @@ int gnix_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 #else
 #define DIRECT_FN
 #define STATIC static
-#endif
-
-#ifdef __cplusplus
-} /* extern "C" */
 #endif
 
 #endif /* _GNIX_H_ */

--- a/prov/gni/include/gnix_cntr.h
+++ b/prov/gni/include/gnix_cntr.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -33,10 +33,6 @@
 
 #ifndef _GNIX_CNTR_H_
 #define _GNIX_CNTR_H_
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <fi.h>
 
@@ -99,9 +95,5 @@ int _gnix_cntr_poll_nic_add(struct gnix_fid_cntr *cntr, struct gnix_nic *nic);
  * @return             FI_SUCCESS on success, -FI_EINVAL on invalid argument
  */
 int _gnix_cntr_poll_nic_rem(struct gnix_fid_cntr *cntr, struct gnix_nic *nic);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/prov/gni/include/gnix_cq.h
+++ b/prov/gni/include/gnix_cq.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -33,10 +33,6 @@
 
 #ifndef _GNIX_CQ_H_
 #define _GNIX_CQ_H_
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <fi.h>
 
@@ -94,9 +90,5 @@ ssize_t _gnix_cq_add_error(struct gnix_fid_cq *cq, void *op_context,
 
 int _gnix_cq_poll_nic_add(struct gnix_fid_cq *cq, struct gnix_nic *nic);
 int _gnix_cq_poll_nic_rem(struct gnix_fid_cq *cq, struct gnix_nic *nic);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/prov/gni/include/gnix_datagram.h
+++ b/prov/gni/include/gnix_datagram.h
@@ -34,10 +34,6 @@
 #ifndef _GNIX_DATAGRAM_H_
 #define _GNIX_DATAGRAM_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "gnix.h"
 
 /*
@@ -336,9 +332,5 @@ int _gnix_dgram_rewind_buf(struct gnix_datagram *d, enum gnix_dgram_buf);
 int _gnix_dgram_poll(struct gnix_dgram_hndl *hndl_ptr,
 			enum gnix_dgram_poll_type type);
 
-
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
 
 #endif /* _GNIX_DATAGRAM_H_ */

--- a/prov/gni/include/gnix_eq.h
+++ b/prov/gni/include/gnix_eq.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -33,10 +33,6 @@
 
 #ifndef _GNIX_EQ_H_
 #define _GNIX_EQ_H_
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <rdma/fi_eq.h>
 
@@ -86,9 +82,5 @@ struct gnix_fid_eq {
 	fastlock_t lock;
 	struct gnix_reference ref_cnt;
 };
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* _GNIX_EQ_H_ */

--- a/prov/gni/include/gnix_freelist.h
+++ b/prov/gni/include/gnix_freelist.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -33,10 +33,6 @@
 
 #ifndef _GNIX_FREELIST_H_
 #define _GNIX_FREELIST_H_
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <fi.h>
 #include <fi_list.h>
@@ -130,9 +126,5 @@ static inline int _gnix_fl_empty(struct gnix_freelist *fl)
 {
 	return dlist_empty(&fl->freelist);
 }
-
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
 
 #endif /* _GNIX_FREELIST_H_ */

--- a/prov/gni/include/gnix_mbox_allocator.h
+++ b/prov/gni/include/gnix_mbox_allocator.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -33,10 +33,6 @@
 
 #ifndef _GNIX_MBOX_ALLOCATOR_
 #define _GNIX_MBOX_ALLOCATOR_
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <stddef.h>
 
@@ -193,9 +189,5 @@ int _gnix_mbox_free(struct gnix_mbox *ptr);
  * hugepages.
  */
 extern atomic_t file_id_counter;
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* _GNIX_MBOX_ALLOCATOR_ */

--- a/prov/gni/include/gnix_nameserver.h
+++ b/prov/gni/include/gnix_nameserver.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -34,10 +34,6 @@
 #ifndef _GNIX_NAMESERVER_H_
 #define _GNIX_NAMESERVER_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "gnix.h"
 
 /*
@@ -51,9 +47,5 @@ extern "C" {
 int gnix_resolve_name(IN const char *node, IN const char *service,
 		      IN uint64_t flags, INOUT struct gnix_ep_name
 		      *resolved_addr);
-
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
 
 #endif /* _GNIX_NAMESERVER_H_ */

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -34,10 +34,6 @@
 #ifndef _GNIX_NIC_H_
 #define _GNIX_NIC_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if HAVE_CONFIG_H
 #include <config.h>
 #endif /* HAVE_CONFIG_H */
@@ -465,9 +461,5 @@ static inline void *__gnix_nic_elem_by_rem_id(struct gnix_nic *nic, int rem_id)
 
 void _gnix_nic_txd_err_inject(struct gnix_nic *nic,
 			      struct gnix_tx_descriptor *txd);
-
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
 
 #endif /* _GNIX_NIC_H_ */

--- a/prov/gni/include/gnix_poll.h
+++ b/prov/gni/include/gnix_poll.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All
- * rights reserved.
+ * Copyright (c) 2016 Cray Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -33,10 +33,6 @@
 
 #ifndef _GNIX_POLL_H_
 #define _GNIX_POLL_H_
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /*******************************************************************************
  * API Functions
@@ -86,9 +82,5 @@ int gnix_poll_del(struct fid_poll *pollset, struct fid *event_fid,
 /*******************************************************************************
  * Exposed internal functions.
  ******************************************************************************/
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* _GNIX_POLL_H_ */

--- a/prov/gni/include/gnix_queue.h
+++ b/prov/gni/include/gnix_queue.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2016 Cray Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -33,10 +34,6 @@
 #ifndef _GNIX_QUEUE_H
 #define _GNIX_QUEUE_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <fi_list.h>
 
 typedef struct slist_entry *(*alloc_func)(size_t entry_size);
@@ -66,9 +63,5 @@ struct slist_entry *_gnix_queue_dequeue_free(struct gnix_queue *queue);
 void _gnix_queue_enqueue(struct gnix_queue *queue, struct slist_entry *item);
 void _gnix_queue_enqueue_free(struct gnix_queue *queue,
 			      struct slist_entry *item);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* #define _GNIX_QUEUE_H */

--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -34,10 +34,6 @@
 #ifndef _GNIX_VC_H_
 #define _GNIX_VC_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if HAVE_CONFIG_H
 #include <config.h>
 #endif /* HAVE_CONFIG_H */
@@ -345,5 +341,6 @@ static inline enum gnix_vc_conn_state _gnix_vc_state(struct gnix_vc *vc)
 	assert(vc);
 	return vc->conn_state;
 }
+
 
 #endif /* _GNIX_VC_H_ */

--- a/prov/gni/include/gnix_wait.h
+++ b/prov/gni/include/gnix_wait.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2016 Cray Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -32,10 +33,6 @@
 
 #ifndef _GNIX_WAIT_H_
 #define _GNIX_WAIT_H_
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <pthread.h>
 #include <rdma/fi_eq.h>
@@ -86,9 +83,5 @@ int _gnix_wait_set_add(struct fid_wait *wait, struct fid *wait_obj);
 int _gnix_wait_set_remove(struct fid_wait *wait, struct fid *wait_obj);
 int _gnix_get_wait_obj(struct fid_wait *wait, void *arg);
 void _gnix_signal_wait_obj(struct fid_wait *wait);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif


### PR DESCRIPTION
- Add closing brace for extern C block in fi_ext_gni.h
- Include fi_atomic.h for enum definition in fi_ext_gni.h
- Remove unnecessary extern blocks for other GNI provider headers

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com

Fixes #949 

@hppritcha @sdvormwa
