### PR TITLE
prov/gni: Fix kdreg tests

### DIFF
--- a/prov/gni/configure.m4
+++ b/prov/gni/configure.m4
@@ -135,6 +135,7 @@ dnl looks like we need to get rid of some white space
 
         if test "$with_kdreg" != "" && test "$with_kdreg" != "no"; then
 		    gni_CPPFLAGS="-I$with_kdreg/include -DHAVE_KDREG $gni_CPPFLAGS"
+		    gnitest_CPPFLAGS="-I$with_kdreg/include -DHAVE_KDREG $gnitest_CPPFLAGS"
         fi
 
 

--- a/prov/gni/include/gnix_mr_notifier.h
+++ b/prov/gni/include/gnix_mr_notifier.h
@@ -147,7 +147,7 @@ _gnix_notifier_init(void)
 }
 
 static inline int
-_gnix_notifier_open(struct gnix_mr_notifier *mrn)
+_gnix_notifier_open(struct gnix_mr_notifier **mrn)
 {
 	return FI_SUCCESS;
 }


### PR DESCRIPTION
We didn't notice that the notifier tests stopped being tested with
kdreg when we changed the configure script to use separate flags for
compiling gnitest and the provider.  This commit adds the kdreg flags
to the gnitest flags and fixes the notifier tests to use the new
notifier interface from bc3f605.

@hppritcha @ztiffany 

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>