### PR TITLE
/prov/gni: Implement FI_AV_TABLE for scalable endpoints

### DIFF
--- a/prov/gni/include/gnix_av.h
+++ b/prov/gni/include/gnix_av.h
@@ -104,36 +104,6 @@ int _gnix_av_reverse_lookup(struct gnix_fid_av *gnix_av,
  ******************************************************************************/
 
 /**
- * @brief (FI_AV_TABLE) Return the gnix address using its corresponding
- * fi_addr.
- *
- * @param[in] int_av		The AV to use for the lookup.
- * @param[in] fi_addr		The corresponding fi_addr_t.
- * @param[in/out] entry_ptr	pointer to an av entry struct
- *
- * @return FI_SUCCESS on successfully looking up the entry in the entry table.
- * @return -FI_EINVAL upon passing an invalid parameter.
- */
-int _gnix_table_lookup(struct gnix_fid_av *int_av,
-		       fi_addr_t fi_addr,
-		       struct gnix_av_addr_entry *entry_ptr);
-
-/**
- * @brief (FI_AV_MAP) Return the gnix address using its corresponding
- * fi_addr.
- *
- * @param[in] int_av		The AV to use for the lookup.
- * @param[in] fi_addr		The corresponding fi_addr_t.
- * @param[in/out] entry_ptr	pointer to an av entry struct
- *
- * @return FI_SUCCESS on successfully looking up the entry in the entry table.
- * @return -FI_EINVAL upon passing an invalid parameter.
- */
-int _gnix_map_lookup(struct gnix_fid_av *int_av,
-		     fi_addr_t fi_addr,
-		     struct gnix_av_addr_entry *entry_ptr);
-
-/**
  * @brief (FI_AV_TABLE) Return fi_addr using its corresponding gnix address.
  *
  * @param[in] int_av		The AV to use for the lookup.

--- a/prov/gni/src/gnix_sep.c
+++ b/prov/gni/src/gnix_sep.c
@@ -326,11 +326,6 @@ static int gnix_sep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 			return -FI_EINVAL;
 		}
 
-		/* We currently only support FI_AV_MAP */
-		if (av->type != FI_AV_MAP) {
-			return -FI_EINVAL;
-		}
-
 		for (i = 0; i < sep->info->ep_attr->tx_ctx_cnt; i++) {
 			ep = container_of(sep->tx_ep_table[i],
 					  struct gnix_fid_ep, ep_fid);


### PR DESCRIPTION
Removed unused functions _gnix_map_lookup and _gnix_table_lookup
to simplify table_lookup and map_lookup calls.
Reorganized sep test with no setup/teardown between tests.
Added use of criterion_log for debug output instead of dbg_print.

Reference #1072

Signed-off-by: Chuck Fossen <chuckf@cray.com>

@sungeunchoi @hppritcha @ztiffany 