### PR TITLE
prov/gni: help out KNL with symbol resolution

### DIFF
--- a/prov/gni/configure.m4
+++ b/prov/gni/configure.m4
@@ -26,22 +26,30 @@ AC_DEFUN([FI_GNI_CONFIGURE],[
                                       [Enable xpmem (gni provider) @<:@default=yes@:>@])],
                       )
 
+        AC_ARG_ENABLE([ugni-static],
+                      [AS_HELP_STRING([--enable-ugni-static],
+                                      [Enable static linking with uGNI.  Recommended for KNL.])],
+                     )
+
         AS_IF([test x"$enable_gni" != x"no"],
                [FI_PKG_CHECK_MODULES([CRAY_GNI_HEADERS], [cray-gni-headers],
                                  [gni_header_happy=1
                                   gni_CPPFLAGS="$CRAY_GNI_HEADERS_CFLAGS $gni_CPPFLAGS"
-                                  gni_LDFLAGS="$CRAY_GNI_HEADER_LIBS $gni_LDFLAGS"
                                  ],
                                  [gni_header_happy=0])
               ])
 
         AS_IF([test "$gni_header_happy" -eq 1],
-              [FI_PKG_CHECK_MODULES([CRAY_UGNI], [cray-ugni],
+              [FI_PKG_CHECK_MODULES_STATIC([CRAY_UGNI], [cray-ugni],
                                  [ugni_lib_happy=1
                                   gni_CPPFLAGS=$CRAY_UGNI_CFLAGS
                                   gni_LDFLAGS=$CRAY_UGNI_LIBS
                                  ],
                                  [ugni_lib_happy=0])
+
+               AS_IF([test x"$enable_ugni_static" == x"yes" && test $ugni_lib_happy -eq 1],
+                     [gni_LDFLAGS=$(echo $gni_LDFLAGS | sed -e 's/lugni/l:libugni.a/')],[])
+
                FI_PKG_CHECK_MODULES_STATIC([CRAY_ALPS_LLI], [cray-alpslli],
                                  [alps_lli_happy=1
                                   gni_CPPFLAGS="$CRAY_ALPS_LLI_CFLAGS $gni_CPPFLAGS"


### PR DESCRIPTION
Turns out the KNL branch predictor wigdet has a hard
time with branches to symbols in shared libraries that
are located more than 4 GB of VM space away from where
the jump is going to be initiated.  This leads to
successively worse performance for software that traverses,
say, multiple shared libraries to access the network.

This problem is decribed in the Intel Xeon Phi Processor
High Performance Programming: Knights Landing Edition.
In that text, a workaround using the LD_PREFER_MAP_32BIT_EXEC
environment variable is described, but unfortunately that
requires glibc 2.23 or higher, which is not yet available on
Cray XC systems.

As a way to help out the KNL with the GNI provider, add
a configury option that allows for the libfabric.so to
be statically linked against the Cray ugni library.

This commit adds in a

--enable-ugni-static

configury option which allows for static linking against
libugni.a when building the libfabric with GNI provider.

Note that an ldd of the resulting libfabric.so will still
show a dependency on libugni.so but that is owing to a dependency
of the ALPS libalpslli.so on libugni.so and does not impact
the static linking of the GNI provider/libfabric.so against libugni.a.

A GNI provider micro benchmark shows the advantage of static
linking of the libfabric.so against libugni.a:

With static linking:

```
~/cray_tests_install/bin>aprun -n 2 -N 1 ./rdm_pingpong
1 threads
1                         4.82                4.82                4.82
2                         4.86                4.86                4.86
4                         4.84                4.84                4.84
8                         4.87                4.87                4.87
16                        4.84                4.84                4.84
32                        4.89                4.89                4.89
64                        4.91                4.91                4.91
128                       4.94                4.94                4.94
256                       5.04                5.04                5.04
512                       5.32                5.32                5.32
1024                      6.36                6.36                6.36

```

with default dynamic linking:

```
1                         5.06                5.06                5.06
2                         5.08                5.08                5.08
4                         5.06                5.06                5.06
8                         5.09                5.09                5.09
16                        5.07                5.07                5.07
32                        5.06                5.06                5.06
64                        5.12                5.12                5.12
128                       5.16                5.16                5.16
256                       5.22                5.22                5.22
512                       5.49                5.49                5.49
1024                      6.60                6.60                6.60
```

This configury option is not enabled by default for now as it might confuse
GNI provider developers trying to debug problems using modified
ugni libraries.

@sungeunchoi 
@jswaro 

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>