### PR TITLE
prov/gni: some opts for KNL

### DIFF
--- a/prov/gni/include/gnix_ep.h
+++ b/prov/gni/include/gnix_ep.h
@@ -205,11 +205,11 @@ static inline void _gnix_ep_release_int_tx_buf(struct gnix_fid_ep *ep,
 static inline struct gnix_fab_req *
 _gnix_fr_alloc(struct gnix_fid_ep *ep)
 {
-	struct dlist_entry *de;
+	struct dlist_entry *de = NULL;
 	struct gnix_fab_req *fr = NULL;
 	int ret = _gnix_fl_alloc(&de, &ep->fr_freelist);
 
-	while (ret == -FI_EAGAIN)
+	while (unlikely(ret == -FI_EAGAIN))
 		ret = _gnix_fl_alloc(&de, &ep->fr_freelist);
 
 	if (ret == FI_SUCCESS) {

--- a/prov/gni/include/gnix_freelist.h
+++ b/prov/gni/include/gnix_freelist.h
@@ -36,6 +36,7 @@
 
 #include <fi.h>
 #include <fi_list.h>
+#include "include/gnix_util.h"
 
 /* Number of elements to seed the freelist with */
 #define GNIX_FL_INIT_SIZE 100
@@ -102,20 +103,74 @@ int _gnix_fl_init_ts(int elem_size, int offset, int init_size,
  */
 void _gnix_fl_destroy(struct gnix_freelist *fl);
 
+extern int __gnix_fl_refill(struct gnix_freelist *fl, int n);
+
 /** Return an item from the freelist
  *
  * @param e     item
  * @param fl    gnix_freelist
  * @return      FI_SUCCESS on success, -FI_ENOMEM or -FI_EAGAIN on failure
  */
-int _gnix_fl_alloc(struct dlist_entry **e, struct gnix_freelist *fl);
+__attribute__((unused))
+static int inline _gnix_fl_alloc(struct dlist_entry **e, struct gnix_freelist *fl)
+{
+    int ret = FI_SUCCESS;
+    struct dlist_entry *de = NULL;
+
+    assert(fl);
+
+    if (fl->ts)
+        fastlock_acquire(&fl->lock);
+
+    if (dlist_empty(&fl->freelist)) {
+        ret = __gnix_fl_refill(fl, fl->refill_size);
+        if (ret != FI_SUCCESS)
+            goto err;
+        if (fl->refill_size < fl->max_refill_size) {
+            int ns = fl->refill_size *= fl->growth_factor;
+
+            fl->refill_size = (ns >= fl->max_refill_size ?
+                            fl->max_refill_size : ns);
+        }
+
+        if (dlist_empty(&fl->freelist)) {
+            /* Can't happen unless multithreaded */
+            ret = -FI_EAGAIN;
+            goto err;
+        }
+    }
+
+    de = fl->freelist.next;
+    dlist_remove_init(de);
+
+    *e = de;
+err:
+    if (fl->ts)
+        fastlock_release(&fl->lock);
+    return ret;
+}
 
 /** Return an item to the free list
  *
  * @param e     item
  * @param fl    gnix_freelist
  */
-void _gnix_fl_free(struct dlist_entry *e, struct gnix_freelist *fl);
+__attribute__((unused))
+static inline void _gnix_fl_free(struct dlist_entry *e, struct gnix_freelist *fl)
+{
+    assert(e);
+    assert(fl);
+
+    e->next = NULL;  /* keep slist implementation happy */
+
+    if (fl->ts)
+        fastlock_acquire(&fl->lock);
+    dlist_init(e);
+    dlist_insert_head(e, &fl->freelist);
+    if (fl->ts)
+        fastlock_release(&fl->lock);
+}
+
 
 /** Is freelist empty (primarily used for testing
  *

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -651,46 +651,6 @@ err:
 }
 
 /*
- * allocate a tx desc for this nic
- */
-
-int _gnix_nic_tx_alloc(struct gnix_nic *nic,
-		       struct gnix_tx_descriptor **desc)
-{
-	struct dlist_entry *entry;
-
-	COND_ACQUIRE(nic->requires_lock, &nic->tx_desc_lock);
-	if (dlist_empty(&nic->tx_desc_free_list)) {
-		COND_RELEASE(nic->requires_lock, &nic->tx_desc_lock);
-		return -FI_ENOSPC;
-	}
-
-	entry = nic->tx_desc_free_list.next;
-	dlist_remove_init(entry);
-	dlist_insert_head(entry, &nic->tx_desc_active_list);
-	*desc = dlist_entry(entry, struct gnix_tx_descriptor, list);
-	COND_RELEASE(nic->requires_lock, &nic->tx_desc_lock);
-
-	return FI_SUCCESS;
-}
-
-/*
- * free a tx desc for this nic - the nic is not embedded in the
- * descriptor to help keep it small
- */
-
-int _gnix_nic_tx_free(struct gnix_nic *nic,
-		      struct gnix_tx_descriptor *desc)
-{
-	COND_ACQUIRE(nic->requires_lock, &nic->tx_desc_lock);
-	dlist_remove_init(&desc->list);
-	dlist_insert_head(&desc->list, &nic->tx_desc_free_list);
-	COND_RELEASE(nic->requires_lock, &nic->tx_desc_lock);
-
-	return FI_SUCCESS;
-}
-
-/*
  * allocate a free list of tx descs for a gnix_nic struct.
  */
 

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -1420,7 +1420,7 @@ int _gnix_vc_alloc(struct gnix_fid_ep *ep_priv,
 	int remote_id;
 	struct gnix_vc *vc_ptr = NULL;
 	struct gnix_nic *nic = NULL;
-	struct dlist_entry *de;
+	struct dlist_entry *de = NULL;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
@@ -1729,27 +1729,6 @@ int _gnix_vc_disconnect(struct gnix_vc *vc)
 	vc->conn_state = GNIX_VC_CONN_TERMINATED;
 	return FI_SUCCESS;
 }
-
-/* Return 0 if VC is connected.  Progress VC CM if not. */
-static int __gnix_vc_connected(struct gnix_vc *vc)
-{
-	struct gnix_cm_nic *cm_nic;
-	int ret;
-
-	if (unlikely(vc->conn_state < GNIX_VC_CONNECTED)) {
-		cm_nic = vc->ep->cm_nic;
-		ret = _gnix_cm_nic_progress(cm_nic);
-		if ((ret != FI_SUCCESS) && (ret != -FI_EAGAIN))
-			GNIX_WARN(FI_LOG_EP_CTRL,
-				"_gnix_cm_nic_progress() failed: %s\n",
-			fi_strerror(-ret));
-		/* waiting to connect, check back later */
-		return -FI_EAGAIN;
-	}
-
-	return 0;
-}
-
 
 /******************************************************************************
  *


### PR DESCRIPTION
move some functions to header files to allow for inlining.
This tends to help with KNL processor.  This is low hanging fruit, but the start
on a long long road to better performance on KNL processors.  

Using the gcc 6.1 compiler these results were obtained with and without
these inlining optimizations:

```
# Libfabric Latency Test 
# Size            Latency (us)        Min Lat (us)        Max Lat (us)
1                         5.11                5.11                5.11
2                         5.11                5.11                5.11
4                         5.11                5.11                5.11
8                         5.04                5.04                5.04
16                        5.07                5.07                5.07
32                        5.10                5.10                5.10
64                        5.14                5.14                5.14
128                       5.21                5.21                5.21
256                       5.32                5.32                5.32
512                       5.55                5.55                5.55
1024                      6.46                6.46                6.46
2048                      7.20                7.20                7.20
4096                      8.96                8.96                8.96
8192                     11.89               11.89               11.89
Application 1805851 resources: utime ~4s, stime ~0s, Rss ~11952, inblocks ~0, outblocks ~0
hpp@tt-login1[27.36]:~/cray_tests_install/bin>aprun -n 2 -N 1 ./rdm_pingpong
1 threads
# Libfabric Latency Test 
# Size            Latency (us)        Min Lat (us)        Max Lat (us)
1                         5.54                5.54                5.54
2                         5.55                5.55                5.55
4                         5.53                5.53                5.53
8                         5.54                5.54                5.54
16                        5.53                5.53                5.53
32                        5.54                5.54                5.54
64                        5.58                5.58                5.58
128                       5.62                5.62                5.62
256                       5.69                5.69                5.69
512                       5.94                5.94                5.94
1024                      6.88                6.88                6.88
2048                      7.54                7.54                7.54
4096                      9.27                9.27                9.27
8192                     12.26               12.26               12.26
```

Configure options:

```
./configure CC=gcc --prefix=/users/hpp/libfabric_install --disable-sockets --disable-verbs --disable-rxd --disable-udp --disable-rxm
```

@sungeunchoi 

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>