### PR TITLE
prov/gni: Implement support for fi_wait

### DIFF
--- a/prov/gni/include/fi_ext_gni.h
+++ b/prov/gni/include/fi_ext_gni.h
@@ -74,6 +74,12 @@ typedef enum ep_ops_val {
 	GNI_NUM_EP_OPS,
 } ep_ops_val_t;
 
+#define FI_GNI_FAB_OPS_1 "fab ops 1"
+typedef enum fab_ops_val {
+	GNI_WAIT_THREAD_SLEEP = 0,
+	GNI_NUM_FAB_OPS,
+} fab_ops_val_t;
+
 /* per domain gni provider specific ops */
 struct fi_gni_ops_domain {
 	int (*set_val)(struct fid *fid, dom_ops_val_t t, void *val);
@@ -117,6 +123,11 @@ struct gnix_ops_domain {
 	uint32_t max_retransmits;
 	int32_t err_inject_count;
 	bool xpmem_enabled;
+};
+
+struct fi_gni_ops_fab {
+	int (*set_val)(struct fid *fid, fab_ops_val_t t, void *val);
+	int (*get_val)(struct fid *fid, fab_ops_val_t t, void *val);
 };
 
 #ifdef __cplusplus

--- a/prov/gni/include/gnix_eq.h
+++ b/prov/gni/include/gnix_eq.h
@@ -43,10 +43,15 @@
 
 #define GNIX_EQ_DEFAULT_SIZE 256
 
+extern struct dlist_entry gnix_eq_list;
+extern pthread_mutex_t gnix_eq_list_lock;
+
 ssize_t _gnix_eq_write_error(struct fid_eq *eq, fid_t fid,
 			     void *context, uint64_t index, int err,
 			     int prov_errno, void *err_data,
 			     size_t err_size);
+
+int _gnix_eq_progress(struct gnix_fid_eq *eq);
 
 /*
  * Stores events inside of the event queue.
@@ -92,6 +97,7 @@ struct gnix_fid_eq {
 
 	rwlock_t poll_obj_lock;
 	struct dlist_entry poll_objs;
+	struct dlist_entry gnix_fid_eq_list;
 };
 
 int _gnix_eq_poll_obj_add(struct gnix_fid_eq *eq, struct fid *obj_fid);

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -48,7 +48,8 @@
 #define GNIX_DEF_MAX_NICS_PER_PTAG	4
 
 extern uint32_t gnix_max_nics_per_ptag;
-
+extern struct dlist_entry gnix_nic_list;
+extern pthread_mutex_t gnix_nic_list_lock;
 /*
  * allocation flags for cleaning up GNI resources
  * when closing a gnix_nic - needed since these

--- a/prov/gni/include/gnix_wait.h
+++ b/prov/gni/include/gnix_wait.h
@@ -68,6 +68,8 @@ struct gnix_fid_wait {
 	struct slist set;
 };
 
+extern uint32_t gnix_wait_thread_sleep_time;
+
 /*
  * API Functions
  */

--- a/prov/gni/src/gnix_cm.c
+++ b/prov/gni/src/gnix_cm.c
@@ -368,6 +368,10 @@ DIRECT_FN STATIC int gnix_connect(struct fid_ep *ep, const void *addr,
 		ret = -FI_EIO;
 		goto err_write;
 	}
+	/* set fd to non-blocking now since we can't block within the eq
+	 * progress system
+	 */
+	fi_fd_nonblock(ep_priv->conn_fd);
 
 	COND_RELEASE(ep_priv->requires_lock, &ep_priv->vc_lock);
 

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -76,6 +76,9 @@ static int gnix_def_gni_n_dgrams = 128;
 static int gnix_def_gni_n_wc_dgrams = 4;
 static uint64_t gnix_def_gni_datagram_timeouts = -1;
 
+static struct fi_ops gnix_fab_fi_ops;
+static struct fi_gni_ops_fab gnix_ops_fab;
+
 const struct fi_fabric_attr gnix_fabric_attr = {
 	.fabric = NULL,
 	.name = NULL,
@@ -111,6 +114,17 @@ static void __fabric_destruct(void *obj)
 	free(fab);
 }
 
+static int gnix_fab_ops_open(struct fid *fid, const char *ops_name,
+				uint64_t flags, void **ops, void *context)
+{
+	if (strcmp(ops_name, FI_GNI_FAB_OPS_1) == 0)
+		*ops = &gnix_ops_fab;
+	else
+		return -FI_EINVAL;
+
+	return 0;
+}
+
 static int gnix_fabric_close(fid_t fid)
 {
 	struct gnix_fid_fabric *fab;
@@ -126,14 +140,6 @@ static int gnix_fabric_close(fid_t fid)
 
 	return FI_SUCCESS;
 }
-
-static struct fi_ops gnix_fab_fi_ops = {
-	.size = sizeof(struct fi_ops),
-	.close = gnix_fabric_close,
-	.bind = fi_no_bind,
-	.control = fi_no_control,
-	.ops_open = fi_no_ops_open,
-};
 
 /*
  * define methods needed for the GNI fabric provider
@@ -630,3 +636,68 @@ GNI_INI
 
 	return (provider);
 }
+
+static int
+__gnix_fab_ops_get_val(struct fid *fid, fab_ops_val_t t, void *val)
+{
+	GNIX_TRACE(FI_LOG_FABRIC, "\n");
+
+	assert(val);
+
+	if (fid->fclass != FI_CLASS_FABRIC) {
+		GNIX_WARN(FI_LOG_FABRIC, "Invalid fabric\n");
+		return -FI_EINVAL;
+	}
+
+	switch (t) {
+	case GNI_WAIT_THREAD_SLEEP:
+		*(uint32_t *)val = gnix_wait_thread_sleep_time;
+		break;
+	default:
+		GNIX_WARN(FI_LOG_FABRIC, ("Invalid fab_ops_val\n"));
+	}
+
+	return FI_SUCCESS;
+}
+
+static int
+__gnix_fab_ops_set_val(struct fid *fid, fab_ops_val_t t, void *val)
+{
+	int v;
+
+	assert(val);
+
+	if (fid->fclass != FI_CLASS_FABRIC) {
+		GNIX_WARN(FI_LOG_FABRIC, "Invalid fabric\n");
+		return -FI_EINVAL;
+	}
+
+	switch (t) {
+	case GNI_WAIT_THREAD_SLEEP:
+		v = *(uint32_t *) val;
+		gnix_wait_thread_sleep_time = v;
+		break;
+	default:
+		GNIX_WARN(FI_LOG_FABRIC, ("Invalid fab_ops_val\n"));
+		return -FI_EINVAL;
+	}
+
+	return FI_SUCCESS;
+}
+
+/*******************************************************************************
+ * FI_OPS_* data structures.
+ ******************************************************************************/
+
+static struct fi_gni_ops_fab gnix_ops_fab = {
+	.set_val = __gnix_fab_ops_set_val,
+	.get_val = __gnix_fab_ops_get_val
+};
+
+static struct fi_ops gnix_fab_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = gnix_fabric_close,
+	.bind = fi_no_bind,
+	.control = fi_no_control,
+	.ops_open = gnix_fab_ops_open,
+};

--- a/prov/gni/test/cntr.c
+++ b/prov/gni/test/cntr.c
@@ -78,6 +78,7 @@ static struct fid_cq *recv_cq;
 static struct fi_cq_attr cq_attr;
 static struct fid_cntr *write_cntr, *read_cntr, *rcv_cntr;
 static struct fi_cntr_attr cntr_attr = {.events = FI_CNTR_EVENTS_COMP,
+					.wait_obj = FI_WAIT_UNSPEC,
 					.flags = 0};
 
 #define BUF_SZ (64*1024)

--- a/prov/gni/test/cq.c
+++ b/prov/gni/test/cq.c
@@ -658,7 +658,7 @@ Test(check_cqe, tagged_multi_read) {
 /* This test should be combined with cq_multi_read_test above when
  * wait object are implemented.
  */
-Test(cq_msg, multi_sread, .init = cq_wait_unspec_setup, .disabled = true)
+Test(cq_msg, multi_sread, .init = cq_wait_unspec_setup, .disabled = false)
 {
 	int ret = 0;
 	size_t count = 3;
@@ -691,9 +691,9 @@ Test(cq_wait_obj, none, .init = cq_wait_none_setup)
 	cr_expect(!wait_priv, "wait_priv is not null.");
 }
 
-Test(cq_wait_obj, unspec, .init = cq_wait_unspec_setup, .disabled = true)
+Test(cq_wait_obj, unspec, .init = cq_wait_unspec_setup)
 {
-	cr_expect_eq(wait_priv->type, FI_WAIT_FD);
+	cr_expect_eq(wait_priv->type, FI_WAIT_UNSPEC);
 	cr_expect_eq(wait_priv->type, cq_priv->attr.wait_obj);
 	cr_expect_eq(wait_priv->type, cq_attr.wait_obj);
 	cr_expect_eq(&wait_priv->fabric->fab_fid, fab);
@@ -738,7 +738,8 @@ Test(cq_wait_control, unspec, .init = cq_wait_unspec_setup, .disabled = true)
 	cr_expect_eq(wait_priv->fd[WAIT_READ], fd);
 }
 
-Test(cq_wait_control, fd, .init = cq_wait_fd_setup)
+Test(cq_wait_control, fd, .init = cq_wait_fd_setup,
+	.disabled = true)
 {
 	int ret;
 	int fd;
@@ -749,7 +750,8 @@ Test(cq_wait_control, fd, .init = cq_wait_fd_setup)
 	cr_expect_eq(wait_priv->fd[WAIT_READ], fd);
 }
 
-Test(cq_wait_control, mutex_cond, .init = cq_wait_mutex_cond_setup)
+Test(cq_wait_control, mutex_cond, .init = cq_wait_mutex_cond_setup,
+	.disabled = true)
 {
 	int ret;
 	struct fi_mutex_cond mutex_cond;

--- a/prov/gni/test/eq.c
+++ b/prov/gni/test/eq.c
@@ -235,19 +235,26 @@ TestSuite(eq_wait_obj, .fini = eq_teardown);
 
 Test(eq_wait_obj, none, .init = eq_wait_none_setup)
 {
+	char out_buf[1024];
+	uint32_t out_event = 'a';
+	int ret;
+
+	ret = fi_eq_sread(eq, &out_event, &out_buf, 1024, 1, 0);
+	cr_expect_eq(ret, -FI_EINVAL);
 	cr_expect(!wait_priv, "wait_priv should be null.");
 }
 
 Test(eq_wait_obj, unspec, .init = eq_wait_unspec_setup)
 {
-	cr_expect_eq(wait_priv->type, FI_WAIT_FD);
+	cr_expect_eq(wait_priv->type, FI_WAIT_UNSPEC);
 	cr_expect_eq(wait_priv->type, eq_priv->attr.wait_obj);
 	cr_expect_eq(wait_priv->type, eq_attr.wait_obj);
 	cr_expect_eq(&wait_priv->fabric->fab_fid, fab);
 	cr_expect_eq(wait_priv->cond_type, FI_CQ_COND_NONE);
 }
 
-Test(eq_wait_obj, fd, .init = eq_wait_fd_setup)
+Test(eq_wait_obj, fd, .init = eq_wait_fd_setup,
+	.disabled =  true)
 {
 	cr_expect_eq(wait_priv->type, FI_WAIT_FD);
 	cr_expect_eq(wait_priv->type, eq_priv->attr.wait_obj);
@@ -256,7 +263,8 @@ Test(eq_wait_obj, fd, .init = eq_wait_fd_setup)
 	cr_expect_eq(wait_priv->cond_type, FI_CQ_COND_NONE);
 }
 
-Test(eq_wait_obj, mutex_cond, .init = eq_wait_mutex_cond_setup)
+Test(eq_wait_obj, mutex_cond, .init = eq_wait_mutex_cond_setup,
+	.disabled = true)
 {
 	cr_expect_eq(wait_priv->type, FI_WAIT_MUTEX_COND);
 	cr_expect_eq(wait_priv->type, eq_priv->attr.wait_obj);

--- a/prov/gni/test/wait.c
+++ b/prov/gni/test/wait.c
@@ -108,13 +108,14 @@ void mutex_cond_setup(void)
 
 Test(wait_creation, unspec, .init = unspec_setup, .fini = wait_teardown)
 {
-	cr_expect_eq(wait_priv->type, FI_WAIT_FD);
+	cr_expect_eq(wait_priv->type, FI_WAIT_UNSPEC);
 	cr_expect_eq(wait_priv->type, wait_attr.wait_obj);
 	cr_expect_eq(&wait_priv->fabric->fab_fid, fab);
 	cr_expect_eq(wait_priv->cond_type, FI_CQ_COND_NONE);
 }
 
-Test(wait_creation, fd, .init = fd_setup, .fini = wait_teardown)
+Test(wait_creation, fd, .init = fd_setup, .fini = wait_teardown,
+	.disabled = true)
 {
 	cr_expect_eq(wait_priv->type, FI_WAIT_FD);
 	cr_expect_eq(wait_priv->type, wait_attr.wait_obj);
@@ -122,7 +123,8 @@ Test(wait_creation, fd, .init = fd_setup, .fini = wait_teardown)
 	cr_expect_eq(wait_priv->cond_type, FI_CQ_COND_NONE);
 }
 
-Test(wait_creation, mutex_cond, .init = mutex_cond_setup, .fini = wait_teardown)
+Test(wait_creation, mutex_cond, .init = mutex_cond_setup, .fini = wait_teardown,
+	.disabled = true)
 {
 	cr_expect_eq(wait_priv->type, FI_WAIT_MUTEX_COND);
 	cr_expect_eq(wait_priv->type, wait_attr.wait_obj);
@@ -172,7 +174,59 @@ Test(wait_control, mutex_cond, .init = mutex_cond_setup, .fini = wait_teardown,
 	cr_expect_eq(0, ret, "cond compare failed.");
 }
 
-Test(wait_set, add, .init = fd_setup)
+Test(wait_set, signal_multi, .init = unspec_setup)
+{
+	int ret;
+	struct gnix_wait_entry *entry;
+
+	struct fid temp_wait = {
+		.fclass = FI_CLASS_CNTR
+	};
+
+	struct fid temp_wait2 = {
+		.fclass = FI_CLASS_CQ
+	};
+
+	cr_expect(slist_empty(&wait_priv->set),
+		  "wait set is not initially empty.");
+	ret = _gnix_wait_set_add(&wait_priv->wait, &temp_wait);
+
+	cr_expect_eq(FI_SUCCESS, ret, "gnix_wait_set_add failed.");
+
+	ret = _gnix_wait_set_add(&wait_priv->wait, &temp_wait2);
+	cr_expect_eq(FI_SUCCESS, ret, "gnix_wait_set_add failed.");
+
+	cr_expect(!slist_empty(&wait_priv->set),
+		  "wait set is empty after add.");
+
+	entry = container_of(wait_priv->set.head, struct gnix_wait_entry,
+			     entry);
+
+	ret = memcmp(entry->wait_obj, &temp_wait, sizeof(temp_wait));
+	cr_expect_eq(0, ret, "wait objects are not equal.");
+
+	ret = fi_close(&wait_set->fid);
+	cr_expect_eq(-FI_EBUSY, ret);
+
+	ret = _gnix_wait_set_remove(&wait_priv->wait, &temp_wait);
+
+	cr_expect_eq(FI_SUCCESS, ret, "gnix_wait_set_remove failed.");
+
+	ret = _gnix_wait_set_remove(&wait_priv->wait, &temp_wait2);
+
+	cr_expect_eq(FI_SUCCESS, ret, "gnix_wait_set_remove failed.");
+
+	ret = fi_close(&wait_set->fid);
+	cr_expect_eq(FI_SUCCESS, ret, "fi_close on wait set failed.");
+
+	ret = fi_close(&fab->fid);
+	cr_expect_eq(FI_SUCCESS, ret, "failure in closing fabric.");
+
+	fi_freeinfo(fi);
+	fi_freeinfo(hints);
+}
+
+Test(wait_set, add, .init = unspec_setup)
 {
 	int ret;
 	struct gnix_wait_entry *entry;
@@ -213,7 +267,7 @@ Test(wait_set, add, .init = fd_setup)
 	fi_freeinfo(hints);
 }
 
-Test(wait_set, empty_remove, .init = fd_setup)
+Test(wait_set, empty_remove, .init = unspec_setup)
 {
 	int ret;
 
@@ -254,4 +308,66 @@ Test(wait_verify, invalid_type, .init = wait_setup)
 	ret = fi_wait_open(fab, &wait_attr, &wait_set);
 	cr_expect_eq(-FI_EINVAL, ret,
 		     "Requesting verifications with flags set succeeded.");
+}
+
+Test(wait_signal, has_data, .init = unspec_setup)
+{
+	int ret;
+
+	struct fid temp_wait = {
+		.fclass = FI_CLASS_CQ
+	};
+
+	cr_expect(slist_empty(&wait_priv->set),
+		"error");
+	ret = _gnix_wait_set_add(&wait_priv->wait, &temp_wait);
+
+	cr_expect_eq(FI_SUCCESS, ret, "gnix_wait_set_add failed.");
+
+	cr_expect(!slist_empty(&wait_priv->set),
+		"wait set is empty after add.");
+
+	_gnix_signal_wait_obj(&wait_priv->wait);
+
+	ret = fi_wait(&wait_priv->wait, 60);
+	cr_expect_eq(FI_SUCCESS, ret, "fi_wait test failed. %d", ret);
+
+	ret = _gnix_wait_set_remove(&wait_priv->wait, &temp_wait);
+
+	ret = fi_close(&wait_set->fid);
+	cr_expect_eq(FI_SUCCESS, ret, "fi_close on wait set failed.");
+
+	ret = fi_close(&fab->fid);
+	cr_expect_eq(FI_SUCCESS, ret, "fi_close on fabric failed.");
+
+	fi_freeinfo(fi);
+	fi_freeinfo(hints);
+}
+
+Test(wait_spin_adjust, set_val, .init = unspec_setup)
+{
+	int ret;
+	int op = GNI_WAIT_THREAD_SLEEP;
+	struct fi_gni_ops_fab *gni_fabric_ops;
+	int32_t get_val, val;
+
+	ret = fi_open_ops(&fab->fid, FI_GNI_FAB_OPS_1,
+			  0, (void **) &gni_fabric_ops, NULL);
+
+	cr_assert(ret == FI_SUCCESS, "fi_open_ops");
+
+	ret = gni_fabric_ops->get_val(&fab->fid, op, &get_val);
+	cr_assert(ret == FI_SUCCESS, "get_val");
+
+	cr_expect_eq(20, get_val, "Value returned does not match default");
+
+	val = 300;
+	ret = gni_fabric_ops->set_val(&fab->fid, op, &val);
+
+	cr_assert(ret == FI_SUCCESS, "set val");
+
+	ret = gni_fabric_ops->get_val(&fab->fid, op, &get_val);
+	cr_assert(val == get_val, "get val");
+
+
 }


### PR DESCRIPTION
Add support for FI_WAIT_UNSPEC and FI_WAITSET

Created a thread infrastructure so that progression
occurs when fi_wait is used. Move fi_cq_read to utilize
fi_cq_sreadfrom so that the wait_objects are emptied
during normal cq reads.

Adjust gnix_eq_read and gnix_eq_sread to follow the
man page.

Adjust gnix_cntr_wait to follow the man page.

Allow the wait systems progression thread to have
an adjustable sleep by adding a fabric op that exposes
the variable used.

Tests to validate the fi_wait system are enabled for unspec
and disabled for the other types.

Thread start and end are based on psmx wait thread startup.
Resolves #150 
@sungeunchoi @hppritcha @chuckfossen @ztiffany 
Signed-off-by: James Shimek <jshimek@cray.com>