### PR TITLE
prov/gni: fix problem with 1dom tests

### DIFF
--- a/prov/gni/test/rdm_dgram_rma.c
+++ b/prov/gni/test/rdm_dgram_rma.c
@@ -551,8 +551,10 @@ void rdm_rma_teardown(void)
 		cr_assert(!ret, "failure in closing dom[1] local mr.");
 	}
 
-	ret = fi_close(&loc_mr2[0]->fid);
-	cr_assert(!ret, "failure in closing dom[0] local mr.");
+	if (loc_mr2[0] != NULL) {
+		ret = fi_close(&loc_mr2[0]->fid);
+		cr_assert(!ret, "failure in closing dom[0] local mr.");
+	}
 
 	if (loc_mr2[1] != NULL) {
 		ret = fi_close(&loc_mr2[1]->fid);
@@ -567,8 +569,10 @@ void rdm_rma_teardown(void)
 		cr_assert(!ret, "failure in closing dom[1] remote mr.");
 	}
 
-	ret = fi_close(&rem_mr2[0]->fid);
-	cr_assert(!ret, "failure in closing dom[0] remote mr.");
+	if (rem_mr2[0] != NULL) {
+		ret = fi_close(&rem_mr2[0]->fid);
+		cr_assert(!ret, "failure in closing dom[0] remote mr.");
+	}
 
 	if (rem_mr2[1] != NULL) {
 		ret = fi_close(&rem_mr2[1]->fid);


### PR DESCRIPTION
Some of the mr handles are NULL when using the 1dom
set for the tests in rdm_dgram_rma, so have to
check for NULL mr handles before invoking fi_close
method.

Fixes ofi-cray/libfabric-cray#1082

@sungeunchoi 
Signed-off-by: Howard Pritchard <howardp@lanl.gov>