### PR TITLE
prov/gni: various shutdown related fixes

### DIFF
--- a/prov/gni/include/gnix_bitmap.h
+++ b/prov/gni/include/gnix_bitmap.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2016 Los Alamos National Security, LLC. All rights reserved.
  *
  *  Created on: Apr 16, 2015
  *      Author: jswaro
@@ -26,16 +27,7 @@
 
 typedef uint64_t gnix_bitmap_value_t;
 
-#ifdef HAVE_ATOMICS
-#include <stdatomic.h>
-
 typedef atomic_uint_fast64_t gnix_bitmap_block_t;
-#else
-typedef struct atomic_uint64_t {
-	fastlock_t lock;
-	gnix_bitmap_value_t val;
-} gnix_bitmap_block_t;
-#endif
 
 typedef enum gnix_bitmap_state {
 	GNIX_BITMAP_STATE_UNINITIALIZED = 0,

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -173,6 +173,8 @@ struct gnix_nic {
 	struct dlist_entry work_vcs;
 	fastlock_t tx_vc_lock;
 	struct dlist_entry tx_vcs;
+¬       /* note this free list will be initialized for thread safe */
+¬       struct gnix_freelist vc_freelist;
 	uint8_t ptag;
 	uint32_t cookie;
 	uint32_t device_id;

--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -111,7 +111,7 @@ enum gnix_vc_conn_req_type {
  * @var peer_id              vc_id of peer.
  * @var modes                Used internally to track current state of
  *                           the VC not pertaining to the connection state.
- * @var flags                Bitmap used to hold vc schedule state
+ * @var flags                field used to hold vc schedule state
  * @var peer_irq_mem_hndl    peer GNI memhndl used for delivering
  *                           GNI_PostCqWrite requests to remote peer
  */
@@ -140,7 +140,7 @@ struct gnix_vc {
 	int vc_id;
 	int peer_id;
 	int modes;
-	gnix_bitmap_t flags; /* We're missing regular bit ops */
+	uint64_t flags;
 	gni_mem_handle_t peer_irq_mem_hndl;
 	xpmem_apid_t peer_apid;
 	uint64_t peer_caps;

--- a/prov/gni/src/gnix_cm_nic.c
+++ b/prov/gni/src/gnix_cm_nic.c
@@ -330,8 +330,10 @@ static void  __cm_nic_destruct(void *obj)
 		cm_nic->addr_to_ep_ht = NULL;
 	}
 
-	if (cm_nic->nic != NULL)
+	if (cm_nic->nic != NULL) {
 		_gnix_ref_put(cm_nic->nic);
+		cm_nic->nic = NULL;
+	}
 
 	free(cm_nic);
 }

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -43,6 +43,7 @@
 #include "gnix_nic.h"
 #include "gnix_util.h"
 #include "gnix_xpmem.h"
+#include "gnix_vc.h"
 
 gni_cq_mode_t gnix_def_gni_cq_modes = GNI_CQ_PHYS_PAGES;
 

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -333,30 +333,39 @@ static int __process_rx_cqe(struct gnix_nic *nic, gni_cq_entry_t cqe)
 	struct gnix_vc *vc;
 
 	vc_id =  GNI_CQ_GET_INST_ID(cqe);
+
+	/*
+	 * its possible this vc has been destroyed, so may get NULL
+	 * back.
+	 */
+
 	vc = __gnix_nic_elem_by_rem_id(nic, vc_id);
+	if (vc != NULL) {
 
 #if 1 /* Process RX inline with arrival of an RX CQE. */
-	if (unlikely(vc->conn_state != GNIX_VC_CONNECTED)) {
-		GNIX_DEBUG(FI_LOG_EP_DATA,
-			  "Scheduling VC for RX processing (%p)\n",
-			  vc);
-		ret = _gnix_vc_rx_schedule(vc);
-		assert(ret == FI_SUCCESS);
-	} else {
-		GNIX_DEBUG(FI_LOG_EP_DATA,
-			  "Processing VC RX (%p)\n",
-			  vc);
-		ret = _gnix_vc_dequeue_smsg(vc);
-		if (ret != FI_SUCCESS) {
-			GNIX_WARN(FI_LOG_EP_DATA,
+		if (unlikely(vc->conn_state != GNIX_VC_CONNECTED)) {
+			GNIX_DEBUG(FI_LOG_EP_DATA,
+				  "Scheduling VC for RX processing (%p)\n",
+				  vc);
+			ret = _gnix_vc_rx_schedule(vc);
+			assert(ret == FI_SUCCESS);
+		} else {
+			GNIX_DEBUG(FI_LOG_EP_DATA,
+				  "Processing VC RX (%p)\n",
+				  vc);
+			ret = _gnix_vc_dequeue_smsg(vc);
+			if (ret != FI_SUCCESS) {
+				GNIX_WARN(FI_LOG_EP_DATA,
 					"_gnix_vc_dqueue_smsg returned %d\n",
-					ret);
+						ret);
+			}
 		}
 	}
 #else /* Defer RX processing until after the RX CQ is cleared. */
 	ret = _gnix_vc_rx_schedule(vc);
 	assert(ret == FI_SUCCESS);
 #endif
+	}
 
 	return ret;
 }
@@ -898,6 +907,12 @@ static void __nic_destruct(void *obj)
 	}
 
 	/*
+	 * destroy VC free list associated with this nic
+	 */
+
+	_gnix_fl_destroy(&nic->vc_freelist);
+
+	/*
 	 * remove the nic from the linked lists
 	 * for the domain and the global nic list
 	 */
@@ -945,6 +960,7 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 	struct gnix_nic_attr *nic_attr = &default_attr;
 	uint32_t num_corespec_cpus = 0;
 	bool must_alloc_nic = false;
+	bool free_list_inited = false;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
@@ -1155,6 +1171,25 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 		}
 		fastlock_init(&nic->vc_id_lock);
 
+		/*
+		 * initialize free list for VC's
+		 */
+
+		ret = _gnix_fl_init_ts(sizeof(struct gnix_vc),
+				       offsetof(struct gnix_vc, list),
+				       128,
+				       0,
+				       0,
+				       0,
+				       &nic->vc_freelist);
+		if (ret == FI_SUCCESS) {
+			free_list_inited = true;
+		} else {
+			GNIX_DEBUG(FI_LOG_EP_DATA, "_gnix_fl_init returned: %s\n",
+				   fi_strerror(-ret));
+			goto err1;
+		}
+
 		fastlock_init(&nic->lock);
 
 		ret = __gnix_nic_tx_freelist_init(nic,
@@ -1328,6 +1363,8 @@ err:
 		if ((nic->gni_cdm_hndl != NULL) && (nic->allocd_gni_res &
 		    GNIX_NIC_CDM_ALLOCD))
 			GNI_CdmDestroy(nic->gni_cdm_hndl);
+		if (free_list_inited == true)
+			_gnix_fl_destroy(&nic->vc_freelist);
 		free(nic);
 	}
 

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -53,6 +53,14 @@
 #include "gnix_trigger.h"
 #include "gnix_vector.h"
 #include "gnix_xpmem.h"
+#include "gnix_freelist.h"
+
+#define __gnix_vc_set_bit(flags, bit) \
+	atomic_fetch_or((flags), (1UL << (bit)))
+#define __gnix_vc_test_and_set_bit(flags, bit) \
+	(__gnix_vc_set_bit(flags, bit) & (1UL << (bit)))
+#define __gnix_vc_clear_bit(flags, bit) \
+	atomic_fetch_and((flags), ~(1UL << (bit)))
 
 /*
  * forward declarations and local struct defs.
@@ -1422,6 +1430,7 @@ int _gnix_vc_alloc(struct gnix_fid_ep *ep_priv,
 	struct gnix_vc *vc_ptr = NULL;
 	struct gnix_cm_nic *cm_nic = NULL;
 	struct gnix_nic *nic = NULL;
+	struct dlist_entry *de;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
@@ -1433,9 +1442,18 @@ int _gnix_vc_alloc(struct gnix_fid_ep *ep_priv,
 	if (cm_nic == NULL)
 		return -FI_EINVAL;
 
-	vc_ptr = calloc(1, sizeof(*vc_ptr));
-	if (!vc_ptr)
-		return -FI_ENOMEM;
+	/*
+	 * allocate VC from domain's vc_freelist
+	 */
+
+	ret = _gnix_fl_alloc(&de, &nic->vc_freelist);
+	while (ret == -FI_EAGAIN)
+		ret = _gnix_fl_alloc(&de, &nic->vc_freelist);
+	if (ret == FI_SUCCESS) {
+		vc_ptr = container_of(de, struct gnix_vc, list);
+		dlist_init(&vc_ptr->list);
+	} else
+		return ret;
 
 	vc_ptr->conn_state = GNIX_VC_CONN_NONE;
 	if (entry) {
@@ -1466,8 +1484,6 @@ int _gnix_vc_alloc(struct gnix_fid_ep *ep_priv,
 	dlist_init(&vc_ptr->list);
 
 	atomic_initialize(&vc_ptr->outstanding_tx_reqs, 0);
-	ret = _gnix_alloc_bitmap(&vc_ptr->flags, 1);
-	assert(!ret);
 
 	/*
 	 * we need an id for the vc to allow for quick lookup
@@ -1531,10 +1547,34 @@ int _gnix_vc_destroy(struct gnix_vc *vc)
 	}
 
 	/*
+	 * if send_q not empty, return -FI_EBUSY
+	 * Note for FI_EP_MSG type eps, this behavior
+	 * may not be correct for handling fi_shutdown.
+	 */
+
+	if (!dlist_empty(&vc->tx_queue)) {
+		GNIX_WARN(FI_LOG_EP_CTRL, "VC TX queue not empty\n");
+		return -FI_EBUSY;
+	}
+
+	if (atomic_get(&vc->outstanding_tx_reqs)) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			   "VC outstanding_tx_reqs out of sync: %d\n",
+			   atomic_get(&vc->outstanding_tx_reqs));
+		return -FI_EBUSY;
+	}
+
+	/*
 	 * move vc state to terminating
 	 */
 
 	vc->conn_state = GNIX_VC_CONN_TERMINATING;
+
+	ret = _gnix_nic_free_rem_id(nic, vc->vc_id);
+	if (ret != FI_SUCCESS)
+		GNIX_WARN(FI_LOG_EP_CTRL,
+		      "__gnix_vc_free_id returned %s\n",
+		      fi_strerror(-ret));
 
 	/*
 	 * try to unbind the gni_ep if non-NULL.
@@ -1588,20 +1628,6 @@ int _gnix_vc_destroy(struct gnix_vc *vc)
 	}
 	 */
 
-	/*
-	 * if send_q not empty, return -FI_EBUSY
-	 * Note for FI_EP_MSG type eps, this behavior
-	 * may not be correct for handling fi_shutdown.
-	 */
-
-	if (!dlist_empty(&vc->tx_queue))
-		GNIX_FATAL(FI_LOG_EP_CTRL, "VC TX queue not empty\n");
-
-	if (atomic_get(&vc->outstanding_tx_reqs))
-		GNIX_FATAL(FI_LOG_EP_CTRL,
-			   "VC outstanding_tx_reqs out of sync: %d\n",
-			   atomic_get(&vc->outstanding_tx_reqs));
-
 	fastlock_destroy(&vc->tx_queue_lock);
 
 	if (vc->smsg_mbox != NULL) {
@@ -1622,15 +1648,11 @@ int _gnix_vc_destroy(struct gnix_vc *vc)
 		vc->dgram = NULL;
 	}
 
-	ret = _gnix_nic_free_rem_id(nic, vc->vc_id);
-	if (ret != FI_SUCCESS)
-		GNIX_WARN(FI_LOG_EP_CTRL,
-		      "__gnix_vc_free_id returned %s\n",
-		      fi_strerror(-ret));
+	/*
+	 * put VC back on the freelist
+	 */
 
-	_gnix_free_bitmap(&vc->flags);
-
-	free(vc);
+	_gnix_fl_free(&vc->list, &nic->vc_freelist);
 
 	return ret;
 }
@@ -1754,7 +1776,8 @@ int _gnix_vc_rx_schedule(struct gnix_vc *vc)
 {
 	struct gnix_nic *nic = vc->ep->nic;
 
-	if (!_gnix_test_and_set_bit(&vc->flags, GNIX_VC_FLAG_RX_SCHEDULED)) {
+	if (!__gnix_vc_test_and_set_bit(&vc->flags,
+					GNIX_VC_FLAG_RX_SCHEDULED)) {
 		COND_ACQUIRE(nic->requires_lock, &nic->rx_vc_lock);
 		dlist_insert_tail(&vc->rx_list, &nic->rx_vcs);
 		COND_RELEASE(nic->requires_lock, &nic->rx_vc_lock);
@@ -1855,7 +1878,7 @@ static struct gnix_vc *__gnix_nic_next_pending_rx_vc(struct gnix_nic *nic)
 
 	if (vc) {
 		GNIX_INFO(FI_LOG_EP_CTRL, "Dequeued RX VC (%p)\n", vc);
-		_gnix_clear_bit(&vc->flags, GNIX_VC_FLAG_RX_SCHEDULED);
+		__gnix_vc_clear_bit(&vc->flags, GNIX_VC_FLAG_RX_SCHEDULED);
 	}
 
 	return vc;
@@ -1893,7 +1916,8 @@ static int __gnix_vc_work_schedule(struct gnix_vc *vc)
 	if (dlist_empty(&vc->work_queue))
 		return FI_SUCCESS;
 
-	if (!_gnix_test_and_set_bit(&vc->flags, GNIX_VC_FLAG_WORK_SCHEDULED)) {
+	if (!__gnix_vc_test_and_set_bit(&vc->flags,
+			GNIX_VC_FLAG_WORK_SCHEDULED)) {
 		COND_ACQUIRE(nic->requires_lock, &nic->work_vc_lock);
 		dlist_insert_tail(&vc->work_list, &nic->work_vcs);
 		COND_RELEASE(nic->requires_lock, &nic->work_vc_lock);
@@ -1987,7 +2011,7 @@ static struct gnix_vc *__gnix_nic_next_pending_work_vc(struct gnix_nic *nic)
 
 	if (vc) {
 		GNIX_INFO(FI_LOG_EP_CTRL, "Dequeued work VC (%p)\n", vc);
-		_gnix_clear_bit(&vc->flags, GNIX_VC_FLAG_WORK_SCHEDULED);
+		__gnix_vc_clear_bit(&vc->flags, GNIX_VC_FLAG_WORK_SCHEDULED);
 	}
 
 	return vc;
@@ -2022,7 +2046,8 @@ int _gnix_vc_tx_schedule(struct gnix_vc *vc)
 	if (dlist_empty(&vc->tx_queue))
 		return FI_SUCCESS;
 
-	if (!_gnix_test_and_set_bit(&vc->flags, GNIX_VC_FLAG_TX_SCHEDULED)) {
+	if (!__gnix_vc_test_and_set_bit(&vc->flags,
+			GNIX_VC_FLAG_TX_SCHEDULED)) {
 		COND_ACQUIRE(nic->requires_lock, &nic->tx_vc_lock);
 		dlist_insert_tail(&vc->tx_list, &nic->tx_vcs);
 		COND_RELEASE(nic->requires_lock, &nic->tx_vc_lock);
@@ -2224,7 +2249,7 @@ static struct gnix_vc *__gnix_nic_next_pending_tx_vc(struct gnix_nic *nic)
 
 	if (vc) {
 		GNIX_INFO(FI_LOG_EP_CTRL, "Dequeued TX VC (%p)\n", vc);
-		_gnix_clear_bit(&vc->flags, GNIX_VC_FLAG_TX_SCHEDULED);
+		__gnix_vc_clear_bit(&vc->flags, GNIX_VC_FLAG_TX_SCHEDULED);
 	}
 
 	return vc;

--- a/prov/gni/test/bitmap.c
+++ b/prov/gni/test/bitmap.c
@@ -50,34 +50,9 @@
 gnix_bitmap_t *test_bitmap = NULL;
 int call_free_bitmap = 0;
 
-#if HAVE_ATOMICS
-
 #define __gnix_set_block(bitmap, index, value) \
 	atomic_store(&(bitmap)->arr[(index)], (value))
 #define __gnix_load_block(bitmap, index) atomic_load(&(bitmap->arr[(index)]))
-#else
-static inline void __gnix_set_block(gnix_bitmap_t *bitmap, int index,
-		uint64_t value)
-{
-	gnix_bitmap_block_t *block = &bitmap->arr[index];
-
-	fastlock_acquire(&block->lock);
-	block->val = value;
-	fastlock_release(&block->lock);
-}
-
-static inline uint64_t __gnix_load_block(gnix_bitmap_t *bitmap, int index)
-{
-	gnix_bitmap_block_t *block = &bitmap->arr[index];
-	uint64_t ret;
-
-	fastlock_acquire(&block->lock);
-	ret = block->val;
-	fastlock_release(&block->lock);
-
-	return ret;
-}
-#endif
 
 void __gnix_bitmap_test_setup(void)
 {


### PR DESCRIPTION
Turns out some of the criterion tests which intentionally
do things to check for errors, etc. have a tendency to
bring out some issues in the destruction of objects within
the GNI provider when EPs, domains, etc. are closed and
there are outstanding transactions/GNI RX CQEs etc. still
outstanding.

One of the ways that these shutdowns with GNI objects still
queued up (like CQEs on GNI hw cqs) was seg faults when
a thread tried to process CQEs that were associated with a VC
that was being destroyed by another thread.  The most frequent
signature was a thread trying to access the flag field of a VC
struct in, for example _gnix_vc_rx_schedule.

Currently it is criterion tests which are trying to check edge
cases that hit these kind of problems.

In general we should probably avoid adding elements to the VC
struct which have to be accessed as part of determining VC
state,  but which may require destruction as part of the VC destructor
code.  Hence the use of a simple 8-byte field now for the flag
status member of the struct rather than a full bitmap.

@sungeunchoi 
@ztiffany 

Signed-off-by: Howard Pritchard howardp@lanl.gov
