### PR TITLE
prov/gni: various shutdown related fixes

### DIFF
--- a/prov/gni/include/gnix_bitmap.h
+++ b/prov/gni/include/gnix_bitmap.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2016 Los Alamos National Security, LLC. All rights reserved.
  *
  *  Created on: Apr 16, 2015
  *      Author: jswaro
@@ -26,16 +27,7 @@
 
 typedef uint64_t gnix_bitmap_value_t;
 
-#ifdef HAVE_ATOMICS
-#include <stdatomic.h>
-
 typedef atomic_uint_fast64_t gnix_bitmap_block_t;
-#else
-typedef struct atomic_uint64_t {
-	fastlock_t lock;
-	gnix_bitmap_value_t val;
-} gnix_bitmap_block_t;
-#endif
 
 typedef enum gnix_bitmap_state {
 	GNIX_BITMAP_STATE_UNINITIALIZED = 0,

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -173,6 +173,8 @@ struct gnix_nic {
 	struct dlist_entry work_vcs;
 	fastlock_t tx_vc_lock;
 	struct dlist_entry tx_vcs;
+	/* note this free list will be initialized for thread safe */
+	struct gnix_freelist vc_freelist;
 	uint8_t ptag;
 	uint32_t cookie;
 	uint32_t device_id;

--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -89,6 +89,8 @@ enum gnix_vc_conn_req_type {
  * @var tx_queue             TX request queue
  * @var tx_queue_lock        TX request queue lock
  * @var tx_list              NIC TX VC list
+ * @var list                 used for unmapped vc list
+ * @var fr_list              used for vc free list
  * @var entry                used internally for managing linked lists
  *                           of vc structs that require O(1) insertion/removal
  * @var peer_fi_addr         FI address of peer with which this VC is connected
@@ -111,7 +113,7 @@ enum gnix_vc_conn_req_type {
  * @var peer_id              vc_id of peer.
  * @var modes                Used internally to track current state of
  *                           the VC not pertaining to the connection state.
- * @var flags                Bitmap used to hold vc schedule state
+ * @var flags                field used to hold vc schedule state
  * @var peer_irq_mem_hndl    peer GNI memhndl used for delivering
  *                           GNI_PostCqWrite requests to remote peer
  */
@@ -127,6 +129,7 @@ struct gnix_vc {
 	struct dlist_entry tx_list;	/* TX VC list entry */
 
 	struct dlist_entry list;	/* General purpose list */
+	struct dlist_entry fr_list;	/* fr list */
 	fi_addr_t peer_fi_addr;
 	struct gnix_address peer_addr;
 	struct gnix_address peer_cm_nic_addr;
@@ -140,7 +143,7 @@ struct gnix_vc {
 	int vc_id;
 	int peer_id;
 	int modes;
-	gnix_bitmap_t flags; /* We're missing regular bit ops */
+	uint64_t flags;
 	gni_mem_handle_t peer_irq_mem_hndl;
 	xpmem_apid_t peer_apid;
 	uint64_t peer_caps;

--- a/prov/gni/src/gnix_cm_nic.c
+++ b/prov/gni/src/gnix_cm_nic.c
@@ -330,8 +330,10 @@ static void  __cm_nic_destruct(void *obj)
 		cm_nic->addr_to_ep_ht = NULL;
 	}
 
-	if (cm_nic->nic != NULL)
+	if (cm_nic->nic != NULL) {
 		_gnix_ref_put(cm_nic->nic);
+		cm_nic->nic = NULL;
+	}
 
 	free(cm_nic);
 }

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -44,6 +44,11 @@
 #include "gnix_vc.h"
 #include "gnix_mbox_allocator.h"
 
+/*
+ * TODO: make this a domain parameter
+ */
+#define GNIX_VC_FL_MIN_SIZE 128
+
 static int gnix_nics_per_ptag[GNI_PTAG_USER_END];
 static DLIST_HEAD(gnix_nic_list);
 static pthread_mutex_t gnix_nic_list_lock = PTHREAD_MUTEX_INITIALIZER;
@@ -333,30 +338,38 @@ static int __process_rx_cqe(struct gnix_nic *nic, gni_cq_entry_t cqe)
 	struct gnix_vc *vc;
 
 	vc_id =  GNI_CQ_GET_INST_ID(cqe);
+
+	/*
+	 * its possible this vc has been destroyed, so may get NULL
+	 * back.
+	 */
+
 	vc = __gnix_nic_elem_by_rem_id(nic, vc_id);
+	if (vc != NULL) {
 
 #if 1 /* Process RX inline with arrival of an RX CQE. */
-	if (unlikely(vc->conn_state != GNIX_VC_CONNECTED)) {
-		GNIX_DEBUG(FI_LOG_EP_DATA,
-			  "Scheduling VC for RX processing (%p)\n",
-			  vc);
+		if (unlikely(vc->conn_state != GNIX_VC_CONNECTED)) {
+			GNIX_DEBUG(FI_LOG_EP_DATA,
+				  "Scheduling VC for RX processing (%p)\n",
+				  vc);
+			ret = _gnix_vc_rx_schedule(vc);
+			assert(ret == FI_SUCCESS);
+		} else {
+			GNIX_DEBUG(FI_LOG_EP_DATA,
+				  "Processing VC RX (%p)\n",
+				  vc);
+			ret = _gnix_vc_dequeue_smsg(vc);
+			if (ret != FI_SUCCESS) {
+				GNIX_WARN(FI_LOG_EP_DATA,
+					"_gnix_vc_dqueue_smsg returned %d\n",
+						ret);
+			}
+		}
+#else /* Defer RX processing until after the RX CQ is cleared. */
 		ret = _gnix_vc_rx_schedule(vc);
 		assert(ret == FI_SUCCESS);
-	} else {
-		GNIX_DEBUG(FI_LOG_EP_DATA,
-			  "Processing VC RX (%p)\n",
-			  vc);
-		ret = _gnix_vc_dequeue_smsg(vc);
-		if (ret != FI_SUCCESS) {
-			GNIX_WARN(FI_LOG_EP_DATA,
-					"_gnix_vc_dqueue_smsg returned %d\n",
-					ret);
-		}
-	}
-#else /* Defer RX processing until after the RX CQ is cleared. */
-	ret = _gnix_vc_rx_schedule(vc);
-	assert(ret == FI_SUCCESS);
 #endif
+	}
 
 	return ret;
 }
@@ -898,6 +911,12 @@ static void __nic_destruct(void *obj)
 	}
 
 	/*
+	 * destroy VC free list associated with this nic
+	 */
+
+	_gnix_fl_destroy(&nic->vc_freelist);
+
+	/*
 	 * remove the nic from the linked lists
 	 * for the domain and the global nic list
 	 */
@@ -945,6 +964,7 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 	struct gnix_nic_attr *nic_attr = &default_attr;
 	uint32_t num_corespec_cpus = 0;
 	bool must_alloc_nic = false;
+	bool free_list_inited = false;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
@@ -1155,6 +1175,25 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 		}
 		fastlock_init(&nic->vc_id_lock);
 
+		/*
+		 * initialize free list for VC's
+		 */
+
+		ret = _gnix_fl_init_ts(sizeof(struct gnix_vc),
+				       offsetof(struct gnix_vc, fr_list),
+				       GNIX_VC_FL_MIN_SIZE,
+				       0,
+				       0,
+				       0,
+				       &nic->vc_freelist);
+		if (ret == FI_SUCCESS) {
+			free_list_inited = true;
+		} else {
+			GNIX_DEBUG(FI_LOG_EP_DATA, "_gnix_fl_init returned: %s\n",
+				   fi_strerror(-ret));
+			goto err1;
+		}
+
 		fastlock_init(&nic->lock);
 
 		ret = __gnix_nic_tx_freelist_init(nic,
@@ -1328,6 +1367,8 @@ err:
 		if ((nic->gni_cdm_hndl != NULL) && (nic->allocd_gni_res &
 		    GNIX_NIC_CDM_ALLOCD))
 			GNI_CdmDestroy(nic->gni_cdm_hndl);
+		if (free_list_inited == true)
+			_gnix_fl_destroy(&nic->vc_freelist);
 		free(nic);
 	}
 

--- a/prov/gni/test/bitmap.c
+++ b/prov/gni/test/bitmap.c
@@ -50,34 +50,9 @@
 gnix_bitmap_t *test_bitmap = NULL;
 int call_free_bitmap = 0;
 
-#if HAVE_ATOMICS
-
 #define __gnix_set_block(bitmap, index, value) \
 	atomic_store(&(bitmap)->arr[(index)], (value))
 #define __gnix_load_block(bitmap, index) atomic_load(&(bitmap->arr[(index)]))
-#else
-static inline void __gnix_set_block(gnix_bitmap_t *bitmap, int index,
-		uint64_t value)
-{
-	gnix_bitmap_block_t *block = &bitmap->arr[index];
-
-	fastlock_acquire(&block->lock);
-	block->val = value;
-	fastlock_release(&block->lock);
-}
-
-static inline uint64_t __gnix_load_block(gnix_bitmap_t *bitmap, int index)
-{
-	gnix_bitmap_block_t *block = &bitmap->arr[index];
-	uint64_t ret;
-
-	fastlock_acquire(&block->lock);
-	ret = block->val;
-	fastlock_release(&block->lock);
-
-	return ret;
-}
-#endif
 
 void __gnix_bitmap_test_setup(void)
 {


### PR DESCRIPTION
Turns out some of the criterion tests which intentionally
do things to check for errors, etc. have a tendency to
bring out some issues in the destruction of objects within
the GNI provider when EPs, domains, etc. are closed and
there are outstanding transactions/GNI RX CQEs etc. still
outstanding.

One of the ways that these shutdowns with GNI objects still
queued up (like CQEs on GNI hw cqs) would seg fault when
a thread tried to process CQEs that were associated with a VC
that was being destroyed by another thread.  The most frequent
signature was a thread trying to access the flag field of a VC
struct in, for example _gnix_vc_rx_schedule.

Currently it is criterion tests which are trying to check edge
cases that hit these kind of problems.
@sungeunchoi 
@ztiffany 

use a nic based freelist for vc's

Signed-off-by: Howard Pritchard howardp@lanl.gov
