### PR TITLE
prov/gni: fix a memory reg leak in rdm_sr test

### DIFF
--- a/prov/gni/test/rdm_sr.c
+++ b/prov/gni/test/rdm_sr.c
@@ -348,6 +348,8 @@ static void rdm_sr_teardown_common(bool unreg)
 		if (unreg) {
 			fi_close(&loc_mr[i]->fid);
 			fi_close(&rem_mr[i]->fid);
+			fi_close(&iov_dest_buf_mr[i]->fid);
+			fi_close(&iov_src_buf_mr[i]->fid);
 		}
 
 		ret = fi_close(&ep[i]->fid);


### PR DESCRIPTION
rdm_sr wasn't closing memory registration fid's
associated with send and recv iovec regions.

This results in resource leaks that leads to failures
of criterion tests if enough of them are run.

@sungeunchoi 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>