### PR TITLE
prov/gni: have stx open allocate a gnix_nic

### DIFF
--- a/prov/gni/Makefile.include
+++ b/prov/gni/Makefile.include
@@ -79,6 +79,7 @@ _gni_headers = \
 	prov/gni/include/gnix_xpmem.h \
 	prov/gni/include/gnix_wait.h
 
+
 if HAVE_CRITERION
 bin_PROGRAMS += prov/gni/test/gnitest
 bin_SCRIPTS += prov/gni/test/run_gnitest
@@ -118,8 +119,9 @@ nodist_prov_gni_test_gnitest_SOURCES = \
 	prov/gni/test/vc_lookup.c \
 	prov/gni/test/vector.c \
 	prov/gni/test/wait.c \
-	prov/gni/test/common.c \
-	prov/gni/test/cm.c
+	prov/gni/test/rdm_dgram_stx.c \
+	prov/gni/test/cm.c \
+	prov/gni/test/common.c
 
 prov_gni_test_gnitest_LDFLAGS = $(CRAY_PMI_LIBS) $(gnitest_LDFLAGS) -static
 prov_gni_test_gnitest_CPPFLAGS = $(AM_CPPFLAGS) $(CRAY_PMI_CFLAGS) $(CRAY_XPMEM_CFLAGS) $(gnitest_CPPFLAGS)

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -523,6 +523,7 @@ struct gnix_fid_ep {
 	struct gnix_xpmem_handle *xpmem_hndl;
 	bool tx_enabled;
 	bool rx_enabled;
+	bool shared_tx;
 	bool requires_lock;
 	int last_cached;
 	struct gnix_addr_cache_entry addr_cache[GNIX_ADDR_CACHE_SIZE];
@@ -629,14 +630,17 @@ struct gnix_fid_trx {
 
 /**
  * gnix_fid_stx struct
+ * @note - another way to associated gnix_nic's with an ep
  *
- * @var stx_fid         embedded struct fid_stx field
- * @var domain          pointer to domain used to create the stx instance
- * @var ref_cnt         ref cnt on this object
+ * @var stx_fid              embedded struct fid_stx field
+ * @var domain               pointer to domain used to create the stx instance
+ * @var nic                  pointer to gnix_nic associated with this stx
+ * @var ref_cnt              ref cnt on this object
  */
 struct gnix_fid_stx {
 	struct fid_stx stx_fid;
 	struct gnix_fid_domain *domain;
+	struct gnix_nic *nic;
 	struct gnix_reference ref_cnt;
 };
 

--- a/prov/gni/include/gnix_ep.h
+++ b/prov/gni/include/gnix_ep.h
@@ -300,6 +300,13 @@ int _gnix_ep_alloc(struct fid_domain *domain, struct fi_info *info,
 
 int _gnix_ep_init_vc(struct gnix_fid_ep *ep_priv);
 
+/**
+ * Internal function for enabling an ep
+ *
+ * @param[in] ep_priv	 pointer to a previously allocated EP
+ */
+int _gnix_ep_enable(struct gnix_fid_ep *ep_priv);
+
 /*******************************************************************************
  * API Functions
  ******************************************************************************/

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -91,6 +91,7 @@ struct gnix_nic_attr {
 	gni_nic_handle_t gni_nic_hndl;
 	bool use_cdm_id;
 	uint32_t cdm_id;
+	bool must_alloc;
 };
 
 /**

--- a/prov/gni/src/gnix_cm_nic.c
+++ b/prov/gni/src/gnix_cm_nic.c
@@ -594,6 +594,11 @@ int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 		goto err;
 	}
 
+	/*
+	 * we have to force allocation of a new nic since we want
+	 * an a particulard cdm id
+	 */
+	nic_attr.must_alloc = true;
 	nic_attr.use_cdm_id = true;
 	nic_attr.cdm_id = cdm_id;
 

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -382,8 +382,11 @@ static int _gnix_ep_getinfo(enum fi_ep_type ep_type, uint32_t version,
 				goto err;
 			}
 
-			if (hints->ep_attr->tx_ctx_cnt > GNIX_SEP_MAX_CNT)
+			if ((hints->ep_attr->tx_ctx_cnt > GNIX_SEP_MAX_CNT) &&
+				(hints->ep_attr->tx_ctx_cnt !=
+						FI_SHARED_CONTEXT)) {
 				goto err;
+			}
 
 			if (hints->ep_attr->rx_ctx_cnt > GNIX_SEP_MAX_CNT)
 				goto err;

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -976,8 +976,7 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 		if (ret != FI_SUCCESS)
 			return ret;
 		nic_attr = attr;
-		if (nic_attr->use_cdm_id == true)
-			must_alloc_nic = true;
+		must_alloc_nic = nic_attr->must_alloc;
 	}
 
 	/*
@@ -1000,7 +999,7 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 
 	/*
 	 * we can reuse previously allocated nics as long as a
-	 * cdm_id is not specified in the nic_attr arg.
+	 * must_alloc is not specified in the nic_attr arg.
 	 */
 
 	if ((must_alloc_nic == false) && (gnix_nics_per_ptag[domain->ptag] >=

--- a/prov/gni/src/gnix_sep.c
+++ b/prov/gni/src/gnix_sep.c
@@ -515,10 +515,17 @@ static int gnix_sep_control(fid_t fid, int command, void *arg)
 					ret);
 				goto err;
 			}
-			if (ep->send_cq)
-				ep->tx_enabled = true;
-			if (ep->recv_cq)
-				ep->rx_enabled = true;
+
+			/*
+			 * enable the EP
+			 */
+			ret = _gnix_ep_enable(ep);
+			if (ret != FI_SUCCESS) {
+				GNIX_WARN(FI_LOG_EP_CTRL,
+				     "_gnix_ep_enable call returned %d\n",
+					ret);
+				goto err;
+			}
 		}
 
 		break;


### PR DESCRIPTION
Some applications might want to use the stx approach
to bind EP's to different "hardware" nic resources.
With this commit, gnix_fid_stx is no longer a no-op
but a way for an app to allocate an underlying
gnix_nic struct and to bind it to one more EP's
allocated from the same domain.

This is closer to the intent of the OFI libfabric
API for shared TX structs than the original GNI
provider code.

The original way of allocating a gnix_nic during
the gnix_ep_open phase is unchanged unless the
info argument's ep_attr->tx_ctx_cnt field is set
to FI_SHARED_CONTEXT.

Note that the fabtest which checks the functionality
of tx shared contexts has a similar issue to that found
for the scalable endpoint test.

A fix to the fabtest should be merged in to that repo
before merging this PR in to libfabric-cray.  PR ofiwg/fabtests#589.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit d2cec4df0b30d7a5303b72d829542f9010bebff3)