### PR TITLE
prov/gni: scalable endpoints phase 2

### DIFF
--- a/prov/gni/include/gnix_atomic.h
+++ b/prov/gni/include/gnix_atomic.h
@@ -34,6 +34,9 @@
 #ifndef _GNIX_ATOMIC_H_
 #define _GNIX_ATOMIC_H_
 
+#define GNIX_ATOMIC_WRITE_FLAGS_DEF	(FI_ATOMIC | FI_WRITE)
+#define GNIX_ATOMIC_READ_FLAGS_DEF	(FI_ATOMIC | FI_READ)
+
 int _gnix_atomic_cmd(enum fi_datatype dt, enum fi_op op,
 		     enum gnix_fab_req_type fr_type);
 ssize_t _gnix_atomic(struct gnix_fid_ep *ep,

--- a/prov/gni/include/gnix_ep.h
+++ b/prov/gni/include/gnix_ep.h
@@ -334,4 +334,15 @@ int gnix_scalable_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags);
  */
 int gnix_pep_bind(fid_t fid, fid_t *bfid, uint64_t flags);
 
-#endif /* _GNIX_EP_H_ */
+DIRECT_FN int gnix_ep_atomic_valid(struct fid_ep *ep,
+				   enum fi_datatype datatype,
+				   enum fi_op op, size_t *count);
+
+DIRECT_FN int gnix_ep_fetch_atomic_valid(struct fid_ep *ep,
+					 enum fi_datatype datatype,
+					 enum fi_op op, size_t *count);
+
+DIRECT_FN int gnix_ep_cmp_atomic_valid(struct fid_ep *ep,
+				       enum fi_datatype datatype,
+				       enum fi_op op, size_t *count);
+#endif /* _GN IX_EP_H_ */

--- a/prov/gni/include/gnix_rma.h
+++ b/prov/gni/include/gnix_rma.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -33,6 +33,9 @@
 
 #ifndef _GNIX_RMA_H_
 #define _GNIX_RMA_H_
+
+#define GNIX_RMA_READ_FLAGS_DEF  (FI_RMA | FI_READ)
+#define GNIX_RMA_WRITE_FLAGS_DEF (FI_RMA | FI_WRITE)
 
 ssize_t _gnix_rma(struct gnix_fid_ep *ep, enum gnix_fab_req_type fr_type,
 		  uint64_t loc_addr, size_t len, void *mdesc,

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -571,9 +571,6 @@ gnix_ep_msg_injectdata(struct fid_ep *ep, const void *buf, size_t len,
  * EP RMA API function implementations.
  ******************************************************************************/
 
-#define GNIX_RMA_READ_FLAGS_DEF		(FI_RMA | FI_READ)
-#define GNIX_RMA_WRITE_FLAGS_DEF	(FI_RMA | FI_WRITE)
-
 DIRECT_FN STATIC ssize_t gnix_ep_read(struct fid_ep *ep, void *buf, size_t len,
 				      void *desc, fi_addr_t src_addr, uint64_t addr,
 				      uint64_t key, void *context)
@@ -928,10 +925,7 @@ DIRECT_FN STATIC ssize_t gnix_ep_tinjectdata(struct fid_ep *ep, const void *buf,
  * EP atomic API implementation.
  ******************************************************************************/
 
-#define GNIX_ATOMIC_WRITE_FLAGS_DEF	(FI_ATOMIC | FI_WRITE)
-#define GNIX_ATOMIC_READ_FLAGS_DEF	(FI_ATOMIC | FI_READ)
-
-DIRECT_FN STATIC int gnix_ep_atomic_valid(struct fid_ep *ep,
+DIRECT_FN int gnix_ep_atomic_valid(struct fid_ep *ep,
 					  enum fi_datatype datatype,
 					  enum fi_op op, size_t *count)
 {
@@ -942,7 +936,7 @@ DIRECT_FN STATIC int gnix_ep_atomic_valid(struct fid_ep *ep,
 		0 : -FI_ENOENT;
 }
 
-DIRECT_FN STATIC int gnix_ep_fetch_atomic_valid(struct fid_ep *ep,
+DIRECT_FN int gnix_ep_fetch_atomic_valid(struct fid_ep *ep,
 						enum fi_datatype datatype,
 						enum fi_op op, size_t *count)
 {
@@ -953,7 +947,7 @@ DIRECT_FN STATIC int gnix_ep_fetch_atomic_valid(struct fid_ep *ep,
 		0 : -FI_ENOENT;
 }
 
-DIRECT_FN STATIC int gnix_ep_cmp_atomic_valid(struct fid_ep *ep,
+DIRECT_FN int gnix_ep_cmp_atomic_valid(struct fid_ep *ep,
 					      enum fi_datatype datatype,
 					      enum fi_op op, size_t *count)
 {

--- a/prov/gni/src/gnix_sep.c
+++ b/prov/gni/src/gnix_sep.c
@@ -44,6 +44,9 @@
 #include "gnix_vc.h"
 #include "gnix_util.h"
 #include "gnix_msg.h"
+#include "gnix_cntr.h"
+#include "gnix_rma.h"
+#include "gnix_atomic.h"
 
 /******************************************************************************
  * Forward declaration for ops structures.
@@ -293,6 +296,7 @@ static int gnix_sep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 	struct gnix_fid_ep  *ep;
 	struct gnix_fid_av  *av;
 	struct gnix_fid_sep *sep;
+	struct gnix_fid_cntr *cntr;
 	struct gnix_fid_trx *trx_priv;
 	struct gnix_fid_domain *domain_priv;
 
@@ -352,6 +356,110 @@ static int gnix_sep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 		}
 
 		break;
+	case FI_CLASS_CNTR:
+		cntr = container_of(bfid, struct gnix_fid_cntr, cntr_fid.fid);
+		if (domain_priv != cntr->domain) {
+			return -FI_EINVAL;
+		}
+
+		for (i = 0; i < sep->info->ep_attr->tx_ctx_cnt; i++) {
+			ep = container_of(sep->tx_ep_table[i],
+					  struct gnix_fid_ep, ep_fid);
+			if (ep == NULL) {
+				return -FI_EINVAL;
+			}
+
+			/* don't allow rebinding */
+			if (flags & FI_SEND) {
+				if (ep->send_cntr) {
+					GNIX_WARN(FI_LOG_EP_CTRL,
+						  "rebind send counter (%p)\n",
+						  cntr);
+					ret = -FI_EINVAL;
+					break;
+				}
+				ep->send_cntr = cntr;
+				_gnix_cntr_poll_nic_add(cntr, ep->nic);
+				_gnix_ref_get(cntr);
+			}
+
+			if (flags & FI_WRITE) {
+				if (ep->write_cntr) {
+					GNIX_WARN(FI_LOG_EP_CTRL,
+						  "rebind write counter (%p)\n",
+						  cntr);
+					ret = -FI_EINVAL;
+					break;
+				}
+				ep->write_cntr = cntr;
+				_gnix_cntr_poll_nic_add(cntr, ep->nic);
+				_gnix_ref_get(cntr);
+			}
+
+			if (flags & FI_REMOTE_WRITE) {
+				if (ep->rwrite_cntr) {
+					GNIX_WARN(FI_LOG_EP_CTRL,
+						  "rebind rwrite counter (%p)\n",
+						  cntr);
+					ret = -FI_EINVAL;
+					break;
+				}
+				ep->rwrite_cntr = cntr;
+				_gnix_cntr_poll_nic_add(cntr, ep->nic);
+				_gnix_ref_get(cntr);
+			}
+		}
+
+		for (i = 0; i < sep->info->ep_attr->rx_ctx_cnt; i++) {
+			ep = container_of(sep->rx_ep_table[i],
+					  struct gnix_fid_ep, ep_fid);
+			if (ep == NULL) {
+				return -FI_EINVAL;
+			}
+
+			/* don't allow rebinding */
+			if (flags & FI_RECV) {
+				if (ep->recv_cntr) {
+					GNIX_WARN(FI_LOG_EP_CTRL,
+						  "rebind recv counter (%p)\n",
+						  cntr);
+					ret = -FI_EINVAL;
+					break;
+				}
+				ep->recv_cntr = cntr;
+				_gnix_cntr_poll_nic_add(cntr, ep->nic);
+				_gnix_ref_get(cntr);
+			}
+
+			if (flags & FI_READ) {
+				if (ep->read_cntr) {
+					GNIX_WARN(FI_LOG_EP_CTRL,
+						  "rebind read counter (%p)\n",
+						  cntr);
+					ret = -FI_EINVAL;
+					break;
+				}
+				ep->read_cntr = cntr;
+				_gnix_cntr_poll_nic_add(cntr, ep->nic);
+				_gnix_ref_get(cntr);
+			}
+
+			if (flags & FI_REMOTE_READ) {
+				if (ep->rread_cntr) {
+					GNIX_WARN(FI_LOG_EP_CTRL,
+						  "rebind rread counter (%p)\n",
+						  cntr);
+					ret = -FI_EINVAL;
+					break;
+				}
+				ep->rread_cntr = cntr;
+				_gnix_cntr_poll_nic_add(cntr, ep->nic);
+				_gnix_ref_get(cntr);
+			}
+		}
+
+		break;
+			break;
 	default:
 		ret = -FI_ENOSYS;
 		break;
@@ -778,6 +886,520 @@ gnix_sep_msg_injectdata(struct fid_ep *ep, const void *buf, size_t len,
 			  NULL, flags, data, 0);
 }
 
+DIRECT_FN STATIC ssize_t
+gnix_sep_read(struct fid_ep *ep, void *buf, size_t len,
+	      void *desc, fi_addr_t src_addr, uint64_t addr,
+	      uint64_t key, void *context)
+{
+	uint64_t flags;
+	struct gnix_fid_trx *rx_ep;
+
+	if (!ep) {
+		return -FI_EINVAL;
+	}
+
+	rx_ep = container_of(ep, struct gnix_fid_trx, ep_fid);
+	assert(GNIX_EP_RDM_DGM_MSG(rx_ep->ep->type));
+	flags = rx_ep->ep->op_flags | GNIX_RMA_READ_FLAGS_DEF;
+
+	return _gnix_rma(rx_ep->ep, GNIX_FAB_RQ_RDMA_READ,
+			 (uint64_t)buf, len, desc,
+			 src_addr, addr, key,
+			 context, flags, 0);
+}
+
+DIRECT_FN STATIC ssize_t
+gnix_sep_readv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+	       size_t count, fi_addr_t src_addr, uint64_t addr, uint64_t key,
+	       void *context)
+{
+	uint64_t flags;
+	struct gnix_fid_trx *rx_ep;
+
+	if (!ep || !iov || !desc || count > GNIX_MAX_RMA_IOV_LIMIT) {
+		return -FI_EINVAL;
+	}
+
+	rx_ep = container_of(ep, struct gnix_fid_trx, ep_fid);
+	assert(GNIX_EP_RDM_DGM_MSG(rx_ep->ep->type));
+	flags = rx_ep->ep->op_flags | GNIX_RMA_READ_FLAGS_DEF;
+
+	return _gnix_rma(rx_ep->ep, GNIX_FAB_RQ_RDMA_READ,
+			 (uint64_t)iov[0].iov_base, iov[0].iov_len, desc[0],
+			 src_addr, addr, key,
+			 context, flags, 0);
+}
+
+DIRECT_FN STATIC ssize_t
+gnix_sep_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
+		 uint64_t flags)
+{
+	struct gnix_fid_trx *rx_ep;
+
+	if (!ep || !msg || !msg->msg_iov || !msg->rma_iov || !msg->desc ||
+	    msg->iov_count != 1 || msg->rma_iov_count != 1 ||
+	    msg->rma_iov[0].len > msg->msg_iov[0].iov_len) {
+		return -FI_EINVAL;
+	}
+
+	rx_ep = container_of(ep, struct gnix_fid_trx, ep_fid);
+	assert(GNIX_EP_RDM_DGM_MSG(rx_ep->ep->type));
+
+	flags = (flags & GNIX_READMSG_FLAGS) | GNIX_RMA_READ_FLAGS_DEF;
+
+	return _gnix_rma(rx_ep->ep, GNIX_FAB_RQ_RDMA_READ,
+			 (uint64_t)msg->msg_iov[0].iov_base,
+			 msg->msg_iov[0].iov_len, msg->desc[0],
+			 msg->addr, msg->rma_iov[0].addr, msg->rma_iov[0].key,
+			 msg->context, flags, msg->data);
+}
+
+DIRECT_FN STATIC ssize_t
+gnix_sep_write(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+	       fi_addr_t dest_addr, uint64_t addr, uint64_t key, void *context)
+{
+	uint64_t flags;
+	struct gnix_fid_trx *tx_ep;
+
+	if (!ep) {
+		return -FI_EINVAL;
+	}
+
+	tx_ep = container_of(ep, struct gnix_fid_trx, ep_fid);
+	assert(GNIX_EP_RDM_DGM_MSG(tx_ep->ep->type));
+	flags = tx_ep->ep->op_flags | GNIX_RMA_WRITE_FLAGS_DEF;
+
+	return _gnix_rma(tx_ep->ep, GNIX_FAB_RQ_RDMA_WRITE,
+			 (uint64_t)buf, len, desc, dest_addr, addr, key,
+			 context, flags, 0);
+}
+
+DIRECT_FN STATIC ssize_t
+gnix_sep_writev(struct fid_ep *ep, const struct iovec *iov, void **desc,
+		size_t count, fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+		void *context)
+{
+	uint64_t flags;
+	struct gnix_fid_trx *tx_ep;
+
+	if (!ep || !iov || !desc || count > GNIX_MAX_RMA_IOV_LIMIT) {
+		return -FI_EINVAL;
+	}
+
+	tx_ep = container_of(ep, struct gnix_fid_trx, ep_fid);
+	assert(GNIX_EP_RDM_DGM_MSG(tx_ep->ep->type));
+	flags = tx_ep->ep->op_flags | GNIX_RMA_WRITE_FLAGS_DEF;
+
+	return _gnix_rma(tx_ep->ep, GNIX_FAB_RQ_RDMA_WRITE,
+			 (uint64_t)iov[0].iov_base, iov[0].iov_len, desc[0],
+			 dest_addr, addr, key, context, flags, 0);
+}
+
+DIRECT_FN STATIC ssize_t
+gnix_sep_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
+		  uint64_t flags)
+{
+	struct gnix_fid_trx *trx_ep;
+
+	if (!ep || !msg || !msg->msg_iov || !msg->rma_iov ||
+	    msg->iov_count != 1 ||
+		msg->rma_iov_count > GNIX_MAX_RMA_IOV_LIMIT ||
+	    msg->rma_iov[0].len > msg->msg_iov[0].iov_len) {
+		return -FI_EINVAL;
+	}
+
+	trx_ep = container_of(ep, struct gnix_fid_trx, ep_fid);
+	assert(GNIX_EP_RDM_DGM_MSG(trx_ep->ep->type));
+
+	flags = (flags & GNIX_WRITEMSG_FLAGS) | GNIX_RMA_WRITE_FLAGS_DEF;
+
+	return _gnix_rma(trx_ep->ep, GNIX_FAB_RQ_RDMA_WRITE,
+			 (uint64_t)msg->msg_iov[0].iov_base,
+			 msg->msg_iov[0].iov_len,
+			 msg->desc ? msg->desc[0] : NULL,
+			 msg->addr, msg->rma_iov[0].addr, msg->rma_iov[0].key,
+			 msg->context, flags, msg->data);
+}
+
+DIRECT_FN STATIC ssize_t
+gnix_sep_rma_inject(struct fid_ep *ep, const void *buf,
+		    size_t len, fi_addr_t dest_addr,
+		    uint64_t addr, uint64_t key)
+{
+	uint64_t flags;
+	struct gnix_fid_trx *trx_ep;
+
+	if (!ep) {
+		return -FI_EINVAL;
+	}
+
+	trx_ep = container_of(ep, struct gnix_fid_trx, ep_fid);
+	assert(GNIX_EP_RDM_DGM_MSG(trx_ep->ep->type));
+
+	flags = trx_ep->ep->op_flags | FI_INJECT | GNIX_SUPPRESS_COMPLETION |
+			GNIX_RMA_WRITE_FLAGS_DEF;
+
+	return _gnix_rma(trx_ep->ep, GNIX_FAB_RQ_RDMA_WRITE,
+			 (uint64_t)buf, len, NULL,
+			 dest_addr, addr, key,
+			 NULL, flags, 0);
+}
+
+DIRECT_FN STATIC ssize_t
+gnix_sep_writedata(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+		   uint64_t data, fi_addr_t dest_addr, uint64_t addr,
+		   uint64_t key, void *context)
+{
+	uint64_t flags;
+	struct gnix_fid_trx *trx_ep;
+
+	if (!ep) {
+		return -FI_EINVAL;
+	}
+
+	trx_ep = container_of(ep, struct gnix_fid_trx, ep_fid);
+	assert(GNIX_EP_RDM_DGM_MSG(trx_ep->ep->type));
+
+	flags = trx_ep->ep->op_flags | FI_REMOTE_CQ_DATA |
+			GNIX_RMA_WRITE_FLAGS_DEF;
+
+	return _gnix_rma(trx_ep->ep, GNIX_FAB_RQ_RDMA_WRITE,
+			 (uint64_t)buf, len, desc,
+			 dest_addr, addr, key,
+			 context, flags, data);
+}
+
+DIRECT_FN STATIC ssize_t
+gnix_sep_rma_injectdata(struct fid_ep *ep, const void *buf, size_t len,
+			uint64_t data, fi_addr_t dest_addr, uint64_t addr,
+			uint64_t key)
+{
+	uint64_t flags;
+	struct gnix_fid_trx *trx_ep;
+
+	if (!ep) {
+		return -FI_EINVAL;
+	}
+
+	trx_ep = container_of(ep, struct gnix_fid_trx, ep_fid);
+	assert(GNIX_EP_RDM_DGM_MSG(trx_ep->ep->type));
+
+	flags = trx_ep->ep->op_flags | FI_INJECT | FI_REMOTE_CQ_DATA |
+			GNIX_SUPPRESS_COMPLETION | GNIX_RMA_WRITE_FLAGS_DEF;
+
+	return _gnix_rma(trx_ep->ep, GNIX_FAB_RQ_RDMA_WRITE,
+			 (uint64_t)buf, len, NULL,
+			 dest_addr, addr, key,
+			 NULL, flags, data);
+}
+
+DIRECT_FN STATIC ssize_t
+gnix_sep_atomic_write(struct fid_ep *ep, const void *buf, size_t count,
+		      void *desc, fi_addr_t dest_addr, uint64_t addr,
+		      uint64_t key, enum fi_datatype datatype, enum fi_op op,
+		      void *context)
+{
+	struct gnix_fid_trx *trx_ep;
+
+	struct fi_msg_atomic msg;
+	struct fi_ioc msg_iov;
+	struct fi_rma_ioc rma_iov;
+	uint64_t flags;
+
+	if (!ep)
+		return -FI_EINVAL;
+
+	if (_gnix_atomic_cmd(datatype, op, GNIX_FAB_RQ_AMO) < 0)
+		return -FI_ENOENT;
+
+	trx_ep = container_of(ep, struct gnix_fid_trx, ep_fid);
+	assert(GNIX_EP_RDM_DGM_MSG(trx_ep->ep->type));
+
+	msg_iov.addr = (void *)buf;
+	msg_iov.count = count;
+	msg.msg_iov = &msg_iov;
+	msg.desc = &desc;
+	msg.iov_count = 1;
+	msg.addr = dest_addr;
+	rma_iov.addr = addr;
+	rma_iov.count = 1;
+	rma_iov.key = key;
+	msg.rma_iov = &rma_iov;
+	msg.datatype = datatype;
+	msg.op = op;
+	msg.context = context;
+
+	flags = trx_ep->ep->op_flags | GNIX_ATOMIC_WRITE_FLAGS_DEF;
+
+	return _gnix_atomic(trx_ep->ep, GNIX_FAB_RQ_AMO, &msg,
+			    NULL, NULL, 0, NULL, NULL, 0, flags);
+}
+
+DIRECT_FN STATIC ssize_t
+gnix_sep_atomic_writev(struct fid_ep *ep, const struct fi_ioc *iov, void **desc,
+		      size_t count, fi_addr_t dest_addr, uint64_t addr,
+		      uint64_t key, enum fi_datatype datatype, enum fi_op op,
+		      void *context)
+{
+	if (!ep || !iov || count > 1)
+		return -FI_EINVAL;
+
+	return gnix_sep_atomic_write(ep, iov[0].addr,
+				     iov[0].count, desc ? desc[0] : NULL,
+				     dest_addr, addr, key, datatype, op,
+				     context);
+}
+
+DIRECT_FN STATIC ssize_t
+gnix_sep_atomic_writemsg(struct fid_ep *ep, const struct fi_msg_atomic *msg,
+			uint64_t flags)
+{
+	struct gnix_fid_trx *trx_ep;
+
+	if (!ep)
+		return -FI_EINVAL;
+
+	if (_gnix_atomic_cmd(msg->datatype, msg->op, GNIX_FAB_RQ_AMO) < 0)
+		return -FI_ENOENT;
+
+	trx_ep = container_of(ep, struct gnix_fid_trx, ep_fid);
+	assert(GNIX_EP_RDM_DGM_MSG(trx_ep->ep->type));
+
+	flags = (flags & GNIX_ATOMICMSG_FLAGS) | GNIX_ATOMIC_WRITE_FLAGS_DEF;
+
+	return _gnix_atomic(trx_ep->ep, GNIX_FAB_RQ_AMO, msg,
+			    NULL, NULL, 0, NULL, NULL, 0, flags);
+}
+
+DIRECT_FN STATIC ssize_t
+gnix_sep_atomic_inject(struct fid_ep *ep, const void *buf, size_t count,
+		       fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+		       enum fi_datatype datatype, enum fi_op op)
+{
+	struct gnix_fid_trx *trx_ep;
+	struct fi_msg_atomic msg;
+	struct fi_ioc msg_iov;
+	struct fi_rma_ioc rma_iov;
+	uint64_t flags;
+
+	if (!ep)
+		return -FI_EINVAL;
+
+	if (_gnix_atomic_cmd(datatype, op, GNIX_FAB_RQ_AMO) < 0)
+		return -FI_ENOENT;
+
+	trx_ep = container_of(ep, struct gnix_fid_trx, ep_fid);
+	assert(GNIX_EP_RDM_DGM_MSG(trx_ep->ep->type));
+
+	msg_iov.addr = (void *)buf;
+	msg_iov.count = count;
+	msg.msg_iov = &msg_iov;
+	msg.desc = NULL;
+	msg.iov_count = 1;
+	msg.addr = dest_addr;
+	rma_iov.addr = addr;
+	rma_iov.count = 1;
+	rma_iov.key = key;
+	msg.rma_iov = &rma_iov;
+	msg.datatype = datatype;
+	msg.op = op;
+
+	flags = trx_ep->ep->op_flags | FI_INJECT | GNIX_SUPPRESS_COMPLETION |
+			GNIX_ATOMIC_WRITE_FLAGS_DEF;
+
+	return _gnix_atomic(trx_ep->ep, GNIX_FAB_RQ_AMO, &msg,
+			    NULL, NULL, 0, NULL, NULL, 0, flags);
+}
+
+DIRECT_FN STATIC ssize_t
+gnix_sep_atomic_readwrite(struct fid_ep *ep, const void *buf, size_t count,
+			 void *desc, void *result, void *result_desc,
+			 fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+			 enum fi_datatype datatype, enum fi_op op,
+			 void *context)
+{
+	struct gnix_fid_trx *trx_ep;
+	struct fi_msg_atomic msg;
+	struct fi_ioc msg_iov;
+	struct fi_rma_ioc rma_iov;
+	struct fi_ioc result_iov;
+	uint64_t flags;
+
+	if (_gnix_atomic_cmd(datatype, op, GNIX_FAB_RQ_FAMO) < 0)
+		return -FI_ENOENT;
+
+	if (!ep)
+		return -FI_EINVAL;
+
+	trx_ep = container_of(ep, struct gnix_fid_trx, ep_fid);
+	assert(GNIX_EP_RDM_DGM_MSG(trx_ep->ep->type));
+
+	msg_iov.addr = (void *)buf;
+	msg_iov.count = count;
+	msg.msg_iov = &msg_iov;
+	msg.desc = &desc;
+	msg.iov_count = 1;
+	msg.addr = dest_addr;
+	rma_iov.addr = addr;
+	rma_iov.count = 1;
+	rma_iov.key = key;
+	msg.rma_iov = &rma_iov;
+	msg.datatype = datatype;
+	msg.op = op;
+	msg.context = context;
+	result_iov.addr = result;
+	result_iov.count = 1;
+
+	flags = trx_ep->ep->op_flags | GNIX_ATOMIC_READ_FLAGS_DEF;
+
+	return _gnix_atomic(trx_ep->ep, GNIX_FAB_RQ_FAMO, &msg,
+			    NULL, NULL, 0,
+			    &result_iov, &result_desc, 1,
+			    flags);
+}
+
+DIRECT_FN STATIC ssize_t
+gnix_sep_atomic_readwritev(struct fid_ep *ep, const struct fi_ioc *iov,
+			  void **desc, size_t count, struct fi_ioc *resultv,
+			  void **result_desc, size_t result_count,
+			  fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+			  enum fi_datatype datatype, enum fi_op op,
+			  void *context)
+{
+	if (!iov || count > 1 || !resultv)
+		return -FI_EINVAL;
+
+	return gnix_sep_atomic_readwrite(ep, iov[0].addr, iov[0].count,
+					desc ? desc[0] : NULL,
+					resultv[0].addr,
+					result_desc ? result_desc[0] : NULL,
+					dest_addr, addr, key, datatype, op,
+					context);
+}
+
+DIRECT_FN STATIC ssize_t
+gnix_sep_atomic_readwritemsg(struct fid_ep *ep, const struct fi_msg_atomic *msg,
+			    struct fi_ioc *resultv, void **result_desc,
+			    size_t result_count, uint64_t flags)
+{
+	struct gnix_fid_trx *trx_ep;
+
+	if (!ep)
+		return -FI_EINVAL;
+
+	if (_gnix_atomic_cmd(msg->datatype, msg->op, GNIX_FAB_RQ_FAMO) < 0)
+		return -FI_ENOENT;
+
+	trx_ep = container_of(ep, struct gnix_fid_trx, ep_fid);
+	assert(GNIX_EP_RDM_DGM_MSG(trx_ep->ep->type));
+
+	flags = (flags & GNIX_FATOMICMSG_FLAGS) | GNIX_ATOMIC_READ_FLAGS_DEF;
+
+	return _gnix_atomic(trx_ep->ep, GNIX_FAB_RQ_FAMO, msg, NULL, NULL, 0,
+			    resultv, result_desc, result_count, flags);
+}
+
+DIRECT_FN STATIC ssize_t
+gnix_sep_atomic_compwrite(struct fid_ep *ep, const void *buf, size_t count,
+			  void *desc, const void *compare, void *compare_desc,
+			  void *result, void *result_desc, fi_addr_t dest_addr,
+			  uint64_t addr, uint64_t key,
+			  enum fi_datatype datatype, enum fi_op op,
+			  void *context)
+{
+	struct gnix_fid_trx *trx_ep;
+	struct fi_msg_atomic msg;
+	struct fi_ioc msg_iov;
+	struct fi_rma_ioc rma_iov;
+	struct fi_ioc result_iov;
+	struct fi_ioc compare_iov;
+	uint64_t flags;
+
+	if (!ep)
+		return -FI_EINVAL;
+
+	if (_gnix_atomic_cmd(datatype, op, GNIX_FAB_RQ_CAMO) < 0)
+		return -FI_ENOENT;
+
+	trx_ep = container_of(ep, struct gnix_fid_trx, ep_fid);
+	assert(GNIX_EP_RDM_DGM_MSG(trx_ep->ep->type));
+
+	msg_iov.addr = (void *)buf;
+	msg_iov.count = count;
+	msg.msg_iov = &msg_iov;
+	msg.desc = &desc;
+	msg.iov_count = 1;
+	msg.addr = dest_addr;
+	rma_iov.addr = addr;
+	rma_iov.count = 1;
+	rma_iov.key = key;
+	msg.rma_iov = &rma_iov;
+	msg.datatype = datatype;
+	msg.op = op;
+	msg.context = context;
+	result_iov.addr = result;
+	result_iov.count = 1;
+	compare_iov.addr = (void *)compare;
+	compare_iov.count = 1;
+
+	flags = trx_ep->ep->op_flags | GNIX_ATOMIC_READ_FLAGS_DEF;
+
+	return _gnix_atomic(trx_ep->ep, GNIX_FAB_RQ_CAMO, &msg,
+			    &compare_iov, &compare_desc, 1,
+			    &result_iov, &result_desc, 1,
+			    flags);
+}
+
+DIRECT_FN STATIC ssize_t
+gnix_sep_atomic_compwritev(struct fid_ep *ep, const struct fi_ioc *iov,
+			   void **desc, size_t count,
+			   const struct fi_ioc *comparev,
+			   void **compare_desc, size_t compare_count,
+			   struct fi_ioc *resultv, void **result_desc,
+			   size_t result_count, fi_addr_t dest_addr,
+			   uint64_t addr, uint64_t key,
+			   enum fi_datatype datatype, enum fi_op op,
+			   void *context)
+{
+	if (!iov || count > 1 || !resultv || !comparev)
+		return -FI_EINVAL;
+
+	return gnix_sep_atomic_compwrite(ep, iov[0].addr, iov[0].count,
+					 desc ? desc[0] : NULL,
+					 comparev[0].addr,
+					 compare_desc ? compare_desc[0] : NULL,
+					 resultv[0].addr,
+					 result_desc ? result_desc[0] : NULL,
+					 dest_addr, addr, key, datatype, op,
+					 context);
+}
+
+DIRECT_FN STATIC ssize_t
+gnix_sep_atomic_compwritemsg(struct fid_ep *ep, const struct fi_msg_atomic *msg,
+			     const struct fi_ioc *comparev, void **compare_desc,
+			     size_t compare_count, struct fi_ioc *resultv,
+			     void **result_desc, size_t result_count,
+			     uint64_t flags)
+{
+	struct gnix_fid_trx *trx_ep;
+
+	if (!ep)
+		return -FI_EINVAL;
+
+	if (_gnix_atomic_cmd(msg->datatype, msg->op, GNIX_FAB_RQ_CAMO) < 0)
+		return -FI_ENOENT;
+
+	trx_ep = container_of(ep, struct gnix_fid_trx, ep_fid);
+	assert(GNIX_EP_RDM_DGM_MSG(trx_ep->ep->type));
+
+	flags = (flags & GNIX_CATOMICMSG_FLAGS) | GNIX_ATOMIC_READ_FLAGS_DEF;
+
+	return _gnix_atomic(trx_ep->ep, GNIX_FAB_RQ_CAMO, msg,
+			    comparev, compare_desc, compare_count,
+			    resultv, result_desc, result_count,
+			    flags);
+}
+
 /*******************************************************************************
  * FI_OPS_* data structures.
  ******************************************************************************/
@@ -816,45 +1438,45 @@ static struct fi_ops_msg gnix_sep_msg_ops = {
 
 static struct fi_ops_rma gnix_sep_rma_ops = {
 	.size = sizeof(struct fi_ops_rma),
-	.read = NULL,
-	.readv = NULL,
-	.readmsg = NULL,
-	.write = NULL,
-	.writev = NULL,
-	.writemsg = NULL,
-	.inject = NULL,
-	.writedata = NULL,
-	.injectdata = NULL,
+	.read = gnix_sep_read,
+	.readv = gnix_sep_readv,
+	.readmsg = gnix_sep_readmsg,
+	.write = gnix_sep_write,
+	.writev = gnix_sep_writev,
+	.writemsg = gnix_sep_writemsg,
+	.inject = gnix_sep_rma_inject,
+	.writedata = gnix_sep_writedata,
+	.injectdata = gnix_sep_rma_injectdata,
 };
 
 static struct fi_ops_tagged gnix_sep_tagged_ops = {
 	.size = sizeof(struct fi_ops_tagged),
-	.recv = NULL,
-	.recvv = NULL,
-	.recvmsg = NULL,
-	.send = NULL,
-	.sendv = NULL,
-	.sendmsg = NULL,
-	.inject = NULL,
-	.senddata = NULL,
-	.injectdata = NULL,
+	.recv = fi_no_tagged_recv,
+	.recvv = fi_no_tagged_recvv,
+	.recvmsg = fi_no_tagged_recvmsg,
+	.send = fi_no_tagged_send,
+	.sendv = fi_no_tagged_sendv,
+	.sendmsg = fi_no_tagged_sendmsg,
+	.inject = fi_no_tagged_inject,
+	.senddata = fi_no_tagged_senddata,
+	.injectdata = fi_no_tagged_injectdata,
 };
 
 static struct fi_ops_atomic gnix_sep_atomic_ops = {
 	.size = sizeof(struct fi_ops_atomic),
-	.write = NULL,
-	.writev = NULL,
-	.writemsg = NULL,
-	.inject = NULL,
-	.readwrite = NULL,
-	.readwritev = NULL,
-	.readwritemsg = NULL,
-	.compwrite = NULL,
-	.compwritev = NULL,
-	.compwritemsg = NULL,
-	.writevalid = NULL,
-	.readwritevalid = NULL,
-	.compwritevalid = NULL,
+	.write = gnix_sep_atomic_write,
+	.writev = gnix_sep_atomic_writev,
+	.writemsg = gnix_sep_atomic_writemsg,
+	.inject = gnix_sep_atomic_inject,
+	.readwrite = gnix_sep_atomic_readwrite,
+	.readwritev = gnix_sep_atomic_readwritev,
+	.readwritemsg = gnix_sep_atomic_readwritemsg,
+	.compwrite = gnix_sep_atomic_compwrite,
+	.compwritev = gnix_sep_atomic_compwritev,
+	.compwritemsg = gnix_sep_atomic_compwritemsg,
+	.writevalid = gnix_ep_atomic_valid,
+	.readwritevalid = gnix_ep_fetch_atomic_valid,
+	.compwritevalid = gnix_ep_cmp_atomic_valid,
 };
 
 /*

--- a/prov/gni/test/common.h
+++ b/prov/gni/test/common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -36,6 +36,11 @@
 #include <time.h>
 #include <stdint.h>
 #include <sys/time.h>
+#include "gnix_rdma_headers.h"
+
+/* defined in rdm_atomic.c */
+extern int supported_compare_atomic_ops[FI_ATOMIC_OP_LAST][FI_DATATYPE_LAST];
+extern int supported_fetch_atomic_ops[FI_ATOMIC_OP_LAST][FI_DATATYPE_LAST];
 
 void calculate_time_difference(struct timeval *start, struct timeval *end,
 		int *secs_out, int *usec_out);

--- a/prov/gni/test/sep.c
+++ b/prov/gni/test/sep.c
@@ -49,6 +49,7 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
+#include "common.h"
 #include "fi_ext_gni.h"
 #include "gnix.h"
 
@@ -63,6 +64,8 @@
 #endif
 
 #define NUMEPS 2
+#define BUF_SZ (1<<20)
+#define IOV_CNT (4)
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom[NUMEPS];
@@ -76,19 +79,27 @@ struct fi_info *hints;
 static struct fi_info *fi[NUMEPS];
 static struct fid_ep *sep[NUMEPS];
 
-#define BUF_SZ (1<<20)
 char *target;
 char *source;
+struct iovec *src_iov, *dest_iov;
+char *iov_src_buf, *iov_dest_buf;
 struct fid_mr *rem_mr[NUMEPS], *loc_mr[NUMEPS];
+struct fid_mr *iov_dest_buf_mr[NUMEPS], *iov_src_buf_mr[NUMEPS];
 uint64_t mr_key[NUMEPS];
 
-/* from scalable_ep.c */
 static int ctx_cnt = 4;
 static int rx_ctx_bits;
 static struct fid_ep **tx_ep[NUMEPS], **rx_ep[NUMEPS];
-static struct fid_cq **txcq_array[NUMEPS];
-static struct fid_cq **rxcq_array[NUMEPS];
+static struct fid_cq **tx_cq[NUMEPS];
+static struct fid_cq **rx_cq[NUMEPS];
 static fi_addr_t *rx_addr;
+static struct fid_cntr *send_cntr[NUMEPS], *recv_cntr[NUMEPS];
+static struct fi_cntr_attr cntr_attr = {
+	.events = FI_CNTR_EVENTS_COMP,
+	.flags = 0
+};
+static uint64_t sends[NUMEPS] = {0}, recvs[NUMEPS] = {0},
+	send_errs[NUMEPS] = {0}, recv_errs[NUMEPS] = {0};
 
 void sep_setup(void)
 {
@@ -99,7 +110,7 @@ void sep_setup(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 	hints->ep_attr->type = FI_EP_RDM;
-	hints->caps = FI_MSG | FI_NAMED_RX_CTX;
+	hints->caps = FI_ATOMIC | FI_RMA | FI_MSG | FI_NAMED_RX_CTX;
 	hints->mode = FI_LOCAL_MR;
 	hints->domain_attr->cq_data_size = NUMEPS * 2;
 	hints->domain_attr->data_progress = FI_PROGRESS_AUTO;
@@ -112,11 +123,11 @@ void sep_setup(void)
 		ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi[i]);
 		cr_assert(!ret, "fi_getinfo");
 
-		txcq_array[i] = calloc(ctx_cnt, sizeof(*txcq_array));
-		rxcq_array[i] = calloc(ctx_cnt, sizeof(*rxcq_array));
+		tx_cq[i] = calloc(ctx_cnt, sizeof(*tx_cq));
+		rx_cq[i] = calloc(ctx_cnt, sizeof(*rx_cq));
 		tx_ep[i] = calloc(ctx_cnt, sizeof(*tx_ep));
 		rx_ep[i] = calloc(ctx_cnt, sizeof(*rx_ep));
-		if (!txcq_array[i] || !txcq_array[i] ||
+		if (!tx_cq[i] || !tx_cq[i] ||
 		    !tx_ep[i] || !rx_ep[i]) {
 			cr_assert(0, "calloc");
 		}
@@ -141,9 +152,22 @@ void sep_setup(void)
 	rx_addr = calloc(ctx_cnt, sizeof(*rx_addr));
 	target = calloc(BUF_SZ, 1);
 	source = calloc(BUF_SZ, 1);
+	iov_src_buf = malloc(BUF_SZ * IOV_CNT);
+	iov_dest_buf = malloc(BUF_SZ * IOV_CNT);
+	src_iov = malloc(sizeof(struct iovec) * IOV_CNT);
+	dest_iov = malloc(sizeof(struct iovec) * IOV_CNT);
 
-	if (!rx_addr || !target || !source) {
-		cr_assert(0, "calloc");
+	if (!rx_addr || !target || !source || !iov_src_buf || !iov_dest_buf ||
+	    !src_iov || !dest_iov) {
+		cr_assert(0, "allocation");
+	}
+
+	for (i = 0; i < IOV_CNT; i++) {
+		src_iov[i].iov_base = malloc(BUF_SZ);
+		assert(src_iov[i].iov_base != NULL);
+
+		dest_iov[i].iov_base = malloc(BUF_SZ * 3);
+		assert(dest_iov[i].iov_base != NULL);
 	}
 
 	for (i = 0; i < NUMEPS; i++) {
@@ -159,12 +183,18 @@ void sep_setup(void)
 		ret = fi_av_open(dom[i], &av_attr, &av[i], NULL);
 		cr_assert(!ret, "fi_av_open");
 
+		ret = fi_cntr_open(dom[i], &cntr_attr, &send_cntr[i], 0);
+		cr_assert(!ret, "fi_cntr_open");
+
+		ret = fi_cntr_open(dom[i], &cntr_attr, &recv_cntr[i], 0);
+		cr_assert(!ret, "fi_cntr_open");
+
 		for (j = 0; j < ctx_cnt; j++) {
 			ret = fi_tx_context(sep[i], j, NULL, &tx_ep[i][j],
 					    NULL);
 			cr_assert(!ret, "fi_tx_context");
 
-			ret = fi_cq_open(dom[i], &cq_attr, &txcq_array[i][j],
+			ret = fi_cq_open(dom[i], &cq_attr, &tx_cq[i][j],
 					 NULL);
 			cr_assert(!ret, "fi_cq_open");
 
@@ -172,7 +202,7 @@ void sep_setup(void)
 					    NULL);
 			cr_assert(!ret, "fi_rx_context");
 
-			ret = fi_cq_open(dom[i], &cq_attr, &rxcq_array[i][j],
+			ret = fi_cq_open(dom[i], &cq_attr, &rx_cq[i][j],
 					 NULL);
 			cr_assert(!ret, "fi_cq_open");
 		}
@@ -181,19 +211,28 @@ void sep_setup(void)
 		cr_assert(!ret, "fi_scalable_ep_bind");
 
 		for (j = 0; j < ctx_cnt; j++) {
-			ret = fi_ep_bind(tx_ep[i][j], &txcq_array[i][j]->fid,
-					 FI_SEND);
+			ret = fi_ep_bind(tx_ep[i][j], &tx_cq[i][j]->fid,
+					 FI_TRANSMIT);
 			cr_assert(!ret, "fi_ep_bind");
 
-			ret = fi_ep_bind(tx_ep[i][j], &rxcq_array[i][j]->fid,
-					 FI_RECV);
+			ret = fi_ep_bind(tx_ep[i][j], &send_cntr[i]->fid,
+					 FI_SEND | FI_WRITE);
 			cr_assert(!ret, "fi_ep_bind");
 
 			ret = fi_enable(tx_ep[i][j]);
 			cr_assert(!ret, "fi_enable");
 
+			ret = fi_ep_bind(rx_ep[i][j], &rx_cq[i][j]->fid,
+					 FI_RECV);
+			cr_assert(!ret, "fi_ep_bind");
+
+			ret = fi_ep_bind(rx_ep[i][j], &recv_cntr[i]->fid,
+					 FI_RECV | FI_READ);
+			cr_assert(!ret, "fi_ep_bind");
+
 			ret = fi_enable(rx_ep[i][j]);
 			cr_assert(!ret, "fi_enable");
+
 		}
 	}
 
@@ -219,6 +258,17 @@ void sep_setup(void)
 		cr_assert_eq(ret, 0);
 
 		mr_key[i] = fi_mr_key(rem_mr[i]);
+
+		ret = fi_mr_reg(dom[i], iov_dest_buf, IOV_CNT * BUF_SZ,
+				FI_REMOTE_WRITE, 0, 0, 0, iov_dest_buf_mr + i,
+				&iov_dest_buf);
+		cr_assert_eq(ret, 0);
+
+		ret = fi_mr_reg(dom[i], iov_src_buf, IOV_CNT * BUF_SZ,
+				FI_REMOTE_WRITE, 0, 0, 0, iov_src_buf_mr + i,
+				&iov_src_buf);
+		cr_assert_eq(ret, 0);
+
 	}
 
 	for (i = 0; i < NUMEPS; i++) {
@@ -249,6 +299,9 @@ static void sep_teardown(void)
 	int ret, i, j;
 
 	for (i = 0; i < NUMEPS; i++) {
+		fi_close(&recv_cntr[i]->fid);
+		fi_close(&send_cntr[i]->fid);
+
 		for (j = 0; j < ctx_cnt; j++) {
 			ret = fi_close(&tx_ep[i][j]->fid);
 			cr_assert(!ret, "failure closing tx_ep.");
@@ -256,12 +309,14 @@ static void sep_teardown(void)
 			ret = fi_close(&rx_ep[i][j]->fid);
 			cr_assert(!ret, "failure closing rx_ep.");
 
-			ret = fi_close(&txcq_array[i][j]->fid);
+			ret = fi_close(&tx_cq[i][j]->fid);
 			cr_assert(!ret, "failure closing tx cq.");
 
-			ret = fi_close(&rxcq_array[i][j]->fid);
+			ret = fi_close(&rx_cq[i][j]->fid);
 			cr_assert(!ret, "failure closing rx cq.");
 		}
+
+		cr_assert(1);
 
 		ret = fi_close(&sep[i]->fid);
 		cr_assert(!ret, "failure in closing ep.");
@@ -281,6 +336,16 @@ static void sep_teardown(void)
 		fi_freeinfo(fi[i]);
 	}
 
+	for (i = 0; i < IOV_CNT; i++) {
+		free(src_iov[i].iov_base);
+		free(dest_iov[i].iov_base);
+	}
+
+	free(src_iov);
+	free(dest_iov);
+	free(iov_src_buf);
+	free(iov_dest_buf);
+
 	fi_freeinfo(hints);
 	free(target);
 	free(source);
@@ -289,7 +354,8 @@ static void sep_teardown(void)
 	cr_assert(!ret, "failure in closing fabric.");
 }
 
-void sep_init_data(char *buf, int len, char seed)
+static void
+sep_init_data(char *buf, int len, char seed)
 {
 	int i;
 
@@ -297,7 +363,8 @@ void sep_init_data(char *buf, int len, char seed)
 		buf[i] = seed++;
 }
 
-int sep_check_data(char *buf1, char *buf2, int len)
+static int
+sep_check_data(char *buf1, char *buf2, int len)
 {
 	int i;
 
@@ -312,19 +379,21 @@ int sep_check_data(char *buf1, char *buf2, int len)
 	return 1;
 }
 
-static void wait_for_cqs(struct fid_cq *scq, struct fid_cq *dcq)
+static void
+wait_for_cqs(struct fid_cq *scq, struct fid_cq *dcq,
+		struct fi_cq_tagged_entry *scqe,
+		struct fi_cq_tagged_entry *dcqe)
 {
-	struct fi_cq_tagged_entry cqe;
 	int ret;
 	int s_done = 0, d_done = 0;
 
 	do {
-		ret = fi_cq_read(scq, &cqe, 1);
+		ret = fi_cq_read(scq, scqe, 1);
 		if (ret == 1) {
 			s_done = 1;
 		}
 
-		ret = fi_cq_read(dcq, &cqe, 1);
+		ret = fi_cq_read(dcq, dcqe, 1);
 		if (ret == 1) {
 			d_done = 1;
 		}
@@ -341,6 +410,130 @@ xfer_each_size(void (*xfer)(int index, int len), int index, int slen, int elen)
 	}
 }
 
+static void
+sep_check_cqe(struct fi_cq_tagged_entry *cqe, void *ctx,
+		uint64_t flags, void *addr, size_t len,
+		uint64_t data, bool buf_is_non_null)
+{
+	cr_assert(cqe->op_context == ctx, "CQE Context mismatch");
+	cr_assert(cqe->flags == flags, "CQE flags mismatch");
+
+	if (flags & FI_RECV) {
+		cr_assert(cqe->len == len, "CQE length mismatch");
+
+		if (buf_is_non_null)
+			cr_assert(cqe->buf == addr, "CQE address mismatch");
+		else
+			cr_assert(cqe->buf == NULL, "CQE address mismatch");
+
+
+		if (flags & FI_REMOTE_CQ_DATA)
+			cr_assert(cqe->data == data, "CQE data mismatch");
+	} else {
+		cr_assert(cqe->len == 0, "Invalid CQE length");
+		cr_assert(cqe->buf == 0, "Invalid CQE address");
+		cr_assert(cqe->data == 0, "Invalid CQE data");
+	}
+
+	cr_assert(cqe->tag == 0, "Invalid CQE tag");
+}
+
+static void
+sep_check_tcqe(struct fi_cq_tagged_entry *tcqe, void *ctx,
+	       uint64_t flags, uint64_t data)
+{
+	cr_assert(tcqe->op_context == ctx, "CQE Context mismatch");
+	cr_assert(tcqe->flags == flags, "CQE flags mismatch");
+
+	if (flags & FI_REMOTE_CQ_DATA) {
+		cr_assert(tcqe->data == data, "CQE data invalid");
+	} else {
+		cr_assert(tcqe->data == 0, "CQE data invalid");
+	}
+
+	cr_assert(tcqe->len == 0, "CQE length mismatch");
+	cr_assert(tcqe->buf == 0, "CQE address mismatch");
+	cr_assert(tcqe->tag == 0, "CQE tag invalid");
+}
+
+static void
+sep_check_cntrs(uint64_t s[], uint64_t r[], uint64_t s_e[],
+		uint64_t r_e[])
+{
+	int i = 0;
+
+	for (; i < NUMEPS; i++) {
+		sends[i] += s[i];
+		recvs[i] += r[i];
+		send_errs[i] += s_e[i];
+		recv_errs[i] += r_e[i];
+
+		cr_assert(fi_cntr_read(send_cntr[i]) == sends[i],
+			  "Bad send count i:%d send_cntr:%ld sends:%ld",
+			  i, fi_cntr_read(send_cntr[i]), sends[i]);
+		cr_assert(fi_cntr_read(recv_cntr[i]) == recvs[i],
+			  "Bad recv count");
+		cr_assert(fi_cntr_readerr(send_cntr[i]) == send_errs[i],
+			  "Bad send err count");
+		cr_assert(fi_cntr_readerr(recv_cntr[i]) == recv_errs[i],
+			  "Bad recv err count");
+	}
+}
+
+static int
+sep_check_iov_data(struct iovec *iov_buf, char *buf, size_t cnt, size_t buf_len)
+{
+	size_t i, j, cum_len = 0, len, iov_idx;
+
+	for (i = 0; i < cnt; i++) {
+		cum_len += iov_buf[i].iov_len;
+	}
+
+	len = MIN(cum_len, buf_len);
+
+	cum_len = iov_buf[0].iov_len;
+
+	for (i = j = iov_idx = 0; j < len; j++, iov_idx++) {
+
+		if (j == cum_len) {
+			i++, iov_idx = 0;
+			cum_len += iov_buf[i].iov_len;
+
+			if (i >= cnt)
+				break;
+		}
+
+		if (((char *)iov_buf[i].iov_base)[iov_idx] != buf[j]) {
+			printf("data mismatch, iov_index: %lu, elem: %lu, "
+			       "iov_buf_len: %lu, "
+			       " iov_buf: %hhx, buf: %hhx\n", i, j,
+			       iov_buf[i].iov_len,
+			       ((char *)iov_buf[i].iov_base)[iov_idx],
+			       buf[j]);
+			return 0;
+		}
+	}
+
+	return 1;
+}
+
+static int
+check_iov_data(struct iovec *ib, struct iovec *ob, size_t cnt)
+{
+	size_t i;
+
+	for (i = 0; i < cnt; i++) {
+		if (memcmp(ib[i].iov_base, ob[i].iov_base, ib[i].iov_len)) {
+			printf("data mismatch, ib:%x ob:%x\n",
+			       *(char *)ib[i].iov_base,
+			       *(char *)ob[i].iov_base);
+			return 0;
+		}
+	}
+
+	return 1;
+}
+
 /*******************************************************************************
  * Test MSG functions
  ******************************************************************************/
@@ -355,11 +548,12 @@ TestSuite(scalable, .init = sep_setup, .fini = sep_teardown,
  * ssize_t fi_recv(struct fid_ep *ep, void * buf, size_t len,
  *		void *desc, fi_addr_t src_addr, void *context);
  */
-void sep_send_recv(int index, int len)
+static void sep_send_recv(int index, int len)
 {
 	ssize_t ret;
+	struct fi_cq_tagged_entry cqe;
 
-	sep_init_data(source, len, 0xab);
+	sep_init_data(source, len, 0xab + index);
 	sep_init_data(target, len, 0);
 
 	ret = fi_send(tx_ep[0][index], source, len, loc_mr[0],
@@ -370,7 +564,7 @@ void sep_send_recv(int index, int len)
 		      FI_ADDR_UNSPEC, source);
 	cr_assert(ret == 0, "fi_recv failed err:%ld", ret);
 
-	wait_for_cqs(txcq_array[0][index], rxcq_array[1][index]);
+	wait_for_cqs(tx_cq[0][index], rx_cq[1][index], &cqe, &cqe);
 
 	ret = sep_check_data(source, target, 8);
 	cr_assert(ret == 1, "Data check failed");
@@ -383,6 +577,1340 @@ Test(scalable, sr)
 	for (i = 0; i < ctx_cnt; i++) {
 		xfer_each_size(sep_send_recv, i, 1, BUF_SZ);
 	}
+}
 
-	dbg_printf("scalable done\n");
+/*
+ssize_t fi_sendv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+		 size_t count, fi_addr_t dest_addr, void *context);
+*/
+static void sep_sendv(int index, int len)
+{
+	int i, iov_cnt;
+	struct fi_cq_tagged_entry s_cqe, d_cqe;
+	ssize_t sz;
+	uint64_t s[NUMEPS] = {0}, r[NUMEPS] = {0}, s_e[NUMEPS] = {0};
+	uint64_t r_e[NUMEPS] = {0};
+
+	for (iov_cnt = 1; iov_cnt <= IOV_CNT; iov_cnt++) {
+		for (i = 0; i < iov_cnt; i++) {
+			sep_init_data(src_iov[i].iov_base, len, 0x25);
+			src_iov[i].iov_len = len;
+		}
+		sep_init_data(iov_dest_buf, len * iov_cnt, 0);
+
+		sz = fi_sendv(tx_ep[0][index], src_iov, NULL, iov_cnt,
+				rx_addr[index], iov_dest_buf);
+		cr_assert_eq(sz, 0);
+
+		sz = fi_recv(rx_ep[1][index], iov_dest_buf, len * iov_cnt,
+			     iov_dest_buf_mr[0], FI_ADDR_UNSPEC, src_iov);
+		cr_assert_eq(sz, 0);
+
+		/* reset cqe */
+		s_cqe.op_context = s_cqe.buf = (void *) -1;
+		s_cqe.flags = s_cqe.len = s_cqe.data = s_cqe.tag = UINT_MAX;
+		d_cqe.op_context = d_cqe.buf = (void *) -1;
+		d_cqe.flags = d_cqe.len = d_cqe.data = d_cqe.tag = UINT_MAX;
+
+		wait_for_cqs(tx_cq[0][index], rx_cq[1][index], &s_cqe, &d_cqe);
+		sep_check_cqe(&s_cqe, iov_dest_buf, (FI_MSG|FI_SEND),
+				 0, 0, 0, false);
+		sep_check_cqe(&d_cqe, src_iov, (FI_MSG|FI_RECV), iov_dest_buf,
+				 len * iov_cnt, 0, false);
+
+		s[0] = 1; r[1] = 1;
+		sep_check_cntrs(s, r, s_e, r_e);
+		cr_assert(sep_check_iov_data(src_iov, iov_dest_buf, iov_cnt,
+			len * iov_cnt), "Data mismatch");
+	}
+}
+
+Test(scalable, sendv)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		xfer_each_size(sep_sendv, i, 1, BUF_SZ);
+	}
+}
+
+static void sep_recvv(int index, int len)
+{
+	int i, iov_cnt;
+	ssize_t sz;
+	struct fi_cq_tagged_entry s_cqe, d_cqe;
+	uint64_t s[NUMEPS] = {0}, r[NUMEPS] = {0}, s_e[NUMEPS] = {0};
+	uint64_t r_e[NUMEPS] = {0};
+
+	for (iov_cnt = 1; iov_cnt <= IOV_CNT; iov_cnt++) {
+		for (i = 0; i < iov_cnt; i++) {
+			sep_init_data(src_iov[i].iov_base, len, 0x25 + index);
+			src_iov[i].iov_len = len;
+		}
+
+		for (i = 0; i < iov_cnt; i++) {
+			sep_init_data(dest_iov[i].iov_base, len, 0);
+			dest_iov[i].iov_len = len;
+		}
+
+		sz = fi_sendv(tx_ep[0][index], src_iov, NULL, iov_cnt,
+				rx_addr[index], iov_dest_buf);
+		cr_assert_eq(sz, 0);
+
+		sz = fi_recvv(rx_ep[1][index], dest_iov, NULL, iov_cnt,
+				FI_ADDR_UNSPEC, iov_src_buf);
+		cr_assert_eq(sz, 0);
+
+		/* reset cqe */
+		s_cqe.op_context = s_cqe.buf = (void *) -1;
+		s_cqe.flags = s_cqe.len = s_cqe.data = s_cqe.tag = UINT_MAX;
+		d_cqe.op_context = d_cqe.buf = (void *) -1;
+		d_cqe.flags = d_cqe.len = d_cqe.data = d_cqe.tag = UINT_MAX;
+
+		wait_for_cqs(tx_cq[0][index], rx_cq[1][index], &s_cqe, &d_cqe);
+		sep_check_cqe(&s_cqe, iov_dest_buf, (FI_MSG|FI_SEND),
+				 0, 0, 0, false);
+		sep_check_cqe(&d_cqe, iov_src_buf, (FI_MSG|FI_RECV),
+				iov_dest_buf, len * iov_cnt, 0, false);
+
+		s[0] = 1; r[1] = 1;
+		sep_check_cntrs(s, r, s_e, r_e);
+		cr_assert(check_iov_data(src_iov, dest_iov, iov_cnt),
+			  "Data mismatch");
+	}
+}
+
+Test(scalable, recvv)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		xfer_each_size(sep_recvv, i, 1, BUF_SZ);
+	}
+}
+
+static void sep_sendmsg(int index, int len)
+{
+	ssize_t sz;
+	struct fi_cq_tagged_entry s_cqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					    (void *) -1, UINT_MAX, UINT_MAX };
+	struct fi_cq_tagged_entry d_cqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					    (void *) -1, UINT_MAX, UINT_MAX };
+	struct fi_msg msg;
+	struct iovec iov;
+	uint64_t s[NUMEPS] = {0}, r[NUMEPS] = {0}, s_e[NUMEPS] = {0};
+	uint64_t r_e[NUMEPS] = {0};
+
+	iov.iov_base = source;
+	iov.iov_len = len;
+
+	msg.msg_iov = &iov;
+	msg.desc = (void **)loc_mr;
+	msg.iov_count = 1;
+	msg.addr = rx_addr[index];
+	msg.context = target;
+	msg.data = (uint64_t)target;
+
+	sep_init_data(source, len, 0xd0 + index);
+	sep_init_data(target, len, 0);
+
+	sz = fi_sendmsg(tx_ep[0][index], &msg, 0);
+	cr_assert_eq(sz, 0);
+
+	sz = fi_recv(rx_ep[1][index], target, len, rem_mr[0],
+		     FI_ADDR_UNSPEC, source);
+	cr_assert_eq(sz, 0);
+
+	wait_for_cqs(tx_cq[0][index], rx_cq[1][index], &s_cqe, &d_cqe);
+	sep_check_cqe(&s_cqe, target, (FI_MSG|FI_SEND), 0, 0, 0, false);
+	sep_check_cqe(&d_cqe, source, (FI_MSG|FI_RECV), target, len, 0,
+			false);
+
+	s[0] = 1; r[1] = 1;
+	sep_check_cntrs(s, r, s_e, r_e);
+	cr_assert(sep_check_data(source, target, len), "Data mismatch");
+}
+
+Test(scalable, sendmsg)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		xfer_each_size(sep_sendmsg, i, 1, BUF_SZ);
+	}
+}
+
+void sep_sendmsgdata(int index, int len)
+{
+	ssize_t sz;
+	struct fi_cq_tagged_entry s_cqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					    (void *) -1, UINT_MAX, UINT_MAX };
+	struct fi_cq_tagged_entry d_cqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					    (void *) -1, UINT_MAX, UINT_MAX };
+	struct fi_msg msg;
+	struct iovec iov;
+	uint64_t s[NUMEPS] = {0}, r[NUMEPS] = {0}, s_e[NUMEPS] = {0};
+	uint64_t r_e[NUMEPS] = {0};
+
+	iov.iov_base = source;
+	iov.iov_len = len;
+
+	msg.msg_iov = &iov;
+	msg.desc = (void **)loc_mr;
+	msg.iov_count = 1;
+	msg.addr = rx_addr[index];
+	msg.context = target;
+	msg.data = (uint64_t)source;
+
+	sep_init_data(source, len, 0xe0 + index);
+	sep_init_data(target, len, 0);
+
+	sz = fi_sendmsg(tx_ep[0][index], &msg, FI_REMOTE_CQ_DATA);
+	cr_assert_eq(sz, 0);
+
+	sz = fi_recv(rx_ep[1][index], target, len, rem_mr[0],
+		     FI_ADDR_UNSPEC, source);
+	cr_assert_eq(sz, 0);
+
+	wait_for_cqs(tx_cq[0][index], rx_cq[1][index], &s_cqe, &d_cqe);
+	sep_check_cqe(&s_cqe, target, (FI_MSG|FI_SEND), 0, 0, 0, false);
+	sep_check_cqe(&d_cqe, source, (FI_MSG|FI_RECV|FI_REMOTE_CQ_DATA),
+		      target, len, (uint64_t)source, false);
+
+	s[0] = 1; r[1] = 1;
+	sep_check_cntrs(s, r, s_e, r_e);
+	cr_assert(sep_check_data(source, target, len), "Data mismatch");
+}
+
+Test(scalable, sendmsgdata)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		xfer_each_size(sep_sendmsgdata, i, 1, BUF_SZ);
+	}
+}
+
+#define INJECT_SIZE 64
+void sep_inject(int index, int len)
+{
+	int ret;
+	ssize_t sz;
+	struct fi_cq_tagged_entry cqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					  (void *) -1, UINT_MAX, UINT_MAX };
+	uint64_t s[NUMEPS] = {0}, r[NUMEPS] = {0}, s_e[NUMEPS] = {0};
+	uint64_t r_e[NUMEPS] = {0};
+
+	sep_init_data(source, len, 0x13 + index);
+	sep_init_data(target, len, 0);
+
+	sz = fi_inject(tx_ep[0][index], source, len, rx_addr[index]);
+	cr_assert_eq(sz, 0);
+
+	sz = fi_recv(rx_ep[1][index], target, len, rem_mr[1],
+		     FI_ADDR_UNSPEC, source);
+	cr_assert_eq(sz, 0);
+
+	while ((ret = fi_cq_read(rx_cq[1][index], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+		/* Manually progress connection to domain 1 */
+		fi_cq_read(tx_cq[0][index], &cqe, 1);
+	}
+
+	cr_assert_eq(ret, 1);
+	sep_check_cqe(&cqe, source, (FI_MSG|FI_RECV),
+			 target, len, (uint64_t)source, false);
+
+	/* do progress until send counter is updated */
+	while (fi_cntr_read(send_cntr[0]) < 1) {
+		pthread_yield();
+	}
+	s[0] = 1; r[1] = 1;
+	sep_check_cntrs(s, r, s_e, r_e);
+
+	/* make sure inject does not generate a send competion */
+	cr_assert_eq(fi_cq_read(tx_cq[0][index], &cqe, 1), -FI_EAGAIN);
+	cr_assert(sep_check_data(source, target, len), "Data mismatch");
+}
+
+Test(scalable, inject)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		xfer_each_size(sep_inject, i, 1, INJECT_SIZE);
+	}
+}
+
+/*
+ssize_t fi_senddata(struct fid_ep *ep, void *buf, size_t len, void *desc,
+		    uint64_t data, fi_addr_t dest_addr, void *context);
+*/
+void sep_senddata(int index, int len)
+{
+	ssize_t sz;
+	struct fi_cq_tagged_entry s_cqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					    (void *) -1, UINT_MAX, UINT_MAX };
+	struct fi_cq_tagged_entry d_cqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					    (void *) -1, UINT_MAX, UINT_MAX };
+	uint64_t s[NUMEPS] = {0}, r[NUMEPS] = {0}, s_e[NUMEPS] = {0};
+	uint64_t r_e[NUMEPS] = {0};
+
+	sep_init_data(source, len, 0xab + index);
+	sep_init_data(target, len, 0);
+
+	sz = fi_senddata(tx_ep[0][index], source, len, loc_mr[0],
+			 (uint64_t)source, rx_addr[index], target);
+	cr_assert_eq(sz, 0);
+
+	sz = fi_recv(rx_ep[1][index], target, len, rem_mr[0],
+		     FI_ADDR_UNSPEC, source);
+	cr_assert_eq(sz, 0);
+
+	wait_for_cqs(tx_cq[0][index], rx_cq[1][index], &s_cqe, &d_cqe);
+	sep_check_cqe(&s_cqe, target, (FI_MSG|FI_SEND), 0, 0, 0, false);
+	sep_check_cqe(&d_cqe, source, (FI_MSG|FI_RECV|FI_REMOTE_CQ_DATA),
+			 target, len, (uint64_t)source, false);
+
+	s[0] = 1; r[1] = 1;
+	sep_check_cntrs(s, r, s_e, r_e);
+	cr_assert(sep_check_data(source, target, len), "Data mismatch");
+}
+
+Test(scalable, senddata)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		xfer_each_size(sep_senddata, i, 1, INJECT_SIZE);
+	}
+}
+
+/*
+ssize_t fi_injectdata(struct fid_ep *ep, const void *buf, size_t len,
+		      uint64_t data, fi_addr_t dest_addr);
+*/
+void sep_injectdata(int index, int len)
+{
+	int ret;
+	ssize_t sz;
+	struct fi_cq_tagged_entry cqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					  (void *) -1, UINT_MAX, UINT_MAX };
+	uint64_t s[NUMEPS] = {0}, r[NUMEPS] = {0}, s_e[NUMEPS] = {0};
+	uint64_t r_e[NUMEPS] = {0};
+
+	sep_init_data(source, len, 0x9b + index);
+	sep_init_data(target, len, 0);
+
+	sz = fi_injectdata(tx_ep[0][index], source, len, (uint64_t)source,
+			   rx_addr[index]);
+	cr_assert_eq(sz, 0);
+
+	sz = fi_recv(rx_ep[1][index], target, len, rem_mr[0],
+		     FI_ADDR_UNSPEC, source);
+	cr_assert_eq(sz, 0);
+
+	while ((ret = fi_cq_read(rx_cq[1][index], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+		/* Manually progress connection to domain 1 */
+		fi_cq_read(tx_cq[0][index], &cqe, 1);
+	}
+	sep_check_cqe(&cqe, source, (FI_MSG|FI_RECV|FI_REMOTE_CQ_DATA),
+			 target, len, (uint64_t)source, false);
+
+	/* don't progress until send counter is updated */
+	while (fi_cntr_read(send_cntr[0]) < 1) {
+		pthread_yield();
+	}
+
+	s[0] = 1; r[1] = 1;
+	sep_check_cntrs(s, r, s_e, r_e);
+
+	/* make sure inject does not generate a send competion */
+	cr_assert_eq(fi_cq_read(tx_cq[0][index], &cqe, 1), -FI_EAGAIN);
+	cr_assert(sep_check_data(source, target, len), "Data mismatch");
+}
+
+Test(scalable, injectdata)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		xfer_each_size(sep_injectdata, i, 1, INJECT_SIZE);
+	}
+}
+
+void sep_read(int index, int len)
+{
+	int ret;
+	ssize_t sz;
+	struct fi_cq_tagged_entry cqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					  (void *) -1, UINT_MAX, UINT_MAX };
+	uint64_t w[2] = {0}, r[2] = {0}, w_e[2] = {0}, r_e[2] = {0};
+
+#define READ_CTX 0x4e3dda1aULL
+	sep_init_data(source, len, 0);
+	sep_init_data(target, len, 0xad);
+
+	sz = fi_read(tx_ep[0][index], source, len,
+		     loc_mr[0], rx_addr[index], (uint64_t)target, mr_key[1],
+		     (void *)READ_CTX);
+	cr_assert_eq(sz, 0);
+
+	while ((ret = fi_cq_read(tx_cq[0][index], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	sep_check_tcqe(&cqe, (void *)READ_CTX, FI_RMA | FI_READ, 0);
+
+	r[0] = 1;
+	sep_check_cntrs(w, r, w_e, r_e);
+	cr_assert(sep_check_data(source, target, len), "Data mismatch");
+}
+
+Test(scalable, read)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		xfer_each_size(sep_read, i, 8, BUF_SZ);
+	}
+}
+
+void sep_readv(int index, int len)
+{
+	int ret;
+	ssize_t sz;
+	struct fi_cq_tagged_entry cqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					  (void *) -1, UINT_MAX, UINT_MAX };
+	struct iovec iov;
+	uint64_t w[2] = {0}, r[2] = {0}, w_e[2] = {0}, r_e[2] = {0};
+
+	iov.iov_base = source;
+	iov.iov_len = len;
+
+	sep_init_data(target, len, 0x25);
+	sep_init_data(source, len, 0);
+	sz = fi_readv(tx_ep[0][index], &iov, (void **)loc_mr, 1,
+		      rx_addr[index], (uint64_t)target, mr_key[1],
+		      target);
+	cr_assert_eq(sz, 0);
+
+	while ((ret = fi_cq_read(tx_cq[0][index], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	sep_check_tcqe(&cqe, target, FI_RMA | FI_READ, 0);
+
+	r[0] = 1;
+	sep_check_cntrs(w, r, w_e, r_e);
+	cr_assert(sep_check_data(source, target, len), "Data mismatch");
+}
+
+Test(scalable, readv)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		xfer_each_size(sep_readv, i, 8, BUF_SZ);
+	}
+}
+
+void sep_readmsg(int index, int len)
+{
+	int ret;
+	ssize_t sz;
+	struct fi_cq_tagged_entry cqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					  (void *) -1, UINT_MAX, UINT_MAX };
+	struct iovec iov;
+	struct fi_msg_rma msg;
+	struct fi_rma_iov rma_iov;
+	uint64_t w[2] = {0}, r[2] = {0}, w_e[2] = {0}, r_e[2] = {0};
+
+	iov.iov_base = source;
+	iov.iov_len = len;
+
+	rma_iov.addr = (uint64_t)target;
+	rma_iov.len = len;
+	rma_iov.key = mr_key[1];
+
+	msg.msg_iov = &iov;
+	msg.desc = (void **)loc_mr;
+	msg.iov_count = 1;
+	msg.addr = rx_addr[index];
+	msg.rma_iov = &rma_iov;
+	msg.rma_iov_count = 1;
+	msg.context = target;
+	msg.data = (uint64_t)target;
+
+	sep_init_data(target, len, 0xe0 + index);
+	sep_init_data(source, len, 0);
+	sz = fi_readmsg(tx_ep[0][index], &msg, 0);
+	cr_assert_eq(sz, 0);
+
+	while ((ret = fi_cq_read(tx_cq[0][index], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	sep_check_tcqe(&cqe, target, FI_RMA | FI_READ, 0);
+
+	r[0] = 1;
+	sep_check_cntrs(w, r, w_e, r_e);
+	cr_assert(sep_check_data(source, target, len), "Data mismatch");
+}
+
+Test(scalable, readmsg)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		xfer_each_size(sep_readmsg, i, 8, BUF_SZ);
+	}
+}
+
+void sep_write(int index, int len)
+{
+	int ret;
+	ssize_t sz;
+	struct fi_cq_tagged_entry cqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					  (void *) -1, UINT_MAX, UINT_MAX };
+	uint64_t w[2] = {0}, r[2] = {0}, w_e[2] = {0}, r_e[2] = {0};
+
+	sep_init_data(source, len, 0xab);
+	sep_init_data(target, len, 0);
+
+	sz = fi_write(tx_ep[0][index], source, len, loc_mr[0], rx_addr[index],
+		      (uint64_t)target, mr_key[1], target);
+	cr_assert_eq(sz, 0);
+
+	while ((ret = fi_cq_read(tx_cq[0][index], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	sep_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+
+	w[0] = 1;
+	sep_check_cntrs(w, r, w_e, r_e);
+	cr_assert(sep_check_data(source, target, len), "Data mismatch");
+}
+
+Test(scalable, write)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		xfer_each_size(sep_write, i, 8, BUF_SZ);
+	}
+}
+
+void sep_writev(int index, int len)
+{
+	int ret;
+	ssize_t sz;
+	struct fi_cq_tagged_entry cqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					  (void *) -1, UINT_MAX, UINT_MAX };
+	struct iovec iov;
+	uint64_t w[2] = {0}, r[2] = {0}, w_e[2] = {0}, r_e[2] = {0};
+
+	iov.iov_base = source;
+	iov.iov_len = len;
+
+	sep_init_data(source, len, 0x25 + index);
+	sep_init_data(target, len, 0);
+
+	sz = fi_writev(tx_ep[0][index], &iov, (void **)loc_mr, 1,
+		       gni_addr[1], (uint64_t)target, mr_key[1],
+		       target);
+	cr_assert_eq(sz, 0);
+
+	while ((ret = fi_cq_read(tx_cq[0][index], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	sep_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+
+	w[0] = 1;
+	sep_check_cntrs(w, r, w_e, r_e);
+	cr_assert(sep_check_data(source, target, len), "Data mismatch");
+}
+
+Test(scalable, writev)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		xfer_each_size(sep_writev, i, 8, BUF_SZ);
+	}
+}
+
+void sep_writemsg(int index, int len)
+{
+	int ret;
+	ssize_t sz;
+	struct fi_cq_tagged_entry cqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					  (void *) -1, UINT_MAX, UINT_MAX };
+	struct iovec iov;
+	struct fi_msg_rma msg;
+	struct fi_rma_iov rma_iov;
+	uint64_t w[2] = {0}, r[2] = {0}, w_e[2] = {0}, r_e[2] = {0};
+
+	iov.iov_base = source;
+	iov.iov_len = len;
+
+	rma_iov.addr = (uint64_t)target;
+	rma_iov.len = len;
+	rma_iov.key = mr_key[1];
+
+	msg.msg_iov = &iov;
+	msg.desc = (void **)loc_mr;
+	msg.iov_count = 1;
+	msg.addr = gni_addr[1];
+	msg.rma_iov = &rma_iov;
+	msg.rma_iov_count = 1;
+	msg.context = target;
+	msg.data = (uint64_t)target;
+
+	sep_init_data(source, len, 0xe4 + index);
+	sep_init_data(target, len, 0);
+	sz = fi_writemsg(tx_ep[0][index], &msg, 0);
+	cr_assert_eq(sz, 0);
+
+	while ((ret = fi_cq_read(tx_cq[0][index], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	sep_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+
+	w[0] = 1;
+	sep_check_cntrs(w, r, w_e, r_e);
+	cr_assert(sep_check_data(source, target, len), "Data mismatch");
+}
+
+Test(scalable, writemsg)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		xfer_each_size(sep_writemsg, i, 8, BUF_SZ);
+	}
+}
+
+void sep_inject_write(int index, int len)
+{
+	ssize_t sz;
+	int ret, i;
+	struct fi_cq_tagged_entry cqe;
+
+	sep_init_data(source, len, 0x33);
+	sep_init_data(target, len, 0);
+	sz = fi_inject_write(tx_ep[0][index], source, len,
+			     rx_addr[index], (uint64_t)target, mr_key[1]);
+	cr_assert_eq(sz, 0, "fi_inject_write returned %ld (%s)", sz,
+		     fi_strerror(-sz));
+
+	for (i = 0; i < len; i++) {
+		while (source[i] != target[i]) {
+			/* for progress */
+			ret = fi_cq_read(tx_cq[0][index], &cqe, 1);
+			cr_assert(ret == -FI_EAGAIN || ret == -FI_EAVAIL,
+				  "Received unexpected event\n");
+
+			pthread_yield();
+		}
+	}
+}
+
+Test(scalable, injectwrite)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		xfer_each_size(sep_inject_write, i, 8, INJECT_SIZE);
+	}
+}
+
+void sep_writedata(int index, int len)
+{
+	int ret;
+	ssize_t sz;
+	struct fi_cq_tagged_entry cqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					  (void *) -1, UINT_MAX, UINT_MAX };
+	struct fi_cq_tagged_entry dcqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					  (void *) -1, UINT_MAX, UINT_MAX };
+	uint64_t w[2] = {0}, r[2] = {0}, w_e[2] = {0}, r_e[2] = {0};
+
+
+#define WRITE_DATA 0x5123da1a145
+	sep_init_data(source, len, 0x43 + index);
+	sep_init_data(target, len, 0);
+	sz = fi_writedata(tx_ep[0][index], source, len, loc_mr[0], WRITE_DATA,
+			  rx_addr[index], (uint64_t)target, mr_key[1],
+			  target);
+	cr_assert_eq(sz, 0);
+
+	while ((ret = fi_cq_read(tx_cq[0][index], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	sep_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+
+	w[0] = 1;
+	sep_check_cntrs(w, r, w_e, r_e);
+	cr_assert(sep_check_data(source, target, len), "Data mismatch");
+
+	while ((ret = fi_cq_read(rx_cq[1][index], &dcqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+	cr_assert(ret != FI_SUCCESS, "Missing remote data");
+
+	sep_check_tcqe(&dcqe, NULL,
+		       (FI_RMA | FI_REMOTE_WRITE | FI_REMOTE_CQ_DATA),
+		       WRITE_DATA);
+}
+
+Test(scalable, writedata)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		xfer_each_size(sep_writedata, i, 8, BUF_SZ);
+	}
+}
+
+#define INJECTWRITE_DATA 0xdededadadeadbeaf
+void sep_inject_writedata(int index, int len)
+{
+	ssize_t sz;
+	int ret, i;
+	struct fi_cq_tagged_entry cqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					  (void *) -1, UINT_MAX, UINT_MAX };
+	struct fi_cq_tagged_entry dcqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					   (void *) -1, UINT_MAX, UINT_MAX };
+
+	sep_init_data(source, len, 0x53 + index);
+	sep_init_data(target, len, 0);
+	sz = fi_inject_writedata(tx_ep[0][index], source, len, INJECTWRITE_DATA,
+				 rx_addr[index], (uint64_t)target, mr_key[1]);
+	cr_assert_eq(sz, 0);
+
+	for (i = 0; i < len; i++) {
+		while (source[i] != target[i]) {
+			/* for progress */
+			ret = fi_cq_read(tx_cq[0][index], &cqe, 1);
+			cr_assert(ret == -FI_EAGAIN || ret == -FI_EAVAIL,
+				  "Received unexpected event\n");
+
+			pthread_yield();
+		}
+	}
+
+	while ((ret = fi_cq_read(rx_cq[1][index], &dcqe, 1)) == -FI_EAGAIN) {
+		ret = fi_cq_read(tx_cq[0][index], &cqe, 1); /* for progress */
+		pthread_yield();
+	}
+	cr_assert(ret != FI_SUCCESS, "Missing remote data");
+
+	sep_check_tcqe(&dcqe, NULL,
+		      (FI_RMA | FI_REMOTE_WRITE | FI_REMOTE_CQ_DATA),
+		      INJECTWRITE_DATA);
+}
+
+Test(scalable, inject_writedata)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		xfer_each_size(sep_inject_writedata, i, 8, INJECT_SIZE);
+	}
+}
+
+#define SOURCE_DATA	0xBBBB0000CCCCULL
+#define TARGET_DATA	0xAAAA0000DDDDULL
+void sep_atomic(int index)
+{
+	int ret;
+	ssize_t sz;
+	struct fi_cq_tagged_entry cqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					  (void *) -1, UINT_MAX, UINT_MAX };
+	uint64_t w[NUMEPS] = {0}, r[NUMEPS] = {0}, w_e[NUMEPS] = {0};
+	uint64_t r_e[NUMEPS] = {0};
+
+	/* u64 */
+	*((uint64_t *)source) = SOURCE_DATA;
+	*((uint64_t *)target) = TARGET_DATA;
+	sz = fi_atomic(tx_ep[0][index], source, 1,
+		       loc_mr[0], rx_addr[index], (uint64_t)target, mr_key[1],
+		       FI_UINT64, FI_ATOMIC_WRITE, target);
+	cr_assert_eq(sz, 0);
+
+	while ((ret = fi_cq_read(tx_cq[0][index], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_WRITE, 0);
+
+	w[0] = 1;
+	sep_check_cntrs(w, r, w_e, r_e);
+	ret = *((uint64_t *)target) == SOURCE_DATA;
+	cr_assert(ret, "Data mismatch");
+
+}
+
+Test(scalable, atomic)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		sep_atomic(i);
+	}
+}
+
+void sep_atomic_v(int index)
+{
+	int ret;
+	ssize_t sz;
+	struct fi_cq_tagged_entry cqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					  (void *) -1, UINT_MAX, UINT_MAX };
+	uint64_t min;
+	struct fi_ioc iov;
+	uint64_t w[NUMEPS] = {0}, r[NUMEPS] = {0}, w_e[NUMEPS] = {0};
+	uint64_t r_e[NUMEPS] = {0};
+
+	iov.addr = source;
+	iov.count = 1;
+
+	/* i64 */
+	*((int64_t *)source) = SOURCE_DATA;
+	*((int64_t *)target) = TARGET_DATA;
+	sz = fi_atomicv(tx_ep[0][index], &iov, (void **)loc_mr, 1,
+			rx_addr[index], (uint64_t)target, mr_key[1],
+			FI_INT64, FI_MIN, target);
+	cr_assert_eq(sz, 0);
+
+	while ((ret = fi_cq_read(tx_cq[0][index], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_WRITE, 0);
+
+	w[0] = 1;
+	sep_check_cntrs(w, r, w_e, r_e);
+	min = ((int64_t)SOURCE_DATA < (int64_t)TARGET_DATA) ?
+		SOURCE_DATA : TARGET_DATA;
+	ret = *((int64_t *)target) == min;
+	cr_assert(ret, "Data mismatch");
+}
+
+Test(scalable, atomicv)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		sep_atomic_v(i);
+	}
+}
+
+#define U32_MASK	0xFFFFFFFFULL
+void sep_atomic_msg(int index)
+{
+	int ret;
+	ssize_t sz;
+	struct fi_cq_tagged_entry cqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					  (void *) -1, UINT_MAX, UINT_MAX };
+	uint64_t min;
+	struct fi_msg_atomic msg;
+	struct fi_ioc msg_iov;
+	struct fi_rma_ioc rma_iov;
+	uint64_t w[NUMEPS] = {0}, r[NUMEPS] = {0}, w_e[NUMEPS] = {0};
+	uint64_t r_e[NUMEPS] = {0};
+
+	msg_iov.addr = source;
+	msg_iov.count = 1;
+	msg.msg_iov = &msg_iov;
+	msg.desc = (void **)loc_mr;
+	msg.iov_count = 1;
+	msg.addr = gni_addr[1];
+	rma_iov.addr = (uint64_t)target;
+	rma_iov.count = 1;
+	rma_iov.key = mr_key[1];
+	msg.rma_iov = &rma_iov;
+	msg.context = target;
+	msg.op = FI_MIN;
+
+	/* i32 */
+	*((int64_t *)source) = SOURCE_DATA;
+	*((int64_t *)target) = TARGET_DATA;
+	msg.datatype = FI_INT32;
+	sz = fi_atomicmsg(tx_ep[0][index], &msg, 0);
+	cr_assert_eq(sz, 0);
+
+	/* reset cqe */
+	cqe.op_context = cqe.buf = (void *) -1;
+	cqe.flags = cqe.len = cqe.data = cqe.tag = UINT_MAX;
+	while ((ret = fi_cq_read(tx_cq[0][index], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_WRITE, 0);
+
+	w[0] = 1;
+	sep_check_cntrs(w, r, w_e, r_e);
+	min = ((int32_t)SOURCE_DATA < (int32_t)TARGET_DATA) ?
+		SOURCE_DATA : TARGET_DATA;
+	min = (min & U32_MASK) | (TARGET_DATA & (U32_MASK << 32));
+	ret = *((int64_t *)target) == min;
+	cr_assert(ret, "Data mismatch");
+}
+
+Test(scalable, atomicmsg)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		sep_atomic_msg(i);
+	}
+}
+
+void sep_atomic_inject(int index)
+{
+	int ret, loops;
+	ssize_t sz;
+	struct fi_cq_tagged_entry cqe;
+	uint64_t min;
+
+	/* i64 */
+	*((int64_t *)source) = SOURCE_DATA;
+	*((int64_t *)target) = TARGET_DATA;
+	sz = fi_inject_atomic(tx_ep[0][index], source, 1,
+			      gni_addr[1], (uint64_t)target, mr_key[1],
+			      FI_INT64, FI_MIN);
+	cr_assert_eq(sz, 0);
+
+	min = ((int64_t)SOURCE_DATA < (int64_t)TARGET_DATA) ?
+		SOURCE_DATA : TARGET_DATA;
+	loops = 0;
+	while (*((int64_t *)target) != min) {
+		ret = fi_cq_read(tx_cq[0][index], &cqe, 1); /* for progress */
+		cr_assert(ret == -FI_EAGAIN,
+			  "Received unexpected event\n");
+
+		pthread_yield();
+		cr_assert(++loops < 10000, "Data mismatch");
+	}
+}
+
+Test(scalable, atomicinj)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		sep_atomic_inject(i);
+	}
+}
+
+#define FETCH_SOURCE_DATA	0xACEDACEDULL
+void sep_atomic_rw(int index)
+{
+	int ret;
+	ssize_t sz;
+	struct fi_cq_tagged_entry cqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					  (void *) -1, UINT_MAX, UINT_MAX };
+	uint64_t operand = SOURCE_DATA;
+	uint64_t w[NUMEPS] = {0}, r[NUMEPS] = {0}, w_e[NUMEPS] = {0};
+	uint64_t r_e[NUMEPS] = {0};
+
+	/* u64 */
+	*((uint64_t *)source) = FETCH_SOURCE_DATA;
+	*((uint64_t *)target) = TARGET_DATA;
+	sz = fi_fetch_atomic(tx_ep[0][index], &operand, 1, NULL, source,
+			     loc_mr[0], rx_addr[index], (uint64_t)target,
+			     mr_key[1], FI_UINT64, FI_SUM, target);
+	cr_assert_eq(sz, 0);
+
+	while ((ret = fi_cq_read(tx_cq[0][index], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_READ, 0);
+
+	r[0] = 1;
+	sep_check_cntrs(w, r, w_e, r_e);
+	ret = *((uint64_t *)target) == (SOURCE_DATA + TARGET_DATA);
+	cr_assert(ret, "Data mismatch");
+	ret = *((uint64_t *)source) == TARGET_DATA;
+	cr_assert(ret, "Fetch data mismatch");
+}
+
+Test(scalable, atomicrw)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		sep_atomic_rw(i);
+	}
+}
+
+void sep_atomic_rwv(int index)
+{
+	int ret;
+	ssize_t sz;
+	struct fi_cq_tagged_entry cqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					  (void *) -1, UINT_MAX, UINT_MAX };
+	uint64_t min;
+	uint64_t operand = SOURCE_DATA;
+	struct fi_ioc iov, r_iov;
+	uint64_t w[NUMEPS] = {0}, r[NUMEPS] = {0}, w_e[NUMEPS] = {0};
+	uint64_t r_e[NUMEPS] = {0};
+
+	iov.count = 1;
+	r_iov.count = 1;
+
+	/* i64 */
+	*((int64_t *)source) = FETCH_SOURCE_DATA;
+	*((int64_t *)target) = TARGET_DATA;
+	iov.addr = &operand;
+	r_iov.addr = source;
+	sz = fi_fetch_atomicv(tx_ep[0][index], &iov, NULL, 1,
+			      &r_iov, (void **)loc_mr, 1,
+			      gni_addr[1], (uint64_t)target, mr_key[1],
+			      FI_INT64, FI_MIN, target);
+	cr_assert_eq(sz, 0);
+
+	while ((ret = fi_cq_read(tx_cq[0][index], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_READ, 0);
+
+	r[0] = 1;
+	sep_check_cntrs(w, r, w_e, r_e);
+	min = ((int64_t)SOURCE_DATA < (int64_t)TARGET_DATA) ?
+		SOURCE_DATA : TARGET_DATA;
+	ret = *((int64_t *)target) == min;
+	cr_assert(ret, "Data mismatch");
+	ret = *((int64_t *)source) == TARGET_DATA;
+	cr_assert(ret, "Fetch data mismatch");
+}
+
+Test(scalable, atomicrwv)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		sep_atomic_rw(i);
+	}
+}
+
+void sep_atomic_rwmsg(int index)
+{
+	int ret;
+	ssize_t sz;
+	struct fi_cq_tagged_entry cqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					  (void *) -1, UINT_MAX, UINT_MAX };
+	uint64_t min;
+	uint64_t operand = SOURCE_DATA;
+	struct fi_msg_atomic msg;
+	struct fi_ioc msg_iov, res_iov;
+	struct fi_rma_ioc rma_iov;
+	uint64_t w[NUMEPS] = {0}, r[NUMEPS] = {0}, w_e[NUMEPS] = {0};
+	uint64_t r_e[NUMEPS] = {0};
+
+	msg_iov.count = 1;
+	msg.msg_iov = &msg_iov;
+	msg.desc = (void **)loc_mr;
+	msg.iov_count = 1;
+	msg.addr = gni_addr[1];
+	rma_iov.addr = (uint64_t)target;
+	rma_iov.count = 1;
+	rma_iov.key = mr_key[1];
+	msg.rma_iov = &rma_iov;
+	msg.context = target;
+	msg.op = FI_MIN;
+
+	res_iov.addr = source;
+	res_iov.count = 1;
+
+	/* i64 */
+	*((int64_t *)source) = FETCH_SOURCE_DATA;
+	*((int64_t *)target) = TARGET_DATA;
+	msg_iov.addr = &operand;
+	msg.datatype = FI_INT64;
+	sz = fi_fetch_atomicmsg(tx_ep[0][index], &msg, &res_iov,
+				(void **)loc_mr, 1, 0);
+	cr_assert_eq(sz, 0);
+
+	while ((ret = fi_cq_read(tx_cq[0][index], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_READ, 0);
+
+	r[0] = 1;
+	sep_check_cntrs(w, r, w_e, r_e);
+	min = ((int64_t)SOURCE_DATA < (int64_t)TARGET_DATA) ?
+		SOURCE_DATA : TARGET_DATA;
+	ret = *((int64_t *)target) == min;
+	cr_assert(ret, "Data mismatch");
+	ret = *((int64_t *)source) == TARGET_DATA;
+	cr_assert(ret, "Fetch data mismatch");
+}
+
+Test(scalable, atomicrwmsg)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		sep_atomic_rwmsg(i);
+	}
+}
+
+void sep_atomic_compwrite(int index)
+{
+	int ret;
+	ssize_t sz;
+	struct fi_cq_tagged_entry cqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					  (void *) -1, UINT_MAX, UINT_MAX };
+	uint64_t operand = SOURCE_DATA, op2 = TARGET_DATA;
+	uint64_t w[NUMEPS] = {0}, r[NUMEPS] = {0}, w_e[NUMEPS] = {0};
+	uint64_t r_e[NUMEPS] = {0};
+
+	/* u64 */
+	*((uint64_t *)source) = FETCH_SOURCE_DATA;
+	*((uint64_t *)target) = TARGET_DATA;
+	sz = fi_compare_atomic(tx_ep[0][index], &operand, 1, NULL, &op2, NULL,
+			       source, loc_mr[0], rx_addr[index],
+			       (uint64_t)target, mr_key[1], FI_UINT64,
+			       FI_CSWAP, target);
+	cr_assert_eq(sz, 0, "fi_compare_atomic returned %ld (%s)", sz,
+		     fi_strerror(-sz));
+
+	/* reset cqe */
+	cqe.op_context = cqe.buf = (void *) -1;
+	cqe.flags = cqe.len = cqe.data = cqe.tag = UINT_MAX;
+	while ((ret = fi_cq_read(tx_cq[0][index], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_READ, 0);
+
+	r[0] = 1;
+	sep_check_cntrs(w, r, w_e, r_e);
+	ret = *((uint64_t *)target) == SOURCE_DATA;
+	cr_assert(ret, "Data mismatch");
+	ret = *((uint64_t *)source) == TARGET_DATA;
+	cr_assert(ret, "Fetch data mismatch");
+}
+
+Test(scalable, atomiccompwrite)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		sep_atomic_compwrite(i);
+	}
+}
+
+#define SOURCE_DATA_FP	0.83203125
+#define TARGET_DATA_FP	0.83984375
+void sep_atomic_compwritev(int index)
+{
+	int ret;
+	ssize_t sz;
+	struct fi_cq_tagged_entry cqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					  (void *) -1, UINT_MAX, UINT_MAX };
+	double operand_dp, op2_dp;
+	struct fi_ioc iov, r_iov, c_iov;
+	uint64_t w[NUMEPS] = {0}, r[NUMEPS] = {0}, w_e[NUMEPS] = {0};
+	uint64_t r_e[NUMEPS] = {0};
+
+	iov.count = 1;
+	r_iov.count = 1;
+	c_iov.count = 1;
+
+	/* double */
+	*((double *)&operand_dp) = SOURCE_DATA_FP;
+	*((double *)&op2_dp) = TARGET_DATA_FP;
+	*((double *)source) = FETCH_SOURCE_DATA;
+	*((double *)target) = TARGET_DATA_FP;
+	iov.addr = &operand_dp;
+	r_iov.addr = source;
+	c_iov.addr = &op2_dp;
+	sz = fi_compare_atomicv(tx_ep[0][index],
+				&iov, NULL, 1,
+				&c_iov, NULL, 1,
+				&r_iov, (void **)loc_mr, 1,
+				gni_addr[1], (uint64_t)target, mr_key[1],
+				FI_DOUBLE, FI_CSWAP, target);
+	cr_assert_eq(sz, 0);
+
+	/* reset cqe */
+	cqe.op_context = cqe.buf = (void *) -1;
+	cqe.flags = cqe.len = cqe.data = cqe.tag = UINT_MAX;
+
+	while ((ret = fi_cq_read(tx_cq[0][index], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_READ, 0);
+	r[0] = 1;
+	sep_check_cntrs(w, r, w_e, r_e);
+	ret = *((double *)target) == (double)SOURCE_DATA_FP;
+	cr_assert(ret, "Data mismatch");
+	ret = *((double *)source) == (double)TARGET_DATA_FP;
+	cr_assert(ret, "Fetch data mismatch");
+}
+
+Test(scalable, atomiccompwritev)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		sep_atomic_compwritev(i);
+	}
+}
+
+void sep_atomic_compwritemsg(int index)
+{
+	int ret;
+	ssize_t sz;
+	struct fi_cq_tagged_entry cqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					  (void *) -1, UINT_MAX, UINT_MAX };
+	uint64_t operand = SOURCE_DATA, op2 = TARGET_DATA;
+	struct fi_msg_atomic msg;
+	struct fi_ioc msg_iov, res_iov, cmp_iov;
+	struct fi_rma_ioc rma_iov;
+	uint64_t w[NUMEPS] = {0}, r[NUMEPS] = {0}, w_e[NUMEPS] = {0};
+	uint64_t r_e[NUMEPS] = {0};
+
+	msg_iov.count = 1;
+	msg.msg_iov = &msg_iov;
+	msg.desc = (void **)loc_mr;
+	msg.iov_count = 1;
+	msg.addr = gni_addr[1];
+	rma_iov.addr = (uint64_t)target;
+	rma_iov.count = 1;
+	rma_iov.key = mr_key[1];
+	msg.rma_iov = &rma_iov;
+	msg.context = target;
+	msg.op = FI_CSWAP;
+
+	res_iov.count = 1;
+	cmp_iov.count = 1;
+
+	/* i64 */
+	*((uint64_t *)source) = FETCH_SOURCE_DATA;
+	*((uint64_t *)target) = TARGET_DATA;
+	msg_iov.addr = &operand;
+	msg.datatype = FI_INT64;
+	res_iov.addr = source;
+	cmp_iov.addr = &op2;
+	sz = fi_compare_atomicmsg(tx_ep[0][index], &msg, &cmp_iov, NULL, 1,
+				  &res_iov, (void **)loc_mr, 1, 0);
+	cr_assert_eq(sz, 0);
+
+	/* reset cqe */
+	cqe.op_context = cqe.buf = (void *) -1;
+	cqe.flags = cqe.len = cqe.data = cqe.tag = UINT_MAX;
+	while ((ret = fi_cq_read(tx_cq[0][index], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_READ, 0);
+	r[0] = 1;
+	sep_check_cntrs(w, r, w_e, r_e);
+	ret = *((uint64_t *)target) == SOURCE_DATA;
+	cr_assert(ret, "Data mismatch");
+	ret = *((uint64_t *)source) == TARGET_DATA;
+	cr_assert(ret, "Fetch data mismatch");
+}
+
+Test(scalable, atomiccompwritemsg)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		sep_atomic_compwritemsg(i);
+	}
+}
+
+void sep_invalid_compare_atomic(enum fi_datatype dt, enum fi_op op)
+{
+	ssize_t sz;
+	size_t count;
+	uint64_t operand, op2;
+
+	if (!supported_compare_atomic_ops[op][dt]) {
+		sz = fi_compare_atomic(tx_ep[0][0], &operand, 1, NULL,
+				       &op2, NULL, source, loc_mr,
+				       rx_addr[0], (uint64_t)target, mr_key[1],
+				       dt, op, target);
+		cr_assert(sz == -FI_ENOENT);
+
+		sz = fi_compare_atomicvalid(tx_ep[0][0], dt, op, &count);
+		cr_assert(sz == -FI_ENOENT, "fi_atomicvalid() succeeded\n");
+	} else {
+		sz = fi_compare_atomicvalid(tx_ep[0][0], dt, op, &count);
+		cr_assert(!sz, "fi_atomicvalid() failed\n");
+		cr_assert(count == 1, "fi_atomicvalid(): bad count\n");
+	}
+}
+
+Test(scalable, atomic_invalid_compare)
+{
+	int i, j;
+
+	for (i = 0; i < FI_ATOMIC_OP_LAST; i++) {
+		for (j = 0; j < FI_DATATYPE_LAST; j++) {
+			sep_invalid_compare_atomic(j, i);
+		}
+	}
+}
+
+void sep_invalid_fetch_atomic(enum fi_datatype dt, enum fi_op op)
+{
+	ssize_t sz;
+	size_t count;
+	uint64_t operand;
+
+	if (!supported_fetch_atomic_ops[op][dt]) {
+		sz = fi_fetch_atomic(tx_ep[0][0], &operand, 1, NULL,
+				     source, loc_mr[0],
+				     rx_addr[0], (uint64_t)target, mr_key[1],
+				     dt, op, target);
+		cr_assert(sz == -FI_ENOENT);
+
+		sz = fi_fetch_atomicvalid(tx_ep[0][0], dt, op, &count);
+		cr_assert(sz == -FI_ENOENT, "fi_atomicvalid() succeeded\n");
+	} else {
+		sz = fi_fetch_atomicvalid(tx_ep[0][0], dt, op, &count);
+		cr_assert(!sz, "fi_atomicvalid() failed\n");
+		cr_assert(count == 1, "fi_atomicvalid(): bad count\n");
+	}
+}
+
+Test(scalable, atomic_invalid_fetch)
+{
+	int i, j;
+
+	for (i = 0; i < FI_ATOMIC_OP_LAST; i++) {
+		for (j = 0; j < FI_DATATYPE_LAST; j++) {
+			sep_invalid_fetch_atomic(j, i);
+		}
+	}
 }


### PR DESCRIPTION
Implement missing msg, rma, and atomic scalable endpoint ops.
Added tests for all implemented message endpoint ops.
Added support for counters

Future items:
Consider refactor of _gnix_ep_alloc/gnix_ep_open.
Support FI_AV_TABLE
Implement tagged scalable endpoint ops

Fixes ofi-cray/libfabric-cray#1012

Signed-off-by: Chuck Fossen <chuckf@cray.com>
@hppritcha @sungeunchoi 