### PR TITLE
prov/gni: Open MR notifier per domain, add locking

### DIFF
--- a/prov/gni/include/gnix_mr_notifier.h
+++ b/prov/gni/include/gnix_mr_notifier.h
@@ -67,16 +67,15 @@ struct gnix_mr_notifier {
 	int fd;
 	kdreg_user_delta_t *cntr;
 	fastlock_t lock;
+	int ref_cnt;
 };
 
 /**
- * @brief initialize the gnix_mr_notifier struct
+ * @brief initialize the process for use of the notifier
  *
- * @param[out] k        Empty (zeroed) gnix_mr_notifier struct
  * @return              FI_SUCESSS on success
- *                      -FI_EINVAL if k == NULL
  */
-int _gnix_notifier_init(struct gnix_mr_notifier *mrn);
+int _gnix_notifier_init(void);
 
 /**
  * @brief open the kdreg device and prepare for notifications
@@ -87,7 +86,7 @@ int _gnix_notifier_init(struct gnix_mr_notifier *mrn);
  *                      -FI_ENODATA if user delta unavailable
  *                      -fi_errno or -errno on other failures
  */
-int _gnix_notifier_open(struct gnix_mr_notifier *mrn);
+int _gnix_notifier_open(struct gnix_mr_notifier **mrn);
 
 /**
  * @brief close the kdreg device and zero the notifier
@@ -142,7 +141,7 @@ struct gnix_mr_notifier {
 };
 
 static inline int
-_gnix_notifier_init(struct gnix_mr_notifier *mrn)
+_gnix_notifier_init(void)
 {
 	return FI_SUCCESS;
 }

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -101,11 +101,6 @@ static void __fabric_destruct(void *obj)
 {
 	struct gnix_fid_fabric *fab = (struct gnix_fid_fabric *) obj;
 
-	/*
-	 * close the MR notifier
-	 */
-	(void) _gnix_notifier_close(&fab->mr_notifier);
-
 	_gnix_app_cleanup();
 
 	free(fab);
@@ -142,7 +137,6 @@ static int gnix_fabric_open(struct fi_fabric_attr *attr,
 			    struct fid_fabric **fabric,
 			    void *context)
 {
-	int ret;
 	struct gnix_fid_fabric *fab;
 
 	if (strcmp(attr->name, gnix_fab_name)) {
@@ -167,17 +161,6 @@ static int gnix_fabric_open(struct fi_fabric_attr *attr,
 	fab->fab_fid.ops = &gnix_fab_ops;
 	_gnix_ref_init(&fab->ref_cnt, 1, __fabric_destruct);
 	dlist_init(&fab->domain_list);
-
-	ret = _gnix_notifier_init(&fab->mr_notifier);
-	if (ret != FI_SUCCESS) {
-		return ret;
-	}
-
-	// TODO: open dynamically as needed
-	ret = _gnix_notifier_open(&fab->mr_notifier);
-	if (ret != FI_SUCCESS && ret != -FI_EBUSY) {
-		return ret;
-	}
 
 	*fabric = &fab->fab_fid;
 
@@ -627,6 +610,9 @@ GNI_INI
 		gnix_max_nics_per_ptag = 1;
 		GNIX_WARN(FI_LOG_FABRIC, "Using inter-procss FMA sharing\n");
 	}
+
+	/* Initialize global MR notifier. */
+	_gnix_notifier_init();
 
 	return (provider);
 }

--- a/prov/gni/test/cm.c
+++ b/prov/gni/test/cm.c
@@ -349,7 +349,7 @@ void cm_basic_send(void)
 		   source, target);
 }
 
-Test(cm_basic, srv_setup, .disabled = true)
+Test(cm_basic, srv_setup, .disabled = false)
 {
 	int cli_connected = 0, srv_connected = 0;
 	int i;

--- a/prov/gni/test/mr_notifier.c
+++ b/prov/gni/test/mr_notifier.c
@@ -43,9 +43,6 @@ static void mr_notifier_setup(void)
 {
 	int ret;
 
-	ret = _gnix_notifier_init(&mr_notifier);
-	cr_assert(ret == 0, "_gnix_notifier_init failed");
-
 	ret = _gnix_notifier_open(&mr_notifier);
 	cr_assert(ret == 0, "_gnix_notifier_open failed");
 }


### PR DESCRIPTION
kdreg limits us to opening a single MR notifier object per process.  Currently,
the provider uses a new notifier object per fabric.  To allow multiple fabrics
in a single process, create a single, global kdreg MR notifier and share
between all domains on all fabrics.  Use of multiple domains is still limited
by issue #1064.

Fixes ofi-cray/libfabric-cray#1069.

Signed-off-by: Zach <ztiffany@cray.com>

@sungeunchoi @jswaro @hppritcha 