### PR TITLE
prov/gni: Move eq function prototypes after internal eq structs are declared

### DIFF
--- a/prov/gni/include/gnix_eq.h
+++ b/prov/gni/include/gnix_eq.h
@@ -46,13 +46,6 @@
 extern struct dlist_entry gnix_eq_list;
 extern pthread_mutex_t gnix_eq_list_lock;
 
-ssize_t _gnix_eq_write_error(struct fid_eq *eq, fid_t fid,
-			     void *context, uint64_t index, int err,
-			     int prov_errno, void *err_data,
-			     size_t err_size);
-
-int _gnix_eq_progress(struct gnix_fid_eq *eq);
-
 /*
  * Stores events inside of the event queue.
  *
@@ -99,6 +92,13 @@ struct gnix_fid_eq {
 	struct dlist_entry poll_objs;
 	struct dlist_entry gnix_fid_eq_list;
 };
+
+ssize_t _gnix_eq_write_error(struct fid_eq *eq, fid_t fid,
+			     void *context, uint64_t index, int err,
+			     int prov_errno, void *err_data,
+			     size_t err_size);
+
+int _gnix_eq_progress(struct gnix_fid_eq *eq);
 
 int _gnix_eq_poll_obj_add(struct gnix_fid_eq *eq, struct fid *obj_fid);
 int _gnix_eq_poll_obj_rem(struct gnix_fid_eq *eq, struct fid *obj_fid);


### PR DESCRIPTION
Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>