### PR TITLE
prov/gni: Documentation cleanup part 2

### DIFF
--- a/prov/gni/src/gnix_cm_nic.c
+++ b/prov/gni/src/gnix_cm_nic.c
@@ -158,8 +158,8 @@ static int __process_datagram(struct gnix_datagram *dgram,
 	}
 
 	/*
-	 * if we are processing a WC datagram, repost, otherwise
-	 * just put back on the freelist.
+	 * if we are processing a WC datagram, re-post, otherwise
+	 * just put back on the free list.
 	 */
 	if (in_tag == GNIX_CM_NIC_WC_TAG) {
 		dgram->callback_fn = __process_datagram;

--- a/prov/gni/src/gnix_datagram.c
+++ b/prov/gni/src/gnix_datagram.c
@@ -505,7 +505,7 @@ int  _gnix_dgram_poll(struct gnix_dgram_hndl *hndl,
 
 		/*
 		 * pass COMPLETED and error post state cases to
-		 * callback function if present.  If a callback funciton
+		 * callback function if present.  If a callback function
 		 * is not present, the error states set ret to -FI_EIO.
 		 *
 		 * TODO should we also pass pending,remote_data states to
@@ -673,7 +673,7 @@ int _gnix_dgram_hndl_alloc(const struct gnix_fid_fabric *fabric,
 				     (void *)the_hndl);
 		if (ret) {
 			GNIX_WARN(FI_LOG_EP_CTRL,
-			"pthread_ceate  call returned %d\n", ret);
+			"pthread_create  call returned %d\n", ret);
 			goto err1;
 		}
 	}

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -913,7 +913,7 @@ DIRECT_FN STATIC ssize_t gnix_ep_tsenddata(struct fid_ep *ep, const void *buf,
  * @param[in] buf	the data to send
  * @param[in] len	the length of buf
  * @param[in] data	remote CQ data to transfer with the data from buf
- * @param[in] dest_addr	the desitnation address for connectionless transfers
+ * @param[in] dest_addr	the destination address for connection-less transfers
  * @param[in] tag	the tag associated with the message
  *
  * @return FI_SUCCESS	upon successfully writing to the destination
@@ -2081,7 +2081,7 @@ err:
 	err_ret = __destruct_tag_storages(ep_priv);
 	if (err_ret != FI_SUCCESS) {
 		GNIX_WARN(FI_LOG_EP_CTRL,
-			  "__destruct_tag_stroages returned %s\n",
+			  "__destruct_tag_storages returned %s\n",
 			  fi_strerror(-err_ret));
 	}
 


### PR DESCRIPTION
Fixed several spelling issues and general documentation issues in the following files:
gnix_cm_nic.c
gnix_datagram.c
gnix_ep.c

Signed-off-by: James Swaro <jswaro@cray.com>

@sungeunchoi 