### PR TITLE
prov/gni: fix fi_ep_enable misuse in gni tests

### DIFF
--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -1579,6 +1579,17 @@ DIRECT_FN int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 	if (ret)
 		return ret;
 
+	/*
+	 * per fi_endpoint man page, can't bind an object
+	 * to an ep after its been enabled.
+	 */
+	if ((ep->send_cq && ep->tx_enabled) ||
+		(ep->recv_cq && ep->rx_enabled)) {
+		ret = -FI_EOPBADSTATE;
+		goto err;
+	}
+
+
 	switch (bfid->fclass) {
 	case FI_CLASS_EQ:
 		ret = -FI_ENOSYS;

--- a/prov/gni/test/api.c
+++ b/prov/gni/test/api.c
@@ -168,12 +168,6 @@ void rdm_api_setup_ep(void)
 		ret = fi_ep_bind(ep[i], &av[i]->fid, 0);
 		cr_assert(!ret, "fi_ep_bind");
 
-		ret = fi_enable(ep[i]);
-		cr_assert(!ret, "fi_ep_enable");
-
-		ret = fi_enable(ep[i]);
-		cr_assert_eq(ret, -FI_EOPBADSTATE);
-
 		ret = fi_cntr_open(dom[i], &cntr_attr, send_cntr + i, 0);
 		cr_assert(!ret, "fi_cntr_open");
 
@@ -185,6 +179,14 @@ void rdm_api_setup_ep(void)
 
 		ret = fi_ep_bind(ep[i], &recv_cntr[i]->fid, FI_RECV);
 		cr_assert(!ret, "fi_ep_bind");
+
+		ret = fi_enable(ep[i]);
+		cr_assert(!ret, "fi_ep_enable");
+
+		ret = fi_enable(ep[i]);
+		cr_assert_eq(ret, -FI_EOPBADSTATE);
+
+
 	}
 
 	for (i = 0; i < NUMEPS; i++) {

--- a/prov/gni/test/rdm_atomic.c
+++ b/prov/gni/test/rdm_atomic.c
@@ -177,9 +177,6 @@ void common_atomic_setup(void)
 		ret = fi_ep_bind(ep[i], &av[i]->fid, 0);
 		cr_assert(!ret, "fi_ep_bind");
 
-		ret = fi_enable(ep[i]);
-		cr_assert(!ret, "fi_ep_enable");
-
 		ret = fi_mr_reg(dom[i], target, BUF_SZ,
 				FI_REMOTE_WRITE, 0, 0, 0, rem_mr + i, &target);
 		cr_assert_eq(ret, 0);
@@ -201,6 +198,11 @@ void common_atomic_setup(void)
 
 		ret = fi_ep_bind(ep[i], &read_cntr[i]->fid, FI_READ);
 		cr_assert(!ret, "fi_ep_bind");
+
+		if (i != 1) {
+			ret = fi_enable(ep[i]);
+			cr_assert(!ret, "fi_ep_enable");
+		}
 	}
 
 	if (hints->caps & FI_RMA_EVENT) {
@@ -215,7 +217,12 @@ void common_atomic_setup(void)
 
 		ret = fi_ep_bind(ep[1], &rread_cntr->fid, FI_REMOTE_READ);
 		cr_assert(!ret, "fi_ep_bind");
+
 	}
+
+	ret = fi_enable(ep[1]);
+	cr_assert(!ret, "fi_ep_enable");
+
 }
 
 void rdm_atomic_setup(void)

--- a/prov/gni/test/rdm_dgram_rma.c
+++ b/prov/gni/test/rdm_dgram_rma.c
@@ -239,12 +239,6 @@ void common_setup(void)
 	ret = fi_ep_bind(ep[1], &av[1]->fid, 0);
 	cr_assert(!ret, "fi_ep_bind");
 
-	ret = fi_enable(ep[0]);
-	cr_assert(!ret, "fi_ep_enable");
-
-	ret = fi_enable(ep[1]);
-	cr_assert(!ret, "fi_ep_enable");
-
 	target = malloc(BUF_SZ);
 	assert(target);
 	source = malloc(BUF_SZ);
@@ -307,6 +301,13 @@ void common_setup(void)
 		ret = fi_ep_bind(ep[1], &rread_cntr->fid, FI_REMOTE_READ);
 		cr_assert(!ret, "fi_ep_bind");
 	}
+
+	ret = fi_enable(ep[0]);
+	cr_assert(!ret, "fi_ep_enable");
+
+	ret = fi_enable(ep[1]);
+	cr_assert(!ret, "fi_ep_enable");
+
 }
 
 void rdm_rma_setup(void)

--- a/prov/gni/test/rdm_sr.c
+++ b/prov/gni/test/rdm_sr.c
@@ -194,9 +194,6 @@ void rdm_sr_setup_common_eps(void)
 		ret = fi_ep_bind(ep[i], &av[i]->fid, 0);
 		cr_assert(!ret, "fi_ep_bind");
 
-		ret = fi_enable(ep[i]);
-		cr_assert(!ret, "fi_ep_enable");
-
 		ret = fi_cntr_open(dom[i], &cntr_attr, send_cntr + i, 0);
 		cr_assert(!ret, "fi_cntr_open");
 
@@ -208,6 +205,10 @@ void rdm_sr_setup_common_eps(void)
 
 		ret = fi_ep_bind(ep[i], &recv_cntr[i]->fid, FI_RECV);
 		cr_assert(!ret, "fi_ep_bind");
+
+		ret = fi_enable(ep[i]);
+		cr_assert(!ret, "fi_ep_enable");
+
 	}
 }
 

--- a/prov/gni/test/sep.c
+++ b/prov/gni/test/sep.c
@@ -185,12 +185,12 @@ void sep_setup(void)
 					 FI_SEND);
 			cr_assert(!ret, "fi_ep_bind");
 
-			ret = fi_enable(tx_ep[i][j]);
-			cr_assert(!ret, "fi_enable");
-
 			ret = fi_ep_bind(tx_ep[i][j], &rxcq_array[i][j]->fid,
 					 FI_RECV);
 			cr_assert(!ret, "fi_ep_bind");
+
+			ret = fi_enable(tx_ep[i][j]);
+			cr_assert(!ret, "fi_enable");
 
 			ret = fi_enable(rx_ep[i][j]);
 			cr_assert(!ret, "fi_enable");


### PR DESCRIPTION
The gni criterion tests weren't obeying the rules
for fi_ep_enable as stated in the fi_endpoint man page.

Beef up check in gnix ep_bind implementation to check for
this mis-use.

@sungeunchoi 

Fixes ofi-cray/libfabric-cray#1041

Signed-off-by: Howard Pritchard <howardp@lanl.gov>