### PR TITLE
Fix memory leak in UDREG cases

### DIFF
--- a/prov/gni/contrib/gnitest.supp
+++ b/prov/gni/contrib/gnitest.supp
@@ -495,3 +495,35 @@
    fun:GNI_PostCqWrite
    ...
 }
+
+
+{
+   UDREG_BUG_841637_1
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:ckalloc
+   fun:avl_insert
+   ...
+}
+
+{
+   UDREG_BUG_841637_2 
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:ckalloc
+   fun:avlinit
+   fun:UDREG_CacheCreate
+   ... 
+}
+
+{
+   UDRED_BUG_841637_3 
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:UDREG_Register
+   ...
+}
+

--- a/prov/gni/src/gnix_mr.c
+++ b/prov/gni/src/gnix_mr.c
@@ -442,6 +442,8 @@ uint32_t __udreg_deregister(void *registration, void *context)
 
 	grc = __gnix_deregister_region(registration, NULL);
 
+	free(registration);
+
 	return (grc == GNI_RC_SUCCESS) ? 0 : 1;
 }
 


### PR DESCRIPTION
Added free call to the dereg function to deallocate the allocated mr.
Added suppressions to gnitest.supp to squelch warnings.

Signed-off-by: James Swaro <jswaro@cray.com>