### PR TITLE
prov/gni: Documentation cleanup part 1

### DIFF
--- a/prov/gni/src/gnix_av.c
+++ b/prov/gni/src/gnix_av.c
@@ -45,7 +45,7 @@
 #include "gnix_av.h"
 
 /*
- * local variables and structs
+ * local variables and structures
  */
 
 #define GNIX_AV_ENTRY_VALID		(1ULL)

--- a/prov/gni/src/gnix_buddy_allocator.c
+++ b/prov/gni/src/gnix_buddy_allocator.c
@@ -34,7 +34,7 @@
 
 /*
  * The buddy allocator splits the "base" block being managed into smaller
- * blocks.  Each block is a "power-of-two length".  These subblocks are kept
+ * blocks.  Each block is a "power-of-two length".  These sub-blocks are kept
  * track of in a doubly linked list, or free list.  Here are the structures
  * and format of the data structures used in the buddy allocator.  For
  * a description of each field please see gnix_buddy_allocator.h.


### PR DESCRIPTION
Fixed several spelling issues and general documentation issues in the following files:
	gnix_av.c
	gnix_buddy_allocator.c

Signed-off-by: James Swaro <jswaro@cray.com>

@sungeunchoi 