### PR TITLE
prov/gni: FI_MORE support for read_msg

### DIFF
--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -125,19 +125,16 @@ static int __gnix_rma_send_completion(struct gnix_fid_ep *ep,
 	return FI_SUCCESS;
 }
 
-static void __gnix_rma_copy_indirect_get_data(struct gnix_tx_descriptor *txd)
+static inline void __gnix_rma_copy_indirect_get_data(struct gnix_fab_req *req)
 {
-	struct gnix_fab_req *req = txd->req;
 	int head_off = req->rma.rem_addr & GNI_READ_ALIGN_MASK;
-
 	memcpy((void *)req->rma.loc_addr,
 	       (void *) ((uint8_t *) req->int_tx_buf + head_off),
 	       req->rma.len);
 }
 
-static void __gnix_rma_copy_chained_get_data(struct gnix_tx_descriptor *txd)
+static void __gnix_rma_copy_chained_get_data(struct gnix_fab_req *req)
 {
-	struct gnix_fab_req *req = txd->req;
 	int head_off, head_len, tail_len;
 	void *addr;
 
@@ -395,14 +392,35 @@ static int __gnix_rma_more_txd_complete(void *arg, gni_return_t tx_status)
 	struct slist_entry *item;
 	int rc = FI_SUCCESS;
 
-	free(txd->gni_more_ct_descs);
-	_gnix_nic_tx_free(req->gnix_ep->nic, txd);
-
 	if (tx_status != GNI_RC_SUCCESS) {
 		return __gnix_rma_post_err(req, FI_ECANCELED);
 	}
 
-	/* complete request */
+	free(txd->gni_more_ct_descs);
+	_gnix_nic_tx_free(req->gnix_ep->nic, txd);
+
+	/* Successful Delivery. Copy any unaligned data if read req. */
+	if ((req->flags & FI_MORE) && (req->type == GNIX_FAB_RQ_RDMA_READ)) {
+		if (req->flags & GNIX_RMA_INDIRECT) {
+			GNIX_DEBUG(FI_LOG_EP_DATA,
+				"Top TXD is Indirect. Copying\n");
+			__gnix_rma_copy_indirect_get_data(req);
+		} else {
+			__gnix_rma_copy_chained_get_data(req);
+		}
+		slist_entry_foreach(req->rma.sle.next, item) {
+			more_req = container_of(item, struct gnix_fab_req,
+						rma.sle);
+			if (more_req->flags & GNIX_RMA_INDIRECT) {
+				GNIX_DEBUG(FI_LOG_EP_DATA,
+				"Chain Element is Indirect. Copying\n");
+				__gnix_rma_copy_indirect_get_data(more_req);
+			} else {
+				__gnix_rma_copy_chained_get_data(more_req);
+			}
+		}
+	}
+	/* Completion event for top level request */
 	rc = __gnix_rma_send_completion(req->vc->ep, req);
 	if (rc != FI_SUCCESS)
 		GNIX_WARN(FI_LOG_EP_DATA,
@@ -437,7 +455,7 @@ static int __gnix_rma_txd_complete(void *arg, gni_return_t tx_status)
 		 * move unaligned head and/or tail.  If this is the FMA TXD,
 		 * copy the unaligned data to the user buffer. */
 		if (txd->gni_desc.type == GNI_POST_FMA_GET)
-			__gnix_rma_copy_chained_get_data(txd);
+			__gnix_rma_copy_chained_get_data(req);
 
 		/* Remember any failure.  Retransmit both TXDs once both are
 		 * complete. */
@@ -462,10 +480,10 @@ static int __gnix_rma_txd_complete(void *arg, gni_return_t tx_status)
 
 	/* Successful delivery.  Progress request. */
 	if (req->flags & GNIX_RMA_INDIRECT) {
-		__gnix_rma_copy_indirect_get_data(txd);
+		__gnix_rma_copy_indirect_get_data(req);
 	} else if (req->flags & GNIX_RMA_CHAINED &&
 		   !(req->flags & GNIX_RMA_RDMA)) {
-		__gnix_rma_copy_chained_get_data(txd);
+		__gnix_rma_copy_chained_get_data(req);
 	}
 
 	_gnix_nic_tx_free(req->gnix_ep->nic, txd);
@@ -600,6 +618,33 @@ static void __gnix_rma_fill_pd_indirect_get(struct gnix_fab_req *req,
 	txd->gni_desc.local_mem_hndl = req->int_tx_mdh;
 	txd->gni_desc.length = CEILING(req->rma.len + head_off, GNI_READ_ALIGN);
 	txd->gni_desc.remote_addr =
+			(uint64_t)req->rma.rem_addr & ~GNI_READ_ALIGN_MASK;
+}
+
+static void __gnix_rma_more_fill_pd_indirect_get(struct gnix_fab_req *req,
+						 gni_ct_get_post_descriptor_t
+						 *more_get, int idx)
+{
+	int head_off = req->rma.rem_addr & GNI_READ_ALIGN_MASK;
+	struct gnix_fid_ep *ep = req->gnix_ep;
+
+	GNIX_DEBUG(FI_LOG_EP_DATA, "FI_MORE: filling indirect get\n");
+	if (req->int_tx_buf_e == NULL) {
+		req->int_tx_buf_e = _gnix_ep_get_int_tx_buf(ep);
+		if (req->int_tx_buf_e == NULL) {
+			GNIX_FATAL(FI_LOG_EP_DATA, "RAN OUT OF INT_TX_BUFS");
+			/* TODO Create growable list of buffers */
+		}
+	}
+
+	req->int_tx_buf = ((struct gnix_int_tx_buf *) req->int_tx_buf_e)->buf;
+	req->int_tx_mdh = _gnix_ep_get_int_tx_mdh(ep);
+
+	/* Copy all data through an intermediate buffer. */
+	more_get[idx].local_addr = (uint64_t)req->int_tx_buf;
+	more_get[idx].local_mem_hndl = req->int_tx_mdh;
+	more_get[idx].length = CEILING(req->rma.len + head_off, GNI_READ_ALIGN);
+	more_get[idx].remote_addr =
 			(uint64_t)req->rma.rem_addr & ~GNI_READ_ALIGN_MASK;
 }
 
@@ -829,6 +874,76 @@ int _gnix_rma_post_rdma_chain_req(void *data)
 	return FI_SUCCESS;
 }
 
+/* Fill head and tail descriptors for chained gets */
+static void __gnix_rma_more_fill_sub_htd(struct gnix_fab_req *req,
+					gni_ct_get_post_descriptor_t *more_get,
+					gni_mem_handle_t *rem_mdh,
+					int *idx, int *entries)
+{
+	int head_off, tail_len;
+	struct gnix_fid_ep *ep = req->gnix_ep;
+	int indirect = !!(req->flags & GNIX_RMA_INDIRECT);
+
+	head_off = req->rma.rem_addr & GNI_READ_ALIGN_MASK;
+	tail_len = (req->rma.rem_addr + req->rma.len)
+		& GNI_READ_ALIGN_MASK;
+
+	/* Get int_tx_buf if unaligned and not indirect size. */
+	if ((req->int_tx_buf_e == NULL) &&
+			(head_off || tail_len) && !(indirect)) {
+		req->int_tx_buf_e = _gnix_ep_get_int_tx_buf(ep);
+		if (req->int_tx_buf_e == NULL) {
+			GNIX_FATAL(FI_LOG_EP_DATA, "RAN OUT OF INT_TX_BUFS");
+			/* TODO Create growable list of buffers */
+		}
+	} else {
+		return;
+	}
+
+	req->int_tx_buf = ((struct gnix_int_tx_buf *)
+				req->int_tx_buf_e)->buf;
+	req->int_tx_mdh = _gnix_ep_get_int_tx_mdh(ep);
+
+	if (head_off) {
+		assert(*idx < *entries);
+		GNIX_DEBUG(FI_LOG_EP_DATA, "FI_MORE: Chain Head Off\n");
+		more_get[*idx].ep_hndl = req->vc->gni_ep;
+		more_get[*idx].length = GNI_READ_ALIGN;
+		more_get[*idx].remote_addr =
+				req->rma.rem_addr & ~GNI_READ_ALIGN_MASK;
+		more_get[*idx].remote_mem_hndl = *rem_mdh;
+		more_get[*idx].local_addr = (uint64_t)req->int_tx_buf;
+		more_get[*idx].local_mem_hndl = req->int_tx_mdh;
+
+		if (*idx < (*entries) - 1)
+			more_get[*idx].next_descr = &more_get[(*idx) + 1];
+		else
+			more_get[*idx].next_descr = NULL;
+
+		(*idx)++;
+	}
+	if (tail_len) {
+		assert(*idx < *entries);
+		GNIX_DEBUG(FI_LOG_EP_DATA, "FI_MORE: Chain Tail Off\n");
+		more_get[*idx].ep_hndl = req->vc->gni_ep;
+		more_get[*idx].length = GNI_READ_ALIGN;
+		more_get[*idx].remote_addr =
+				(req->rma.rem_addr +
+				 req->rma.len) & ~GNI_READ_ALIGN_MASK;
+		more_get[*idx].remote_mem_hndl = *rem_mdh;
+		more_get[*idx].local_addr =
+				(uint64_t)req->int_tx_buf + GNI_READ_ALIGN;
+		more_get[*idx].local_mem_hndl = req->int_tx_mdh;
+		more_get[*idx].next_descr = NULL;
+
+		if (*idx < (*entries) - 1)
+				more_get[*idx].next_descr = &more_get[(*idx) + 1];
+			else
+				more_get[*idx].next_descr = NULL;
+		(*idx)++;
+	}
+}
+
 static void __gnix_rma_more_fill_pd(struct gnix_fab_req *req,
 				    struct gnix_tx_descriptor *txd)
 {
@@ -836,17 +951,76 @@ static void __gnix_rma_more_fill_pd(struct gnix_fab_req *req,
 	gni_ct_get_post_descriptor_t *more_get = NULL;
 	gni_mem_handle_t mdh;
 	struct gnix_fab_req *more_req;
+	struct gnix_fid_mem_desc *loc_md;
 	struct slist_entry *item;
-	int entries = 0, idx = 0;
+	int head_off, head_len, tail_len, entries = 0, idx = 0;
+	int indirect = !!(req->flags & GNIX_RMA_INDIRECT);
+	int sub_indirect;
 
-	/* Count number of post-descriptors to be chained. */
-	slist_entry_foreach(req->rma.sle.next, item) {
-		entries++;
+	GNIX_DEBUG(FI_LOG_EP_DATA, "FI_MORE: Filling PD\n");
+	/* If top level fab_req is unaligned, increment entries. */
+	if (req->type == GNIX_FAB_RQ_RDMA_READ) {
+		head_off = req->rma.rem_addr & GNI_READ_ALIGN_MASK;
+		head_len = head_off ? GNI_READ_ALIGN - head_off : 0;
+		tail_len = (req->rma.rem_addr + req->rma.len)
+			& GNI_READ_ALIGN_MASK;
+		if (!indirect) {
+			if (head_off) {
+				entries++;
+				GNIX_DEBUG(FI_LOG_EP_DATA,
+				"FI_MORE: Txd Head Off\n");
+			}
+			if (tail_len) {
+				entries++;
+				GNIX_DEBUG(FI_LOG_EP_DATA,
+				"FI_MORE: Txd Tail Off\n");
+			}
+		}
+		/* Populate txd */
+		if (indirect) {
+			GNIX_DEBUG(FI_LOG_EP_DATA, "FI_MORE: Txd Indirect\n");
+			__gnix_rma_fill_pd_indirect_get(req, txd);
+		} else {
+			txd->gni_desc.local_addr = (uint64_t)req->rma.loc_addr + head_len;
+			txd->gni_desc.remote_addr = (uint64_t)req->rma.rem_addr + head_len;
+			txd->gni_desc.length = req->rma.len - head_len - tail_len;
+			assert(txd->gni_desc.length);
+		}
 	}
 
-	GNIX_DEBUG(FI_LOG_EP_DATA, "FI_MORE: %d sub descs to be populated\n",
+	/* Count number of sub post-descriptors to be chained. */
+	slist_entry_foreach(req->rma.sle.next, item) {
+		entries++; /* Increment regardless of type */
+		/* Get fab_req pointer */
+		if (req->type == GNIX_FAB_RQ_RDMA_READ) {
+			more_req = container_of(item, struct gnix_fab_req,
+						rma.sle);
+			sub_indirect = !!(more_req->flags & GNIX_RMA_INDIRECT);
+			head_off = more_req->rma.rem_addr & GNI_READ_ALIGN_MASK;
+			head_len = head_off ? GNI_READ_ALIGN - head_off : 0;
+			tail_len = (more_req->rma.rem_addr + more_req->rma.len)
+				& GNI_READ_ALIGN_MASK;
+
+			/* Additional increments if unaligned */
+			if (!sub_indirect) {
+				if (head_off) {
+					entries++;
+					GNIX_DEBUG(FI_LOG_EP_DATA,
+					"FI_MORE: Chain Req Head off++\n");
+				}
+				if (tail_len) {
+					entries++;
+					GNIX_DEBUG(FI_LOG_EP_DATA,
+					"FI_MORE: Chaing Req Tail off++\n");
+				}
+			}
+		}
+	}
+
+	GNIX_INFO(FI_LOG_EP_DATA, "FI_MORE: %d sub descs to be populated\n",
 		  entries);
 
+	/* Allocate space for sub descriptors */
 	if (req->type == GNIX_FAB_RQ_RDMA_WRITE) {
 		txd->gni_more_ct_descs = malloc(entries *
 					 sizeof(gni_ct_put_post_descriptor_t));
@@ -857,13 +1031,18 @@ static void __gnix_rma_more_fill_pd(struct gnix_fab_req *req,
 					 sizeof(gni_ct_get_post_descriptor_t));
 		more_get = (gni_ct_get_post_descriptor_t *)
 			   txd->gni_more_ct_descs;
+		/* Populate Head and Tail of TOP Req if req is unaligned */
+		 __gnix_rma_more_fill_sub_htd(req, more_get,
+			&txd->gni_desc.remote_mem_hndl, &idx, &entries);
 	}
 
+	/* Populate sub descriptors */
 	slist_entry_foreach(req->rma.sle.next, item) {
 		/* Get fab_req pointer */
 		more_req = container_of(item, struct gnix_fab_req, rma.sle);
+		sub_indirect = !!(more_req->flags & GNIX_RMA_INDIRECT);
 
-		/* Populate txd based on type */
+		/* Populate  based on type */
 		if (req->type == GNIX_FAB_RQ_RDMA_WRITE) {
 			assert(more_put);
 			more_put[idx].ep_hndl = more_req->vc->gni_ep;
@@ -881,15 +1060,46 @@ static void __gnix_rma_more_fill_pd(struct gnix_fab_req *req,
 				more_put[idx].next_descr = &more_put[idx + 1];
 			else
 				more_put[idx].next_descr = NULL;
+			idx++;
 		} else {
-			/* TODO Populate for reads*/
 			assert(more_get);
-			if (idx < entries - 1)
-				more_get[idx].next_descr = &more_get[idx + 1];
-			else
-				more_get[idx].next_descr = NULL;
+			_gnix_convert_key_to_mhdl_no_crc(
+				(gnix_mr_key_t *)&more_req->rma.rem_mr_key,
+				&mdh);
+			more_get[idx].remote_mem_hndl = mdh;
+			more_get[idx].ep_hndl = more_req->vc->gni_ep;
+
+			if (sub_indirect) {
+				__gnix_rma_more_fill_pd_indirect_get(more_req, more_get, idx);
+				if (idx < entries - 1) {
+					more_get[idx].next_descr = &more_get[idx + 1];
+				} else {
+					more_get[idx].next_descr = NULL;
+				}
+				idx++;
+
+			} else {
+				/* get main aligned data in first transaction */
+				loc_md = (struct gnix_fid_mem_desc *)more_req->rma.loc_md;
+				more_get[idx].local_mem_hndl = loc_md->mem_hndl;
+				more_get[idx].local_addr = (uint64_t)more_req->rma.loc_addr + head_len;
+				more_get[idx].remote_addr = (uint64_t)more_req->rma.rem_addr + head_len;
+				more_get[idx].length = more_req->rma.len - head_len - tail_len;
+				GNIX_DEBUG(FI_LOG_EP_DATA, "rma.len: %d - head_len:%d - tail_len:%d\n",
+					more_req->rma.len, head_len, tail_len);
+				assert(more_get[idx].length);
+
+				if (idx < entries - 1) {
+					more_get[idx].next_descr = &more_get[idx + 1];
+				} else {
+					more_get[idx].next_descr = NULL;
+				}
+				idx++;
+				/* head/tail function */
+				__gnix_rma_more_fill_sub_htd(more_req, more_get, &mdh,
+						&idx, &entries);
+			}
 		}
-		idx++;
 	}
 
 	if (req->type == GNIX_FAB_RQ_RDMA_WRITE) {
@@ -938,29 +1148,26 @@ int _gnix_rma_more_post_req(void *data)
 	txd->gni_desc.cq_mode = GNI_CQMODE_GLOBAL_EVENT; /* check flags */
 	txd->gni_desc.dlvr_mode = GNI_DLVMODE_PERFORMANCE; /* check flags */
 
-	__gnix_rma_more_fill_pd(fab_req, txd);
-
 	if (fab_req->type == GNIX_FAB_RQ_RDMA_WRITE) {
-		GNIX_INFO(FI_LOG_EP_DATA, "MORE: Doing a Write\n");
 		txd->gni_desc.local_addr = (uint64_t)fab_req->rma.loc_addr;
 		txd->gni_desc.length = fab_req->rma.len;
 		assert(txd->gni_desc.length);
 		txd->gni_desc.remote_addr = (uint64_t)fab_req->rma.rem_addr;
-
-		loc_md = (struct gnix_fid_mem_desc *)fab_req->rma.loc_md;
-		if (loc_md) {
-			txd->gni_desc.local_mem_hndl = loc_md->mem_hndl;
-		}
 	}
+
+	loc_md = (struct gnix_fid_mem_desc *)fab_req->rma.loc_md;
+	txd->gni_desc.local_mem_hndl = loc_md->mem_hndl; /* assert? */
 	txd->gni_desc.remote_mem_hndl = mdh;
 	txd->gni_desc.rdma_mode = 0; /* check flags */
 	txd->gni_desc.src_cq_hndl = nic->tx_cq; /* check flags */
+
+	__gnix_rma_more_fill_pd(fab_req, txd);
 
 	GNIX_LOG_DUMP_TXD(txd);
 
 	COND_ACQUIRE(nic->requires_lock, &nic->lock);
 	status = GNI_CtPostFma(fab_req->vc->gni_ep, &txd->gni_desc);
-	GNIX_DEBUG(FI_LOG_EP_DATA, "MORE: Returned from GNI_CtPostFma\n");
+	GNIX_DEBUG(FI_LOG_EP_DATA, "FI_MORE: Returned from GNI_CtPostFma\n");
 
 	COND_RELEASE(nic->requires_lock, &nic->lock);
 
@@ -1242,10 +1449,10 @@ ssize_t _gnix_rma(struct gnix_fid_ep *ep, enum gnix_fab_req_type fr_type,
 			slist_insert_tail(&req->rma.sle, &ep->more_write);
 			req->work_fn = _gnix_rma_more_post_req;
 		} else if (fr_type == GNIX_FAB_RQ_RDMA_READ) {
-			/* Not fully implemented. List won't be populated. */
-			/* slist_insert_tail(&req->rma.sle, &ep->more_read); */
+			slist_insert_tail(&req->rma.sle, &ep->more_read);
+			req->work_fn = _gnix_rma_more_post_req;
 		}
-		if ((flags & FI_MORE) && (fr_type == GNIX_FAB_RQ_RDMA_WRITE))
+		if (flags & FI_MORE)
 			return FI_SUCCESS;
 	}
 

--- a/prov/gni/test/rdm_dgram_rma.c
+++ b/prov/gni/test/rdm_dgram_rma.c
@@ -1604,6 +1604,166 @@ Test(dgram_rma_1dom, readmsg)
 	xfer_for_each_size(do_readmsg, 8, BUF_SZ);
 }
 
+void do_readmsg_more(int len, void *s, void *t, int len2, void *s2, void *t2)
+{
+	int ret;
+	ssize_t sz;
+	struct fi_cq_tagged_entry cqe = { (void *) -1, UINT_MAX, UINT_MAX,
+					  (void *) -1, UINT_MAX, UINT_MAX };
+	struct iovec iov, iov2;
+	struct fi_msg_rma msg, msg2;
+	struct fi_rma_iov rma_iov, rma_iov2;
+	uint64_t w[2] = {0}, r[2] = {0}, w_e[2] = {0}, r_e[2] = {0};
+
+	iov.iov_base = s;
+	iov.iov_len = len;
+
+	rma_iov.addr = (uint64_t)t;
+	rma_iov.len = len;
+	rma_iov.key = mr_key[1];
+
+	msg.msg_iov = &iov;
+	msg.desc = (void **)loc_mr;
+	msg.iov_count = 1;
+	msg.addr = gni_addr[1];
+	msg.rma_iov = &rma_iov;
+	msg.rma_iov_count = 1;
+	msg.context = t;
+	msg.data = (uint64_t)t;
+
+	iov2.iov_base = s2;
+	iov2.iov_len = len2;
+
+	rma_iov2.addr = (uint64_t)t2;
+	rma_iov2.len = len2;
+	rma_iov2.key = mr_key2[1];
+
+	msg2.msg_iov = &iov2;
+	msg2.desc = (void **)loc_mr2;
+	msg2.iov_count = 1;
+	msg2.addr = gni_addr[1];
+	msg2.rma_iov = &rma_iov2;
+	msg2.rma_iov_count = 1;
+	msg2.context = t2;
+	msg2.data = (uint64_t)t2;
+
+
+	init_data(t, len, 0xef);
+	init_data(t2, len2, 0xff);
+	init_data(s, len, 0);
+	init_data(s2, len2, 0);
+
+	sz = fi_readmsg(ep[0], &msg, FI_MORE);
+	cr_assert_eq(sz, 0);
+	sz = fi_readmsg(ep[0], &msg2, 0);
+	cr_assert_eq(sz, 0);
+
+	while ((ret = fi_cq_read(send_cq[0], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	rdm_rma_check_tcqe(&cqe, t, FI_RMA | FI_READ, 0);
+
+	while ((ret = fi_cq_read(send_cq[0], &cqe, 1)) == -FI_EAGAIN) {
+		pthread_yield();
+	}
+
+	cr_assert_eq(ret, 1);
+	rdm_rma_check_tcqe(&cqe, t2, FI_RMA | FI_READ, 0);
+
+	r[0] = 2;
+	rdm_rma_check_cntrs(w, r, w_e, r_e);
+
+	dbg_printf("got write context event!\n");
+
+	cr_assert(check_data(s, t, len), "Data mismatch1");
+	cr_assert(check_data(s2, t2, len2), "Data mismatch2");
+}
+
+void do_read_alignment_more(void)
+{
+	/* Size below GNIX_RMA_UREAD_CHAINED_THRESH size. All of these should
+	 * have the same behavior. Code related to head/tail buffers should
+	 * be bypassed */
+	do_readmsg_more(8, source, target, 8, source2, target2);
+	dbg_printf("MORE All Aligned\n");
+
+	do_readmsg_more(8, source, target, 9, source2, target2);
+	dbg_printf("MORE M1 A M2 TUA INDIRECT\n");
+
+	do_readmsg_more(9, source, target, 8, source2, target2);
+	dbg_printf("MORE M1 UA M2 A INDIRECT\n");
+
+	do_readmsg_more(8, source, target, 8, source2, target2+2);
+	dbg_printf("MORE M1 A M2 H&TUA INDIRECT\n");
+
+	/* Size above GNIX_RMA_UREAD_CHAINED_THRESH 'H/T buffers will actually
+	 * be used. Have one test for each possible combination of 2 messages
+	 * with 4 possible paths to follow.
+	 * 'Aligned', 'Head Unaligned', 'Tail Unaligned', 'H&T Unaligned' */
+
+	/* M1 Aligned */
+	do_readmsg_more(64, source, target, 64, source2, target2);
+	dbg_printf("MORE M1 A M2 A\n");
+
+	do_readmsg_more(64, source, target, 65, source2, target2);
+	dbg_printf("MORE M1 A M2 TUA\n");
+
+	do_readmsg_more(64, source, target, 65, source2, target2+3);
+	dbg_printf("MORE M1 A M2 HUA\n");
+
+	do_readmsg_more(64, source, target, 64, source2, target2+2);
+	dbg_printf("MORE M1 A M2 H&TUA\n");
+
+
+	/* M1 Tail Unaligned */
+	do_readmsg_more(65, source, target, 64, source2, target2);
+	dbg_printf("MORE M1 TUA M2 A\n");
+
+	do_readmsg_more(65, source, target, 65, source2, target2);
+	dbg_printf("MORE M1 TUA M2 TUA\n");
+
+	do_readmsg_more(65, source, target, 65, source2, target2+3);
+	dbg_printf("MORE M1 TUA M2 HUA\n");
+
+	do_readmsg_more(65, source, target, 64, source2, target2+2);
+	dbg_printf("MORE M1 TUA M2 H&TUA\n");
+
+	/* M1 Head Unaligned */
+	do_readmsg_more(65, source, target+3, 64, source2, target2);
+	dbg_printf("MORE M1 HUA M2 A\n");
+
+	do_readmsg_more(65, source, target+3, 65, source2, target2);
+	dbg_printf("MORE M1 HUA M2 TUA\n");
+
+	do_readmsg_more(65, source, target+3, 65, source2, target2+3);
+	dbg_printf("MORE M1 HUA M2 HUA\n");
+
+	do_readmsg_more(65, source, target+3, 64, source2, target2+2);
+	dbg_printf("MORE M1 HUA M2 H&TUA\n");
+
+
+	/* M1 Head&Tail Unaligned */
+	do_readmsg_more(64, source, target+2, 64, source2, target2);
+	dbg_printf("MORE M1 H&TUA M2 A\n");
+
+	do_readmsg_more(64, source, target+2, 65, source2, target2);
+	dbg_printf("MORE M1 H&TUA M2 TUA\n");
+
+	do_readmsg_more(64, source, target+2, 65, source2, target2+3);
+	dbg_printf("MORE M1 H&TUA M2 HUA\n");
+
+	do_readmsg_more(64, source, target+2, 64, source2, target2+2);
+	dbg_printf("MORE M1 H&TUA M2 H&TUA\n");
+
+}
+
+Test(rdm_rma, readmsgmore)
+{
+	do_read_alignment_more();
+}
+
 #define READ_DATA 0xdededadadeaddeef
 void do_readmsgdata(int len)
 {


### PR DESCRIPTION
Code to support FI_MORE for reads in gnix_rma.c
Corresponding test created in rdm_dgram_rma.c


@sungeunchoi @ztiffany 