### PR TITLE
prov/gni: return immediately when timeout set to 0

### DIFF
--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -541,7 +541,7 @@ DIRECT_FN STATIC ssize_t gnix_cq_sreadfrom(struct fid_cq *cq, void *buf,
 	int ret;
 
 	ret = gnix_cq_readfrom(cq, buf, count, NULL);
-	if (ret != -FI_EAGAIN)
+	if (ret != -FI_EAGAIN || timeout == 0)
 		return ret;
 
 	if (timeout > 0)


### PR DESCRIPTION
When gnix_cq_sreadfrom runs with a timeout of 0 we don't want
to sleep for 1 ms just to then return. Just return immediately
so the upper layer can decide how fast it wants to poll the cq.

Fixes #1026

Signed-off-by: James Shimek <jshimek@cray.com>

@sungeunchoi @hppritcha @jswaro 