### PR TITLE
prov/gni: Documentation cleanup part 3

### DIFF
--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -511,7 +511,7 @@ err:
 	/*
 	 *  for the getinfo method, we need to return -FI_ENODATA  otherwise
 	 *  the fi_getinfo call will make an early exit without querying
-	 *  other providers which may be avaialble.
+	 *  other providers which may be available.
 	 */
 	return -FI_ENODATA;
 }
@@ -549,7 +549,7 @@ GNI_INI
 	assert(num_devices == 1);
 
 	/*
-	 * don't register if available ugni is older than one libfabric was
+	 * don't register if available uGNI is older than one libfabric was
 	 * built against
 	 */
 	status = GNI_GetVersionInformation(&lib_version);
@@ -581,7 +581,7 @@ GNI_INI
 
 	if (gnix_max_nics_per_ptag == 0) {
 		gnix_max_nics_per_ptag = 1;
-		GNIX_WARN(FI_LOG_FABRIC, "Using inter-procss FMA sharing\n");
+		GNIX_WARN(FI_LOG_FABRIC, "Using inter-process FMA sharing\n");
 	}
 
 	return (provider);

--- a/prov/gni/src/gnix_freelist.c
+++ b/prov/gni/src/gnix_freelist.c
@@ -183,7 +183,7 @@ int _gnix_fl_alloc(struct dlist_entry **e, struct gnix_freelist *fl)
 		}
 
 		if (dlist_empty(&fl->freelist)) {
-			/* Can't happen unless multithreaded */
+			/* Can't happen unless multi-threaded */
 			ret = -FI_EAGAIN;
 			goto err;
 		}

--- a/prov/gni/src/gnix_hashtable.c
+++ b/prov/gni/src/gnix_hashtable.c
@@ -47,7 +47,7 @@
 
 /*
  * __gnix_ht_lf* prefixes denote lock free version of functions intended for
- *   use with hashtables that had attr->ht_internal_locking set to zero
+ *   use with hash tables that had attr->ht_internal_locking set to zero
  *   during initialization
  *
  * __gnix_ht_lk* prefixes denote locking versions of functions intended for


### PR DESCRIPTION
Fixed several spelling issues and general documentation issues in the following files:
gnix_fabric.
gnix_freelist.c
gnix_hashtable.c

Signed-off-by: James Swaro <jswaro@cray.com>

@sungeunchoi 