### PR TITLE
prov/gni: Return -FI_ENOSYS when opening a CQ or counter with a a wait object

### DIFF
--- a/prov/gni/src/gnix_cntr.c
+++ b/prov/gni/src/gnix_cntr.c
@@ -75,7 +75,7 @@ static int __verify_cntr_attr(struct fi_cntr_attr *attr)
 
 	/* TODO: Wait objects are not yet implemented. */
 	if (attr->wait_obj != FI_WAIT_NONE) {
-		return -FI_EINVAL;
+		return -FI_ENOSYS;
 	}
 
 	switch (attr->wait_obj) {

--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -160,7 +160,7 @@ static int verify_cq_attr(struct fi_cq_attr *attr, struct fi_ops_cq *ops,
 
 	/* TODO: Wait objects are not yet implemented. */
 	if (attr->wait_obj != FI_WAIT_NONE) {
-		return -FI_EINVAL;
+		return -FI_ENOSYS;
 	}
 
 	switch (attr->wait_obj) {


### PR DESCRIPTION
Closes #1001 

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com

@ztiffany 
