### PR TITLE
prov/gni: squash compiler complaint

### DIFF
--- a/prov/gni/include/gnix_freelist.h
+++ b/prov/gni/include/gnix_freelist.h
@@ -112,7 +112,7 @@ extern int __gnix_fl_refill(struct gnix_freelist *fl, int n);
  * @return      FI_SUCCESS on success, -FI_ENOMEM or -FI_EAGAIN on failure
  */
 __attribute__((unused))
-static int inline _gnix_fl_alloc(struct dlist_entry **e, struct gnix_freelist *fl)
+static inline int _gnix_fl_alloc(struct dlist_entry **e, struct gnix_freelist *fl)
 {
     int ret = FI_SUCCESS;
     struct dlist_entry *de = NULL;


### PR DESCRIPTION
inline attribute in the wrong place was causing gcc
to complain.

@sungeun

Signed-off-by: Howard Pritchard <howardp@lanl.gov>