### PR TITLE
prov/gni: Refactor EP locking.

### DIFF
--- a/prov/gni/Makefile.include
+++ b/prov/gni/Makefile.include
@@ -34,6 +34,7 @@ _gni_files = \
 	prov/gni/src/gnix_nameserver.c \
 	prov/gni/src/gnix_nic.c \
 	prov/gni/src/gnix_poll.c \
+	prov/gni/src/gnix_progress.c \
 	prov/gni/src/gnix_queue.c \
 	prov/gni/src/gnix_rma.c \
 	prov/gni/src/gnix_sep.c \
@@ -69,6 +70,7 @@ _gni_headers = \
 	prov/gni/include/gnix_nameserver.h \
 	prov/gni/include/gnix_nic.h \
 	prov/gni/include/gnix_poll.h \
+	prov/gni/include/gnix_progress.h \
 	prov/gni/include/gnix_priv.h \
 	prov/gni/include/gnix_queue.h \
 	prov/gni/include/gnix_rma.h \

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -505,14 +505,11 @@ struct gnix_fid_ep {
 	struct gnix_cm_nic *cm_nic;
 	struct gnix_nic *nic;
 	fastlock_t vc_lock;
-	/* lock for unexp and posted recv queue */
-	fastlock_t recv_queue_lock;
 	/* used for unexpected receives */
 	struct gnix_tag_storage unexp_recv_queue;
 	/* used for posted receives */
 	struct gnix_tag_storage posted_recv_queue;
 
-	fastlock_t tagged_queue_lock;
 	struct gnix_tag_storage tagged_unexp_recv_queue;
 	struct gnix_tag_storage tagged_posted_recv_queue;
 

--- a/prov/gni/include/gnix_cm_nic.h
+++ b/prov/gni/include/gnix_cm_nic.h
@@ -39,6 +39,9 @@
 
 #define GNIX_CM_NIC_MAX_MSG_SIZE (GNI_DATAGRAM_MAXSIZE - sizeof(uint8_t))
 
+extern struct dlist_entry gnix_cm_nic_list;
+extern pthread_mutex_t gnix_cm_nic_list_lock;
+
 typedef int gnix_cm_nic_rcv_cb_func(struct gnix_cm_nic *cm_nic,
 				    char *rbuf,
 				    struct gnix_address addr);
@@ -46,6 +49,7 @@ typedef int gnix_cm_nic_rcv_cb_func(struct gnix_cm_nic *cm_nic,
 /**
  * @brief GNI provider connection management (cm) nic structure
  *
+ * @var cm_nic_list    global CM NIC list element
  * @var nic            pointer to gnix_nic associated with this cm nic
  * @var dgram_hndl     handle to dgram allocator associated with this nic
  * @var fabric         GNI provider fabric associated with this nic
@@ -64,6 +68,7 @@ typedef int gnix_cm_nic_rcv_cb_func(struct gnix_cm_nic *cm_nic,
  * @var device_id      local Aries device id associated with this nic.
  */
 struct gnix_cm_nic {
+	struct dlist_entry cm_nic_list;
 	struct gnix_nic *nic;
 	struct gnix_dgram_hndl *dgram_hndl;
 	struct gnix_fid_domain *domain;
@@ -151,13 +156,13 @@ int _gnix_cm_nic_enable(struct gnix_cm_nic *cm_nic);
 /**
  * @brief poke the cm nic's progress engine
  *
- * @param[in] cm_nic   pointer to previously allocated gnix_cm_nic struct
- * @return              FI_SUCCESS on success, -EINVAL on invalid argument.
+ * @param[in] arg      pointer to previously allocated gnix_cm_nic struct
+ * @return             FI_SUCCESS on success, -EINVAL on invalid argument.
  *                     Other error codes may be returned depending on the
  *                     error codes returned from callback function
  *                     that had been added to the nic's work queue.
  */
-int _gnix_cm_nic_progress(struct gnix_cm_nic *cm_nic);
+int _gnix_cm_nic_progress(void *arg);
 
 /**
  * @brief generate a cdm_id to be used in call to  GNI_CdmCreate based on a seed

--- a/prov/gni/include/gnix_cntr.h
+++ b/prov/gni/include/gnix_cntr.h
@@ -37,28 +37,21 @@
 #include <fi.h>
 
 #include "gnix.h"
+#include "gnix_progress.h"
 #include "gnix_wait.h"
 #include "gnix_util.h"
-
-/* many to many relationship between counters and polled NICs */
-struct gnix_cntr_poll_nic {
-	struct dlist_entry list;
-	int ref_cnt;
-	struct gnix_nic *nic;
-};
 
 struct gnix_fid_cntr {
 	struct fid_cntr cntr_fid;
 	struct gnix_fid_domain *domain;
 	struct fid_wait *wait;
 	struct fi_cntr_attr attr;
-	rwlock_t nic_lock;
-	struct dlist_entry poll_nics;
 	atomic_t cnt;
 	atomic_t cnt_err;
 	struct gnix_reference ref_cnt;
 	struct dlist_entry trigger_list;
 	fastlock_t trigger_lock;
+	struct gnix_prog_set pset;
 	bool requires_lock;
 };
 
@@ -79,21 +72,25 @@ int _gnix_cntr_inc(struct gnix_fid_cntr *cntr);
 int _gnix_cntr_inc_err(struct gnix_fid_cntr *cntr);
 
 /**
- * @brief              Add a nic to the set of nics progressed when fi_cntr_read
+ * @brief              Add an object to the list progressed when fi_cntr_read
  *                     and related functions are called.
  * @param[in] cntr     pointer to previously allocated gnix_fid_cntr structure
- * @param[in] nic      pointer to previously allocated gnix_nic structure
+ * @param[in] obj      pointer to object to add to the progress list.
+ * @param[in] prog_fn  object progress function
  * @return             FI_SUCCESS on success, -FI_EINVAL on invalid argument
  */
-int _gnix_cntr_poll_nic_add(struct gnix_fid_cntr *cntr, struct gnix_nic *nic);
+int _gnix_cntr_poll_obj_add(struct gnix_fid_cntr *cntr, void *obj,
+			    int (*prog_fn)(void *data));
 
 /**
- * @brief              remove a nic from the set of nics progressed when fi_cntr_read
- *                     and related functions are called.
+ * @brief              Remove an object from the list progressed when
+ *                     fi_cntr_read and related functions are called.
  * @param[in] cntr     pointer to previously allocated gnix_fid_cntr structure
- * @param[in] nic      pointer to previously allocated gnix_nic structure
+ * @param[in] obj      pointer to previously added object
+ * @param[in] prog_fn  object progress function
  * @return             FI_SUCCESS on success, -FI_EINVAL on invalid argument
  */
-int _gnix_cntr_poll_nic_rem(struct gnix_fid_cntr *cntr, struct gnix_nic *nic);
+int _gnix_cntr_poll_obj_rem(struct gnix_fid_cntr *cntr, void *obj,
+			    int (*prog_fn)(void *data));
 
 #endif

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -124,6 +124,8 @@ struct gnix_nic_attr {
  *                           with this nic
  * @var tx_desc_base         base address for the block of memory from which
  *                           tx descriptors were allocated
+ * @var prog_vcs_lock        lock for prog_vcs
+ * @var prog_vcs             list of VCs needing progress
  * @var wq_lock              lock for serializing access to the nic's work queue
  * @var nic_wq               head of linked list of work queue elements
  *                           associated with this nic
@@ -177,12 +179,8 @@ struct gnix_nic {
 	struct dlist_entry tx_desc_active_list;
 	struct dlist_entry tx_desc_free_list;
 	struct gnix_tx_descriptor *tx_desc_base;
-	fastlock_t rx_vc_lock;
-	struct dlist_entry rx_vcs;
-	fastlock_t work_vc_lock;
-	struct dlist_entry work_vcs;
-	fastlock_t tx_vc_lock;
-	struct dlist_entry tx_vcs;
+	fastlock_t prog_vcs_lock;
+	struct dlist_entry prog_vcs;
 	/* note this free list will be initialized for thread safe */
 	struct gnix_freelist vc_freelist;
 	uint8_t ptag;
@@ -440,12 +438,12 @@ int _gnix_nic_free(struct gnix_nic *nic);
 /**
  * @brief progresses control/data operations associated with the nic
  *
- * @param[in] nic      pointer to previously allocated gnix_nic struct
+ * @param[in] arg      pointer to previously allocated gnix_nic struct
  * @return             FI_SUCCESS on success, -FI_EINVAL if an invalid
  *                     nic struct was supplied. TODO: a lot more error
  *                     values can be returned.
  */
-int _gnix_nic_progress(struct gnix_nic *nic);
+int _gnix_nic_progress(void *arg);
 
 /**
  * @brief allocate a remote id for an object, used for looking up an object

--- a/prov/gni/include/gnix_progress.h
+++ b/prov/gni/include/gnix_progress.h
@@ -1,6 +1,7 @@
 /*
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
+ * Copyright (c) 2016 Cray Inc. All rights reserved.
+ * Copyright (c) 2016 Los Alamos National Security, LLC.
+ *               All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -31,60 +32,28 @@
  * SOFTWARE.
  */
 
-#ifndef _GNIX_CQ_H_
-#define _GNIX_CQ_H_
+#ifndef _GNIX_PROGRESS_H_
+#define _GNIX_PROGRESS_H_
 
-#include <fi.h>
-
-#include "gnix_progress.h"
-#include "gnix_queue.h"
-#include "gnix_wait.h"
 #include "gnix_util.h"
-#include <fi_list.h>
-#include <stdbool.h>
 
-#define GNIX_CQ_DEFAULT_FORMAT struct fi_cq_entry
-#define GNIX_CQ_DEFAULT_SIZE   256
+/*
+ * Progress common code
+ */
 
-struct gnix_cq_entry {
-	void *the_entry;
-	fi_addr_t src_addr;
-	struct slist_entry item;
+struct gnix_prog_set {
+	struct dlist_entry prog_objs;
+	rwlock_t lock;
+	int requires_lock;
 };
 
-struct gnix_fid_cq {
-	struct fid_cq cq_fid;
-	struct gnix_fid_domain *domain;
+int _gnix_prog_progress(struct gnix_prog_set *set);
+int _gnix_prog_obj_add(struct gnix_prog_set *set, void *obj,
+		       int (*prog_fn)(void *data));
+int _gnix_prog_obj_rem(struct gnix_prog_set *set, void *obj,
+		       int (*prog_fn)(void *data));
+int _gnix_prog_init(struct gnix_prog_set *set);
+int _gnix_prog_fini(struct gnix_prog_set *set);
 
-	struct gnix_queue *events;
-	struct gnix_queue *errors;
+#endif /* _GNIX_PROGRESS_H_ */
 
-	struct fi_cq_attr attr;
-	size_t entry_size;
-
-	struct fid_wait *wait;
-
-	fastlock_t lock;
-	struct gnix_reference ref_cnt;
-
-	struct gnix_prog_set pset;
-
-	bool requires_lock;
-};
-
-
-ssize_t _gnix_cq_add_event(struct gnix_fid_cq *cq, void *op_context,
-			  uint64_t flags, size_t len, void *buf,
-			  uint64_t data, uint64_t tag, fi_addr_t src_addr);
-
-ssize_t _gnix_cq_add_error(struct gnix_fid_cq *cq, void *op_context,
-			  uint64_t flags, size_t len, void *buf,
-			  uint64_t data, uint64_t tag, size_t olen,
-			  int err, int prov_errno, void *err_data);
-
-int _gnix_cq_poll_obj_add(struct gnix_fid_cq *cq, void *obj,
-			  int (*prog_fn)(void *data));
-int _gnix_cq_poll_obj_rem(struct gnix_fid_cq *cq, void *obj,
-			  int (*prog_fn)(void *data));
-
-#endif

--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -60,6 +60,7 @@
 #define GNIX_VC_FLAG_RX_SCHEDULED	0
 #define GNIX_VC_FLAG_WORK_SCHEDULED	1
 #define GNIX_VC_FLAG_TX_SCHEDULED	2
+#define GNIX_VC_FLAG_SCHEDULED		4
 
 /*
  * defines for connection state for gnix VC
@@ -84,13 +85,9 @@ enum gnix_vc_conn_req_type {
 /**
  * Virual Connection (VC) struct
  *
- * @var rx_list              NIC RX VC list
+ * @var prog_list            NIC VC progress list
  * @var work_queue           Deferred work request queue
- * @var work_queue_lock      Deferred work request queue lock
- * @var work_list            NIC work VC list
  * @var tx_queue             TX request queue
- * @var tx_queue_lock        TX request queue lock
- * @var tx_list              NIC TX VC list
  * @var list                 used for unmapped vc list
  * @var fr_list              used for vc free list
  * @var entry                used internally for managing linked lists
@@ -120,15 +117,9 @@ enum gnix_vc_conn_req_type {
  *                           GNI_PostCqWrite requests to remote peer
  */
 struct gnix_vc {
-	struct dlist_entry rx_list;	/* RX VC list entry */
-
+	struct dlist_entry prog_list;	/* NIC VC progress list entry */
 	struct dlist_entry work_queue;	/* Work reqs */
-	fastlock_t work_queue_lock;	/* Work req lock */
-	struct dlist_entry work_list;	/* Work VC list entry */
-
 	struct dlist_entry tx_queue;	/* TX reqs */
-	fastlock_t tx_queue_lock;	/* TX reqs lock */
-	struct dlist_entry tx_list;	/* TX VC list entry */
 
 	struct dlist_entry list;	/* General purpose list */
 	struct dlist_entry fr_list;	/* fr list */
@@ -180,17 +171,6 @@ int _gnix_vc_alloc(struct gnix_fid_ep *ep_priv,
 int _gnix_vc_connect(struct gnix_vc *vc);
 
 /**
- * @brief Initiates a non-blocking disconnect of a vc from its peer
- *
- * @param[in]  vc   pointer to previously allocated and connected vc struct
- *
- * @return FI_SUCCESS on success, -FI_EINVAL if an invalid field in the vc
- *         struct is encountered, -ENOMEM if insufficient memory to initiate
- *         connection request.
- */
-int _gnix_vc_disconnect(struct gnix_vc *vc);
-
-/**
  * @brief Destroys a previously allocated vc and cleans up resources
  *        associated with the vc
  *
@@ -237,6 +217,7 @@ int _gnix_vc_rx_schedule(struct gnix_vc *vc);
  * @param[in] req The GNIX fabric request to queue.
  */
 int _gnix_vc_queue_work_req(struct gnix_fab_req *req);
+int _gnix_vc_requeue_work_req(struct gnix_fab_req *req);
 
 /**
  * @brief Schedule a VC for TX progress.
@@ -334,26 +315,5 @@ static inline enum gnix_vc_conn_state _gnix_vc_state(struct gnix_vc *vc)
 	assert(vc);
 	return vc->conn_state;
 }
-
-/* Return 0 if VC is connected.  Progress VC CM if not. */
-static inline int __gnix_vc_connected(struct gnix_vc *vc)
-{
-    struct gnix_cm_nic *cm_nic;
-    int ret;
-
-    if (unlikely(vc->conn_state < GNIX_VC_CONNECTED)) {
-        cm_nic = vc->ep->cm_nic;
-        ret = _gnix_cm_nic_progress(cm_nic);
-        if ((ret != FI_SUCCESS) && (ret != -FI_EAGAIN))
-            GNIX_WARN(FI_LOG_EP_CTRL,
-                "_gnix_cm_nic_progress() failed: %s\n",
-            fi_strerror(-ret));
-        /* waiting to connect, check back later */
-        return -FI_EAGAIN;
-    }
-
-    return 0;
-}
-
 
 #endif /* _GNIX_VC_H_ */

--- a/prov/gni/src/gnix_cm_nic.c
+++ b/prov/gni/src/gnix_cm_nic.c
@@ -49,6 +49,9 @@
 #define GNIX_CM_NIC_BND_TAG (100)
 #define GNIX_CM_NIC_WC_TAG (99)
 
+DLIST_HEAD(gnix_cm_nic_list);
+pthread_mutex_t gnix_cm_nic_list_lock = PTHREAD_MUTEX_INITIALIZER;
+
 /*******************************************************************************
  * Helper functions
  ******************************************************************************/
@@ -155,6 +158,12 @@ static int __process_datagram(struct gnix_datagram *dgram,
 				fi_strerror(-ret));
 			goto err;
 		}
+
+		ret = _gnix_cm_nic_progress(cm_nic);
+		if (ret != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "_gnix_cm_nic_progress returned %s\n",
+				  fi_strerror(-ret));
 	}
 
 	/*
@@ -243,8 +252,9 @@ int _gnix_get_new_cdm_id_set(struct gnix_fid_domain *domain, int nids,
 	return FI_SUCCESS;
 }
 
-int _gnix_cm_nic_progress(struct gnix_cm_nic *cm_nic)
+int _gnix_cm_nic_progress(void *arg)
 {
+	struct gnix_cm_nic *cm_nic = (struct gnix_cm_nic *)arg;
 	int ret = FI_SUCCESS;
 	int complete;
 	struct gnix_work_req *p = NULL;
@@ -334,6 +344,10 @@ static void  __cm_nic_destruct(void *obj)
 	struct gnix_cm_nic *cm_nic = (struct gnix_cm_nic *)obj;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	pthread_mutex_lock(&gnix_cm_nic_list_lock);
+	dlist_remove(&cm_nic->cm_nic_list);
+	pthread_mutex_unlock(&gnix_cm_nic_list_lock);
 
 	if (cm_nic->dgram_hndl != NULL) {
 		ret = _gnix_dgram_hndl_free(cm_nic->dgram_hndl);
@@ -662,6 +676,11 @@ int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 	_gnix_ref_init(&cm_nic->ref_cnt, 1, __cm_nic_destruct);
 
 	*cm_nic_ptr = cm_nic;
+
+	pthread_mutex_lock(&gnix_cm_nic_list_lock);
+	dlist_insert_tail(&cm_nic->cm_nic_list, &gnix_cm_nic_list);
+	pthread_mutex_unlock(&gnix_cm_nic_list_lock);
+
 	return ret;
 
 err:

--- a/prov/gni/src/gnix_cntr.c
+++ b/prov/gni/src/gnix_cntr.c
@@ -121,22 +121,7 @@ static int gnix_cntr_set_wait(struct gnix_fid_cntr *cntr)
 
 static int __gnix_cntr_progress(struct gnix_fid_cntr *cntr)
 {
-	struct gnix_cq_poll_nic *pnic, *tmp;
-	int rc = FI_SUCCESS;
-
-	COND_READ_ACQUIRE(cntr->requires_lock, &cntr->nic_lock);
-
-	dlist_for_each_safe(&cntr->poll_nics, pnic, tmp, list) {
-		rc = _gnix_nic_progress(pnic->nic);
-		if (rc) {
-			GNIX_WARN(FI_LOG_CQ,
-				  "_gnix_nic_progress failed: %d\n", rc);
-		}
-	}
-
-	COND_RW_RELEASE(cntr->requires_lock, &cntr->nic_lock);
-
-	return rc;
+	return _gnix_prog_progress(&cntr->pset);
 }
 
 /*******************************************************************************
@@ -172,65 +157,16 @@ int _gnix_cntr_inc_err(struct gnix_fid_cntr *cntr)
 	return FI_SUCCESS;
 }
 
-int _gnix_cntr_poll_nic_add(struct gnix_fid_cntr *cntr, struct gnix_nic *nic)
+int _gnix_cntr_poll_obj_add(struct gnix_fid_cntr *cntr, void *obj,
+			    int (*prog_fn)(void *data))
 {
-	struct gnix_cntr_poll_nic *pnic, *tmp;
-
-	COND_WRITE_ACQUIRE(cntr->requires_lock, &cntr->nic_lock);
-
-	dlist_for_each_safe(&cntr->poll_nics, pnic, tmp, list) {
-		if (pnic->nic == nic) {
-			pnic->ref_cnt++;
-			COND_RW_RELEASE(cntr->requires_lock, &cntr->nic_lock);
-			return FI_SUCCESS;
-		}
-	}
-
-	pnic = malloc(sizeof(struct gnix_cntr_poll_nic));
-	if (!pnic) {
-		GNIX_WARN(FI_LOG_CQ, "Failed to add NIC to CNTR poll list.\n");
-		COND_RW_RELEASE(cntr->requires_lock, &cntr->nic_lock);
-		return -FI_ENOMEM;
-	}
-
-	/* EP holds a ref count on the NIC */
-	pnic->nic = nic;
-	pnic->ref_cnt = 1;
-	dlist_init(&pnic->list);
-	dlist_insert_tail(&pnic->list, &cntr->poll_nics);
-
-	COND_RW_RELEASE(cntr->requires_lock, &cntr->nic_lock);
-
-	GNIX_INFO(FI_LOG_CQ, "Added NIC(%p) to CNTR(%p) poll list\n",
-		  nic, cntr);
-
-	return FI_SUCCESS;
+	return _gnix_prog_obj_add(&cntr->pset, obj, prog_fn);
 }
 
-int _gnix_cntr_poll_nic_rem(struct gnix_fid_cntr *cntr, struct gnix_nic *nic)
+int _gnix_cntr_poll_obj_rem(struct gnix_fid_cntr *cntr, void *obj,
+			    int (*prog_fn)(void *data))
 {
-	struct gnix_cntr_poll_nic *pnic, *tmp;
-
-	COND_WRITE_ACQUIRE(cntr->requires_lock, &cntr->nic_lock);
-
-	dlist_for_each_safe(&cntr->poll_nics, pnic, tmp, list) {
-		if (pnic->nic == nic) {
-			if (!--pnic->ref_cnt) {
-				dlist_remove(&pnic->list);
-				free(pnic);
-				GNIX_INFO(FI_LOG_CQ,
-					  "Removed NIC(%p) from CNTR(%p) poll list\n",
-					  nic, cntr);
-			}
-			COND_RW_RELEASE(cntr->requires_lock, &cntr->nic_lock);
-			return FI_SUCCESS;
-		}
-	}
-
-	COND_RW_RELEASE(cntr->requires_lock, &cntr->nic_lock);
-
-	GNIX_WARN(FI_LOG_CQ, "NIC not found on CNTR poll list.\n");
-	return -FI_EINVAL;
+	return _gnix_prog_obj_rem(&cntr->pset, obj, prog_fn);
 }
 
 /*******************************************************************************
@@ -319,6 +255,8 @@ static void __cntr_destruct(void *obj)
 			  cntr->attr.wait_obj);
 		break;
 	}
+
+	_gnix_prog_fini(&cntr->pset);
 
 	free(cntr);
 }
@@ -489,8 +427,9 @@ DIRECT_FN int gnix_cntr_open(struct fid_domain *domain,
 	atomic_initialize(&cntr_priv->cnt_err, 0);
 
 	_gnix_ref_get(cntr_priv->domain);
-	dlist_init(&cntr_priv->poll_nics);
-	rwlock_init(&cntr_priv->nic_lock);
+
+	_gnix_prog_init(&cntr_priv->pset);
+
 	dlist_init(&cntr_priv->trigger_list);
 	fastlock_init(&cntr_priv->trigger_lock);
 

--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -251,31 +251,7 @@ err:
 
 static int __gnix_cq_progress(struct gnix_fid_cq *cq)
 {
-	struct gnix_cq_poll_nic *pnic, *tmp;
-	int rc;
-
-	COND_READ_ACQUIRE(cq->requires_lock, &cq->nic_lock);
-
-	dlist_for_each_safe(&cq->poll_nics, pnic, tmp, list) {
-		rc = _gnix_nic_progress(pnic->nic);
-		if (rc) {
-			GNIX_WARN(FI_LOG_CQ,
-				  "_gnix_nic_progress failed: %d\n", rc);
-		}
-	}
-
-	COND_RW_RELEASE(cq->requires_lock, &cq->nic_lock);
-
-	if (unlikely(cq->domain->control_progress != FI_PROGRESS_AUTO)) {
-		if (cq->domain->cm_nic != NULL) {
-			rc = _gnix_cm_nic_progress(cq->domain->cm_nic);
-			if (rc)
-				GNIX_WARN(FI_LOG_CQ,
-				  "_gnix_cm_nic_progress returned: %d\n", rc);
-		}
-	}
-
-	return FI_SUCCESS;
+	return _gnix_prog_progress(&cq->pset);
 }
 
 
@@ -362,65 +338,16 @@ err:
 	return ret;
 }
 
-int _gnix_cq_poll_nic_add(struct gnix_fid_cq *cq, struct gnix_nic *nic)
+int _gnix_cq_poll_obj_add(struct gnix_fid_cq *cq, void *obj,
+			  int (*prog_fn)(void *data))
 {
-	struct gnix_cq_poll_nic *pnic, *tmp;
-
-	COND_WRITE_ACQUIRE(cq->requires_lock, &cq->nic_lock);
-
-	dlist_for_each_safe(&cq->poll_nics, pnic, tmp, list) {
-		if (pnic->nic == nic) {
-			pnic->ref_cnt++;
-			rwlock_unlock(&cq->nic_lock);
-			return FI_SUCCESS;
-		}
-	}
-
-	pnic = malloc(sizeof(struct gnix_cq_poll_nic));
-	if (!pnic) {
-		GNIX_WARN(FI_LOG_CQ, "Failed to add NIC to CQ poll list.\n");
-		COND_RW_RELEASE(cq->requires_lock, &cq->nic_lock);
-		return -FI_ENOMEM;
-	}
-
-	/* EP holds a ref count on the NIC */
-	pnic->nic = nic;
-	pnic->ref_cnt = 1;
-	dlist_init(&pnic->list);
-	dlist_insert_tail(&pnic->list, &cq->poll_nics);
-
-	COND_RW_RELEASE(cq->requires_lock, &cq->nic_lock);
-
-	GNIX_INFO(FI_LOG_CQ, "Added NIC(%p) to CQ(%p) poll list\n",
-		  nic, cq);
-
-	return FI_SUCCESS;
+	return _gnix_prog_obj_add(&cq->pset, obj, prog_fn);
 }
 
-int _gnix_cq_poll_nic_rem(struct gnix_fid_cq *cq, struct gnix_nic *nic)
+int _gnix_cq_poll_obj_rem(struct gnix_fid_cq *cq, void *obj,
+			  int (*prog_fn)(void *data))
 {
-	struct gnix_cq_poll_nic *pnic, *tmp;
-
-	COND_WRITE_ACQUIRE(cq->requires_lock, &cq->nic_lock);
-
-	dlist_for_each_safe(&cq->poll_nics, pnic, tmp, list) {
-		if (pnic->nic == nic) {
-			if (!--pnic->ref_cnt) {
-				dlist_remove(&pnic->list);
-				free(pnic);
-				GNIX_INFO(FI_LOG_CQ,
-					  "Removed NIC(%p) from CQ(%p) poll list\n",
-					  nic, cq);
-			}
-			rwlock_unlock(&cq->nic_lock);
-			return FI_SUCCESS;
-		}
-	}
-
-	COND_RW_RELEASE(cq->requires_lock, &cq->nic_lock);
-
-	GNIX_WARN(FI_LOG_CQ, "NIC not found on CQ poll list.\n");
-	return -FI_EINVAL;
+	return _gnix_prog_obj_rem(&cq->pset, obj, prog_fn);
 }
 
 static void __cq_destruct(void *obj)
@@ -446,6 +373,8 @@ static void __cq_destruct(void *obj)
 			  cq->attr.wait_obj);
 		break;
 	}
+
+	_gnix_prog_fini(&cq->pset);
 
 	_gnix_queue_destroy(cq->events);
 	_gnix_queue_destroy(cq->errors);
@@ -689,8 +618,8 @@ DIRECT_FN int gnix_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 
 	_gnix_ref_init(&cq_priv->ref_cnt, 1, __cq_destruct);
 	_gnix_ref_get(cq_priv->domain);
-	dlist_init(&cq_priv->poll_nics);
-	rwlock_init(&cq_priv->nic_lock);
+
+	_gnix_prog_init(&cq_priv->pset);
 
 	cq_priv->cq_fid.fid.fclass = FI_CLASS_CQ;
 	cq_priv->cq_fid.fid.context = context;

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -178,35 +178,71 @@ int _gnix_ep_enable(struct gnix_fid_ep *ep)
 	 */
 
 	if (ep->send_cq) {
-		_gnix_cq_poll_nic_add(ep->send_cq, ep->nic);
+		_gnix_cq_poll_obj_add(ep->send_cq, ep->nic,
+				      _gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cq_poll_obj_add(ep->send_cq, ep->cm_nic,
+					      _gnix_cm_nic_progress);
 		ep->tx_enabled = true;
 	}
 
 	if (ep->recv_cq) {
-		_gnix_cq_poll_nic_add(ep->recv_cq, ep->nic);
+		_gnix_cq_poll_obj_add(ep->recv_cq, ep->nic,
+				      _gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cq_poll_obj_add(ep->recv_cq, ep->cm_nic,
+					      _gnix_cm_nic_progress);
 		ep->rx_enabled = true;
 	}
 
-	if (ep->send_cntr)
-		_gnix_cntr_poll_nic_add(ep->send_cntr, ep->nic);
+	if (ep->send_cntr) {
+		_gnix_cntr_poll_obj_add(ep->send_cntr, ep->nic,
+					_gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cntr_poll_obj_add(ep->send_cntr, ep->cm_nic,
+						_gnix_cm_nic_progress);
+	}
 
-	if (ep->recv_cntr)
-		_gnix_cntr_poll_nic_add(ep->recv_cntr, ep->nic);
+	if (ep->recv_cntr) {
+		_gnix_cntr_poll_obj_add(ep->recv_cntr, ep->nic,
+					_gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cntr_poll_obj_add(ep->recv_cntr, ep->cm_nic,
+						_gnix_cm_nic_progress);
+	}
 
-	if (ep->write_cntr)
-		_gnix_cntr_poll_nic_add(ep->write_cntr,
-					ep->nic);
+	if (ep->write_cntr) {
+		_gnix_cntr_poll_obj_add(ep->write_cntr, ep->nic,
+					_gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cntr_poll_obj_add(ep->write_cntr, ep->cm_nic,
+						_gnix_cm_nic_progress);
+	}
 
-	if (ep->read_cntr)
-		_gnix_cntr_poll_nic_add(ep->read_cntr, ep->nic);
+	if (ep->read_cntr) {
+		_gnix_cntr_poll_obj_add(ep->read_cntr, ep->nic,
+					_gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cntr_poll_obj_add(ep->read_cntr, ep->cm_nic,
+						_gnix_cm_nic_progress);
+	}
 
-	if (ep->rwrite_cntr)
-		_gnix_cntr_poll_nic_add(ep->rwrite_cntr,
-					ep->nic);
+	if (ep->rwrite_cntr) {
+		_gnix_cntr_poll_obj_add(ep->rwrite_cntr, ep->nic,
+					_gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cntr_poll_obj_add(ep->rwrite_cntr, ep->cm_nic,
+						_gnix_cm_nic_progress);
+	}
 
-	if (ep->rread_cntr)
-		_gnix_cntr_poll_nic_add(ep->rread_cntr,
-					ep->nic);
+	if (ep->rread_cntr) {
+		_gnix_cntr_poll_obj_add(ep->rread_cntr, ep->nic,
+					_gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cntr_poll_obj_add(ep->rread_cntr, ep->cm_nic,
+						_gnix_cm_nic_progress);
+	}
+
 	return FI_SUCCESS;
 }
 
@@ -1504,42 +1540,74 @@ static void __ep_destruct(void *obj)
 	}
 
 	if (ep->send_cq) {
-		_gnix_cq_poll_nic_rem(ep->send_cq, ep->nic);
+		_gnix_cq_poll_obj_rem(ep->send_cq, ep->nic,
+				      _gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cq_poll_obj_rem(ep->send_cq, ep->cm_nic,
+					      _gnix_cm_nic_progress);
 		_gnix_ref_put(ep->send_cq);
 	}
 
 	if (ep->recv_cq) {
-		_gnix_cq_poll_nic_rem(ep->recv_cq, ep->nic);
+		_gnix_cq_poll_obj_rem(ep->recv_cq, ep->nic,
+				       _gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cq_poll_obj_rem(ep->recv_cq, ep->cm_nic,
+					      _gnix_cm_nic_progress);
 		_gnix_ref_put(ep->recv_cq);
 	}
 
 	if (ep->send_cntr) {
-		_gnix_cntr_poll_nic_rem(ep->send_cntr, ep->nic);
+		_gnix_cntr_poll_obj_rem(ep->send_cntr, ep->nic,
+					_gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cntr_poll_obj_rem(ep->send_cntr, ep->cm_nic,
+						_gnix_cm_nic_progress);
 		_gnix_ref_put(ep->send_cntr);
 	}
 
 	if (ep->recv_cntr) {
-		_gnix_cntr_poll_nic_rem(ep->recv_cntr, ep->nic);
+		_gnix_cntr_poll_obj_rem(ep->recv_cntr, ep->nic,
+					_gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cntr_poll_obj_rem(ep->recv_cntr, ep->cm_nic,
+						_gnix_cm_nic_progress);
 		_gnix_ref_put(ep->recv_cntr);
 	}
 
 	if (ep->write_cntr) {
-		_gnix_cntr_poll_nic_rem(ep->write_cntr, ep->nic);
+		_gnix_cntr_poll_obj_rem(ep->write_cntr, ep->nic,
+					_gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cntr_poll_obj_rem(ep->write_cntr, ep->cm_nic,
+						_gnix_cm_nic_progress);
 		_gnix_ref_put(ep->write_cntr);
 	}
 
 	if (ep->read_cntr) {
-		_gnix_cntr_poll_nic_rem(ep->read_cntr, ep->nic);
+		_gnix_cntr_poll_obj_rem(ep->read_cntr, ep->nic,
+					_gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cntr_poll_obj_rem(ep->read_cntr, ep->cm_nic,
+						_gnix_cm_nic_progress);
 		_gnix_ref_put(ep->read_cntr);
 	}
 
 	if (ep->rwrite_cntr) {
-		_gnix_cntr_poll_nic_rem(ep->rwrite_cntr, ep->nic);
+		_gnix_cntr_poll_obj_rem(ep->rwrite_cntr, ep->nic,
+					_gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cntr_poll_obj_rem(ep->rwrite_cntr, ep->cm_nic,
+						_gnix_cm_nic_progress);
 		_gnix_ref_put(ep->rwrite_cntr);
 	}
 
 	if (ep->rread_cntr) {
-		_gnix_cntr_poll_nic_rem(ep->rread_cntr, ep->nic);
+		_gnix_cntr_poll_obj_rem(ep->rread_cntr, ep->nic,
+					_gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cntr_poll_obj_rem(ep->rread_cntr, ep->cm_nic,
+						_gnix_cm_nic_progress);
 		_gnix_ref_put(ep->rread_cntr);
 	}
 
@@ -2103,8 +2171,6 @@ DIRECT_FN int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 	ep_priv->type = info->ep_attr->type;
 	ep_priv->domain = domain_priv;
 	_gnix_ref_init(&ep_priv->ref_cnt, 1, __ep_destruct);
-	fastlock_init(&ep_priv->recv_queue_lock);
-	fastlock_init(&ep_priv->tagged_queue_lock);
 	ep_priv->min_multi_recv = GNIX_OPT_MIN_MULTI_RECV_DEFAULT;
 	fastlock_init(&ep_priv->vc_lock);
 	ep_priv->progress_fn = NULL;
@@ -2261,9 +2327,6 @@ int _gnix_ep_alloc(struct fid_domain *domain, struct fi_info *info,
 	ep_priv->type = info->ep_attr->type;
 
 	_gnix_ref_init(&ep_priv->ref_cnt, 1, __ep_destruct);
-
-	fastlock_init(&ep_priv->recv_queue_lock);
-	fastlock_init(&ep_priv->tagged_queue_lock);
 
 	ep_priv->caps = info->caps & GNIX_EP_CAPS_FULL;
 
@@ -2497,13 +2560,9 @@ static inline struct gnix_fab_req *__find_tx_req(
 
 		while ((vc = (struct gnix_vc *)
 				_gnix_vec_iterator_next(&iter))) {
-			COND_ACQUIRE(vc->ep->requires_lock,
-				     &vc->tx_queue_lock);
 			entry = dlist_remove_first_match(&vc->tx_queue,
 							 __match_context,
 							 context);
-			COND_RELEASE(vc->ep->requires_lock,
-				     &vc->tx_queue_lock);
 
 			if (entry) {
 				req = container_of(entry,
@@ -2516,13 +2575,9 @@ static inline struct gnix_fab_req *__find_tx_req(
 		GNIX_HASHTABLE_ITERATOR(ep->vc_ht, iter);
 
 		while ((vc = _gnix_ht_iterator_next(&iter))) {
-			COND_ACQUIRE(vc->ep->requires_lock,
-				     &vc->tx_queue_lock);
 			entry = dlist_remove_first_match(&vc->tx_queue,
 							 __match_context,
 							 context);
-			COND_RELEASE(vc->ep->requires_lock,
-				     &vc->tx_queue_lock);
 
 			if (entry) {
 				req = container_of(entry,
@@ -2544,17 +2599,16 @@ static inline struct gnix_fab_req *__find_rx_req(
 {
 	struct gnix_fab_req *req = NULL;
 
-	COND_ACQUIRE(ep->requires_lock, &ep->recv_queue_lock);
+	COND_ACQUIRE(ep->requires_lock, &ep->vc_lock);
 	req = _gnix_remove_req_by_context(&ep->posted_recv_queue, context);
-	COND_RELEASE(ep->requires_lock, &ep->recv_queue_lock);
-
-	if (req)
+	if (req) {
+		COND_RELEASE(ep->requires_lock, &ep->vc_lock);
 		return req;
+	}
 
-	COND_ACQUIRE(ep->requires_lock, &ep->tagged_queue_lock);
 	req = _gnix_remove_req_by_context(&ep->tagged_posted_recv_queue,
 			context);
-	COND_RELEASE(ep->requires_lock, &ep->tagged_queue_lock);
+	COND_RELEASE(ep->requires_lock, &ep->vc_lock);
 
 	return req;
 }

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -155,7 +155,7 @@ try_again:
 							&cqe);
 			} while (status == GNI_RC_SUCCESS);
 		}
-		_gnix_nic_progress(nic);
+		_gnix_nic_progress((void *)nic);
 		retry = 1;
 		break;
 	case GNI_RC_TIMEOUT:
@@ -321,12 +321,8 @@ static int __nic_rx_overrun(struct gnix_nic *nic)
 		ret = _gnix_test_bit(&nic->vc_id_bitmap, i);
 		if (ret) {
 			vc = __gnix_nic_elem_by_rem_id(nic, i);
-			ret = _gnix_vc_dequeue_smsg(vc);
-			if (ret != FI_SUCCESS) {
-				GNIX_WARN(FI_LOG_EP_DATA,
-					  "_gnix_vc_dqueue_smsg returned %d\n",
-					  ret);
-			}
+			ret = _gnix_vc_rx_schedule(vc);
+			assert(ret == FI_SUCCESS);
 		}
 	}
 
@@ -359,12 +355,8 @@ static int __process_rx_cqe(struct gnix_nic *nic, gni_cq_entry_t cqe)
 			GNIX_DEBUG(FI_LOG_EP_DATA,
 				  "Processing VC RX (%p)\n",
 				  vc);
-			ret = _gnix_vc_dequeue_smsg(vc);
-			if (ret != FI_SUCCESS) {
-				GNIX_WARN(FI_LOG_EP_DATA,
-					"_gnix_vc_dqueue_smsg returned %d\n",
-					ret);
-			}
+			ret = _gnix_vc_rx_schedule(vc);
+			assert(ret == FI_SUCCESS);
 			break;
 		default:
 			break;  /* VC not in a state for scheduling or
@@ -559,8 +551,9 @@ static int __nic_tx_progress(struct gnix_nic *nic, gni_cq_handle_t cq)
 	return ret;
 }
 
-int _gnix_nic_progress(struct gnix_nic *nic)
+int _gnix_nic_progress(void *arg)
 {
+	struct gnix_nic *nic = (struct gnix_nic *)arg;
 	int ret = FI_SUCCESS;
 
 	ret =  __nic_tx_progress(nic, nic->tx_cq);
@@ -1146,12 +1139,8 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 		if (ret != FI_SUCCESS)
 			goto err1;
 
-		fastlock_init(&nic->rx_vc_lock);
-		dlist_init(&nic->rx_vcs);
-		fastlock_init(&nic->work_vc_lock);
-		dlist_init(&nic->work_vcs);
-		fastlock_init(&nic->tx_vc_lock);
-		dlist_init(&nic->tx_vcs);
+		fastlock_init(&nic->prog_vcs_lock);
+		dlist_init(&nic->prog_vcs);
 
 		_gnix_ref_init(&nic->ref_cnt, 1, __nic_destruct);
 

--- a/prov/gni/src/gnix_progress.c
+++ b/prov/gni/src/gnix_progress.c
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2016 Cray Inc. All rights reserved.
+ * Copyright (c) 2016 Los Alamos National Security, LLC.
+ *               All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * Progress common code
+ */
+
+#include <stdlib.h>
+
+#include "gnix_progress.h"
+
+struct gnix_prog_obj {
+	struct dlist_entry list;
+	int ref_cnt;
+	void *obj;
+	int (*prog_fn)(void *data);
+};
+
+
+int _gnix_prog_progress(struct gnix_prog_set *set)
+{
+	struct gnix_prog_obj *pobj, *tmp;
+	int rc;
+
+	COND_READ_ACQUIRE(set->requires_lock, &set->lock);
+
+	dlist_for_each_safe(&set->prog_objs, pobj, tmp, list) {
+		rc = pobj->prog_fn(pobj->obj);
+		if (rc) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "Obj(%p) prog function failed: %d\n",
+				  pobj, rc);
+		}
+	}
+
+	COND_RW_RELEASE(set->requires_lock, &set->lock);
+
+	return FI_SUCCESS;
+}
+
+int _gnix_prog_obj_add(struct gnix_prog_set *set, void *obj,
+		       int (*prog_fn)(void *data))
+{
+	struct gnix_prog_obj *pobj, *tmp;
+
+	COND_WRITE_ACQUIRE(set->requires_lock, &set->lock);
+
+	dlist_for_each_safe(&set->prog_objs, pobj, tmp, list) {
+		if (obj == pobj->obj && prog_fn == pobj->prog_fn) {
+			pobj->ref_cnt++;
+			COND_RW_RELEASE(set->requires_lock, &set->lock);
+			return FI_SUCCESS;
+		}
+	}
+
+	pobj = malloc(sizeof(struct gnix_prog_obj));
+	if (!pobj) {
+		GNIX_WARN(FI_LOG_EP_CTRL, "Failed to add OBJ to prog set.\n");
+		COND_RW_RELEASE(set->requires_lock, &set->lock);
+		return -FI_ENOMEM;
+	}
+
+	pobj->obj = obj;
+	pobj->prog_fn = prog_fn;
+	pobj->ref_cnt = 1;
+	dlist_init(&pobj->list);
+	dlist_insert_tail(&pobj->list, &set->prog_objs);
+
+	COND_RW_RELEASE(set->requires_lock, &set->lock);
+
+	GNIX_INFO(FI_LOG_EP_CTRL, "Added obj(%p) to set(%p)\n",
+		  obj, set);
+
+	return FI_SUCCESS;
+}
+
+int _gnix_prog_obj_rem(struct gnix_prog_set *set, void *obj,
+		       int (*prog_fn)(void *data))
+{
+	struct gnix_prog_obj *pobj, *tmp;
+
+	COND_WRITE_ACQUIRE(set->requires_lock, &set->lock);
+
+	dlist_for_each_safe(&set->prog_objs, pobj, tmp, list) {
+		if (obj == pobj->obj && prog_fn == pobj->prog_fn) {
+			if (!--pobj->ref_cnt) {
+				dlist_remove(&pobj->list);
+				free(pobj);
+				GNIX_INFO(FI_LOG_EP_CTRL,
+					  "Removed obj(%p) from set(%p)\n",
+					  obj, set);
+			}
+			COND_RW_RELEASE(set->requires_lock, &set->lock);
+			return FI_SUCCESS;
+		}
+	}
+
+	COND_RW_RELEASE(set->requires_lock, &set->lock);
+
+	GNIX_WARN(FI_LOG_EP_CTRL, "Object not found on prog set.\n");
+	return -FI_EINVAL;
+}
+
+int _gnix_prog_init(struct gnix_prog_set *set)
+{
+	dlist_init(&set->prog_objs);
+	rwlock_init(&set->lock);
+	set->requires_lock = 1;
+
+	return FI_SUCCESS;
+}
+
+int _gnix_prog_fini(struct gnix_prog_set *set)
+{
+	struct gnix_prog_obj *pobj, *tmp;
+
+	COND_WRITE_ACQUIRE(set->requires_lock, &set->lock);
+
+	dlist_for_each_safe(&set->prog_objs, pobj, tmp, list) {
+		dlist_remove(&pobj->list);
+		free(pobj);
+	}
+
+	COND_RW_RELEASE(set->requires_lock, &set->lock);
+
+	rwlock_destroy(&set->lock);
+
+	return FI_SUCCESS;
+}
+

--- a/prov/gni/src/gnix_sep.c
+++ b/prov/gni/src/gnix_sep.c
@@ -372,7 +372,10 @@ static int gnix_sep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 					break;
 				}
 				ep->send_cntr = cntr;
-				_gnix_cntr_poll_nic_add(cntr, ep->nic);
+				_gnix_cntr_poll_obj_add(cntr, ep->nic,
+							_gnix_nic_progress);
+				_gnix_cntr_poll_obj_add(cntr, ep->cm_nic,
+							_gnix_cm_nic_progress);
 				_gnix_ref_get(cntr);
 			}
 
@@ -385,7 +388,10 @@ static int gnix_sep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 					break;
 				}
 				ep->write_cntr = cntr;
-				_gnix_cntr_poll_nic_add(cntr, ep->nic);
+				_gnix_cntr_poll_obj_add(cntr, ep->nic,
+							_gnix_nic_progress);
+				_gnix_cntr_poll_obj_add(cntr, ep->cm_nic,
+							_gnix_cm_nic_progress);
 				_gnix_ref_get(cntr);
 			}
 
@@ -398,7 +404,10 @@ static int gnix_sep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 					break;
 				}
 				ep->rwrite_cntr = cntr;
-				_gnix_cntr_poll_nic_add(cntr, ep->nic);
+				_gnix_cntr_poll_obj_add(cntr, ep->nic,
+							_gnix_nic_progress);
+				_gnix_cntr_poll_obj_add(cntr, ep->cm_nic,
+							_gnix_cm_nic_progress);
 				_gnix_ref_get(cntr);
 			}
 		}
@@ -420,7 +429,10 @@ static int gnix_sep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 					break;
 				}
 				ep->recv_cntr = cntr;
-				_gnix_cntr_poll_nic_add(cntr, ep->nic);
+				_gnix_cntr_poll_obj_add(cntr, ep->nic,
+							_gnix_nic_progress);
+				_gnix_cntr_poll_obj_add(cntr, ep->cm_nic,
+							_gnix_cm_nic_progress);
 				_gnix_ref_get(cntr);
 			}
 
@@ -433,7 +445,10 @@ static int gnix_sep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 					break;
 				}
 				ep->read_cntr = cntr;
-				_gnix_cntr_poll_nic_add(cntr, ep->nic);
+				_gnix_cntr_poll_obj_add(cntr, ep->nic,
+							_gnix_nic_progress);
+				_gnix_cntr_poll_obj_add(cntr, ep->cm_nic,
+							_gnix_cm_nic_progress);
 				_gnix_ref_get(cntr);
 			}
 
@@ -446,13 +461,15 @@ static int gnix_sep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 					break;
 				}
 				ep->rread_cntr = cntr;
-				_gnix_cntr_poll_nic_add(cntr, ep->nic);
+				_gnix_cntr_poll_obj_add(cntr, ep->nic,
+							_gnix_nic_progress);
+				_gnix_cntr_poll_obj_add(cntr, ep->cm_nic,
+							_gnix_cm_nic_progress);
 				_gnix_ref_get(cntr);
 			}
 		}
 
 		break;
-			break;
 	default:
 		ret = -FI_ENOSYS;
 		break;

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -71,6 +71,9 @@ static int __gnix_vc_conn_ack_prog_fn(void *data, int *complete_ptr);
 static int __gnix_vc_conn_ack_comp_fn(void *data);
 static int __gnix_vc_push_tx_reqs(struct gnix_vc *vc);
 
+static int __gnix_vc_work_schedule(struct gnix_vc *vc);
+static int _gnix_vc_sched_new_conn(struct gnix_vc *vc);
+
 /*******************************************************************************
  * Helper functions
  ******************************************************************************/
@@ -145,7 +148,9 @@ static int __gnix_vc_gnix_addr_equal(struct dlist_entry *item, const void *arg)
 }
 
 /* Find an unmapped VC that matches 'dest_addr' and map it into the EP's VC
- * look up table.  VC lock must be held. */
+ * look up table.
+ *
+ * Note: EP must be locked. */
 static struct gnix_vc *__gnix_vc_lookup_unmapped(struct gnix_fid_ep *ep,
 						 fi_addr_t dest_addr)
 {
@@ -199,6 +204,8 @@ static struct gnix_vc *__gnix_vc_lookup_unmapped(struct gnix_fid_ep *ep,
  * assumptions: ep is non-null;
  * dest_addr is valid;
  * vc_ptr is non-null.
+ *
+ * Note: EP must be locked.
  */
 static int __gnix_vc_get_vc_by_fi_addr(struct gnix_fid_ep *ep, fi_addr_t dest_addr,
 				       struct gnix_vc **vc_ptr)
@@ -220,12 +227,9 @@ static int __gnix_vc_get_vc_by_fi_addr(struct gnix_fid_ep *ep, fi_addr_t dest_ad
 		return -FI_EINVAL;
 	}
 
-	COND_ACQUIRE(ep->requires_lock, &ep->vc_lock);
-
 	/* Use FI address to lookup in EP VC table. */
 	vc = _gnix_ep_vc_lookup(ep, dest_addr);
 	if (vc) {
-		COND_RELEASE(ep->requires_lock, &ep->vc_lock);
 		*vc_ptr = vc;
 		return FI_SUCCESS;
 	}
@@ -239,7 +243,6 @@ static int __gnix_vc_get_vc_by_fi_addr(struct gnix_fid_ep *ep, fi_addr_t dest_ad
 	 * exists and map it into the AV here. */
 	vc = __gnix_vc_lookup_unmapped(ep, dest_addr);
 	if (vc) {
-		COND_RELEASE(ep->requires_lock, &ep->vc_lock);
 		*vc_ptr = vc;
 		return FI_SUCCESS;
 	}
@@ -281,27 +284,10 @@ static int __gnix_vc_get_vc_by_fi_addr(struct gnix_fid_ep *ep, fi_addr_t dest_ad
 		goto err_w_lock;
 	}
 
-	COND_RELEASE(ep->requires_lock, &ep->vc_lock);
-
-	/* If we just initiated an intra-CM NIC connection, run CM progress.
-	 * This will attempt to complete the connection immediately.  This may
-	 * be required if auto-progress is enabled because CM progress would
-	 * not otherwise be run until a datagram is received on the network. */
-	if (GNIX_ADDR_EQUAL(vc->peer_cm_nic_addr,
-			    vc->ep->cm_nic->my_name.gnix_addr)) {
-		ret = _gnix_cm_nic_progress(ep->domain->cm_nic);
-		if (ret != FI_SUCCESS) {
-			GNIX_WARN(FI_LOG_EP_DATA,
-				  "_gnix_cm_nic_progress() returned %s\n",
-				  fi_strerror(-ret));
-		}
-	}
-
 	*vc_ptr = vc;
 	return ret;
 
 err_w_lock:
-	COND_RELEASE(ep->requires_lock, &ep->vc_lock);
 	if (vc != NULL)
 		_gnix_vc_destroy(vc);
 	return ret;
@@ -680,10 +666,10 @@ static int __gnix_vc_connect_to_self(struct gnix_vc *vc)
 	vc->peer_caps = ep->caps;
 	vc->peer_irq_mem_hndl = ep->nic->irq_mem_hndl;
 
-	ret = _gnix_vc_schedule(vc);
+	ret = _gnix_vc_sched_new_conn(vc);
 	if (ret != FI_SUCCESS)
 		GNIX_WARN(FI_LOG_EP_DATA,
-			  "_gnix_vc_schedule returned %s\n",
+			  "_gnix_vc_sched_new_conn returned %s\n",
 			  fi_strerror(-ret));
 
 	GNIX_DEBUG(FI_LOG_EP_CTRL, "moving vc %p state to connected\n", vc);
@@ -796,10 +782,10 @@ static int __gnix_vc_hndl_conn_resp(struct gnix_cm_nic *cm_nic,
 	vc->peer_caps = peer_caps;
 	COND_RELEASE(ep->requires_lock, &ep->vc_lock);
 
-	ret = _gnix_vc_schedule(vc);
+	ret = _gnix_vc_sched_new_conn(vc);
 	if (ret != FI_SUCCESS)
 		GNIX_WARN(FI_LOG_EP_DATA,
-			  "_gnix_vc_schedule returned %s\n",
+			  "_gnix_vc_sched_new_conn returned %s\n",
 			  fi_strerror(-ret));
 
 	return ret;
@@ -872,8 +858,7 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 	if (ep == NULL) {
 		GNIX_WARN(FI_LOG_EP_DATA,
 			  "_gnix_ht_lookup addr_to_ep failed\n");
-		ret = -FI_ENOENT;
-		goto err;
+		return -FI_ENOENT;
 	}
 
 	/*
@@ -978,21 +963,6 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 		fastlock_acquire(&cm_nic->wq_lock);
 		dlist_insert_before(&work_req->list, &cm_nic->cm_nic_wq);
 		fastlock_release(&cm_nic->wq_lock);
-
-		COND_RELEASE(ep->requires_lock, &ep->vc_lock);
-
-		ret = _gnix_vc_schedule(vc);
-		if (ret != FI_SUCCESS)
-			GNIX_WARN(FI_LOG_EP_DATA,
-				  "_gnix_vc_schedule returned %s\n",
-				  fi_strerror(-ret));
-
-		ret = _gnix_cm_nic_progress(cm_nic);
-		if (ret != FI_SUCCESS)
-			GNIX_WARN(FI_LOG_EP_CTRL,
-				"_gnix_cm_nic_progress returned %s\n",
-				fi_strerror(-ret));
-
 	} else {
 
 		/*
@@ -1035,23 +1005,18 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 		GNIX_DEBUG(FI_LOG_EP_CTRL, "moving vc %p state to connected\n",
 			vc);
 
-		COND_RELEASE(ep->requires_lock, &ep->vc_lock);
-
-		ret = _gnix_vc_schedule(vc);
+		ret = _gnix_vc_sched_new_conn(vc);
 		if (ret != FI_SUCCESS)
 			GNIX_WARN(FI_LOG_EP_DATA,
-				  "_gnix_vc_schedule returned %s\n",
+				  "_gnix_vc_sched_new_conn returned %s\n",
 				  fi_strerror(-ret));
-
-		ret = _gnix_cm_nic_progress(cm_nic);
-		if (ret != FI_SUCCESS)
-			GNIX_WARN(FI_LOG_EP_CTRL,
-				"_gnix_cm_nic_progress returned %s\n",
-				fi_strerror(-ret));
 	}
 
 	vc->peer_caps = peer_caps;
+
 err:
+	COND_RELEASE(ep->requires_lock, &ep->vc_lock);
+
 	return ret;
 }
 
@@ -1238,18 +1203,14 @@ static int __gnix_vc_conn_ack_prog_fn(void *data, int *complete_ptr)
 		GNIX_DEBUG(FI_LOG_EP_CTRL,
 			   "moving vc %p to connected\n",vc);
 		vc->modes |= GNIX_VC_MODE_DG_POSTED;
-		ret = _gnix_vc_schedule(vc);
+
+		ret = _gnix_vc_sched_new_conn(vc);
 		if (ret != FI_SUCCESS)
 			GNIX_WARN(FI_LOG_EP_DATA,
-				  "_gnix_vc_schedule returned %s\n",
+				  "_gnix_vc_sched_new_conn returned %s\n",
 				  fi_strerror(-ret));
 
 	} else if (ret == -FI_EAGAIN) {
-		ret = _gnix_vc_schedule(vc);
-		if (ret != FI_SUCCESS)
-			GNIX_WARN(FI_LOG_EP_DATA,
-				  "_gnix_vc_schedule returned %s\n",
-				  fi_strerror(-ret));
 		ret = FI_SUCCESS;
 	} else {
 		GNIX_FATAL(FI_LOG_EP_CTRL, "_gnix_cm_nic_send returned %s\n",
@@ -1377,11 +1338,6 @@ static int __gnix_vc_conn_req_prog_fn(void *data, int *complete_ptr)
 		GNIX_FATAL(FI_LOG_EP_CTRL, "_gnix_cm_nic_send returned %s\n",
 			   fi_strerror(-ret));
 	}
-	ret = _gnix_vc_schedule(vc);
-	if (ret != FI_SUCCESS)
-		GNIX_WARN(FI_LOG_EP_DATA,
-			  "_gnix_vc_schedule returned %s\n",
-			  fi_strerror(-ret));
 
 err:
 	COND_RELEASE(ep->requires_lock, &ep->vc_lock);
@@ -1457,13 +1413,10 @@ int _gnix_vc_alloc(struct gnix_fid_ep *ep_priv,
 	}
 	vc_ptr->ep = ep_priv;
 
+	dlist_init(&vc_ptr->prog_list);
 	dlist_init(&vc_ptr->work_queue);
-	fastlock_init(&vc_ptr->work_queue_lock);
 	dlist_init(&vc_ptr->tx_queue);
-	fastlock_init(&vc_ptr->tx_queue_lock);
-	dlist_init(&vc_ptr->rx_list);
-	dlist_init(&vc_ptr->work_list);
-	dlist_init(&vc_ptr->tx_list);
+
 	vc_ptr->peer_fi_addr = FI_ADDR_NOTAVAIL;
 
 	dlist_init(&vc_ptr->list);
@@ -1496,20 +1449,10 @@ static void __gnix_vc_cancel(struct gnix_vc *vc)
 {
 	struct gnix_nic *nic = vc->ep->nic;
 
-	COND_ACQUIRE(nic->requires_lock, &nic->rx_vc_lock);
-	if (!dlist_empty(&vc->rx_list))
-		dlist_remove(&vc->rx_list);
-	COND_RELEASE(nic->requires_lock, &nic->rx_vc_lock);
-
-	COND_ACQUIRE(nic->requires_lock, &nic->work_vc_lock);
-	if (!dlist_empty(&vc->work_list))
-		dlist_remove(&vc->work_list);
-	COND_RELEASE(nic->requires_lock, &nic->work_vc_lock);
-
-	COND_ACQUIRE(nic->requires_lock, &nic->tx_vc_lock);
-	if (!dlist_empty(&vc->tx_list))
-		dlist_remove(&vc->tx_list);
-	COND_RELEASE(nic->requires_lock, &nic->tx_vc_lock);
+	COND_ACQUIRE(nic->requires_lock, &nic->prog_vcs_lock);
+	if (!dlist_empty(&vc->prog_list))
+		dlist_remove_init(&vc->prog_list);
+	COND_RELEASE(nic->requires_lock, &nic->prog_vcs_lock);
 }
 
 /* Destroy an unconnected VC.  More Support is needed to shutdown and destroy
@@ -1604,8 +1547,6 @@ int _gnix_vc_destroy(struct gnix_vc *vc)
 		GNIX_FATAL(FI_LOG_EP_CTRL,
 			   "VC outstanding_tx_reqs out of sync: %d\n",
 			   atomic_get(&vc->outstanding_tx_reqs));
-
-	fastlock_destroy(&vc->tx_queue_lock);
 
 	if (vc->smsg_mbox != NULL) {
 		ret = _gnix_mbox_free(vc->smsg_mbox);
@@ -1708,26 +1649,7 @@ int _gnix_vc_connect(struct gnix_vc *vc)
 	dlist_insert_before(&work_req->list, &cm_nic->cm_nic_wq);
 	fastlock_release(&cm_nic->wq_lock);
 
-	ret = _gnix_vc_schedule(vc);
-	if (ret != FI_SUCCESS)
-		GNIX_WARN(FI_LOG_EP_DATA,
-			  "_gnix_vc_schedule returned %s\n",
-			  fi_strerror(-ret));
-
 	return ret;
-}
-
-/*
- * TODO: this is very simple right now and will need more
- * work to propertly disconnect
- */
-
-int _gnix_vc_disconnect(struct gnix_vc *vc)
-{
-	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
-
-	vc->conn_state = GNIX_VC_CONN_TERMINATED;
-	return FI_SUCCESS;
 }
 
 /******************************************************************************
@@ -1736,22 +1658,9 @@ int _gnix_vc_disconnect(struct gnix_vc *vc)
  *
  *****************************************************************************/
 
-/* Schedule the VC for RX progress. */
-int _gnix_vc_rx_schedule(struct gnix_vc *vc)
-{
-	struct gnix_nic *nic = vc->ep->nic;
-
-	if (!_gnix_test_and_set_bit(&vc->flags, GNIX_VC_FLAG_RX_SCHEDULED)) {
-		COND_ACQUIRE(nic->requires_lock, &nic->rx_vc_lock);
-		dlist_insert_tail(&vc->rx_list, &nic->rx_vcs);
-		COND_RELEASE(nic->requires_lock, &nic->rx_vc_lock);
-		GNIX_INFO(FI_LOG_EP_CTRL, "Scheduled RX VC (%p)\n", vc);
-	}
-
-	return FI_SUCCESS;
-}
-
-/* Process a VC's SMSG mailbox. */
+/* Process a VC's SMSG mailbox.
+ *
+ * Note: EP must be locked. */
 int _gnix_vc_dequeue_smsg(struct gnix_vc *vc)
 {
 	int ret = FI_SUCCESS;
@@ -1761,12 +1670,6 @@ int _gnix_vc_dequeue_smsg(struct gnix_vc *vc)
 	uint8_t tag;
 
 	GNIX_TRACE(FI_LOG_EP_DATA, "\n");
-
-	assert(vc->gni_ep != NULL);
-	if (vc->conn_state != GNIX_VC_CONNECTED)
-		GNIX_WARN(FI_LOG_EP_CTRL, "something amiss with vc %p\n",
-			  vc);
-	assert(vc->conn_state == GNIX_VC_CONNECTED);
 
 	nic = vc->ep->nic;
 	assert(nic != NULL);
@@ -1800,18 +1703,12 @@ int _gnix_vc_dequeue_smsg(struct gnix_vc *vc)
 	return ret;
 }
 
-/* Progress VC RXs.  Reschedule VC if more there is more work. */
+/* Progress VC RXs.  Reschedule VC if more there is more work.
+ *
+ * Note: EP must be locked. */
 static int __gnix_vc_rx_progress(struct gnix_vc *vc)
 {
 	int ret;
-
-	ret = __gnix_vc_connected(vc);
-	if (ret) {
-		/* The CM will schedule the VC when the connection is
-		 * complete. */
-		_gnix_vc_rx_schedule(vc);
-		return -FI_EAGAIN;
-	}
 
 	/* Process pending RXs */
 	COND_ACQUIRE(vc->ep->nic->requires_lock, &vc->ep->nic->lock);
@@ -1830,123 +1727,64 @@ static int __gnix_vc_rx_progress(struct gnix_vc *vc)
 	return FI_SUCCESS;
 }
 
-static struct gnix_vc *__gnix_nic_next_pending_rx_vc(struct gnix_nic *nic)
-{
-	struct gnix_vc *vc = NULL;
-
-	COND_ACQUIRE(nic->requires_lock, &nic->rx_vc_lock);
-	vc = dlist_first_entry(&nic->rx_vcs, struct gnix_vc, rx_list);
-	if (vc)
-		dlist_remove_init(&vc->rx_list);
-	COND_RELEASE(nic->requires_lock, &nic->rx_vc_lock);
-
-	if (vc) {
-		GNIX_INFO(FI_LOG_EP_CTRL, "Dequeued RX VC (%p)\n", vc);
-		_gnix_clear_bit(&vc->flags, GNIX_VC_FLAG_RX_SCHEDULED);
-	}
-
-	return vc;
-}
-
-/* Progress VC RXs.  Exit when all VCs are empty or if an error is encountered
- * during progress.  Failure to process an RX on any VC likely indicates an
- * inability to progress other VCs (due to low memory). */
-static int __gnix_vc_nic_rx_progress(struct gnix_nic *nic)
-{
-	struct gnix_vc *vc;
-
-	while ((vc = __gnix_nic_next_pending_rx_vc(nic))) {
-		if (__gnix_vc_rx_progress(vc) != FI_SUCCESS) {
-			break;
-		}
-	}
-
-	return FI_SUCCESS;
-}
-
-
 /******************************************************************************
  *
  * VC work progress
  *
  *****************************************************************************/
 
-/* Schedule the VC for work progress. */
-static int __gnix_vc_work_schedule(struct gnix_vc *vc)
-{
-	struct gnix_nic *nic = vc->ep->nic;
-
-	/* Don't bother scheduling if there's no work to do. */
-	if (dlist_empty(&vc->work_queue))
-		return FI_SUCCESS;
-
-	if (!_gnix_test_and_set_bit(&vc->flags, GNIX_VC_FLAG_WORK_SCHEDULED)) {
-		COND_ACQUIRE(nic->requires_lock, &nic->work_vc_lock);
-		dlist_insert_tail(&vc->work_list, &nic->work_vcs);
-		COND_RELEASE(nic->requires_lock, &nic->work_vc_lock);
-		GNIX_INFO(FI_LOG_EP_CTRL, "Scheduled work VC (%p)\n", vc);
-	}
-
-	return FI_SUCCESS;
-}
-
-/* Schedule deferred request processing.  Usually used in RX completers. */
+/* Schedule deferred request processing.  Usually used in RX completers.
+ *
+ * Note: EP must be locked. */
 int _gnix_vc_queue_work_req(struct gnix_fab_req *req)
 {
 	struct gnix_vc *vc = req->vc;
 
-	COND_ACQUIRE(vc->ep->requires_lock, &vc->work_queue_lock);
 	dlist_insert_tail(&req->dlist, &vc->work_queue);
 	__gnix_vc_work_schedule(vc);
-	COND_RELEASE(vc->ep->requires_lock, &vc->work_queue_lock);
 
 	return FI_SUCCESS;
 }
 
-/* Process deferred request work on the VC. */
+/* Schedule deferred request processing.  Used in TX completers where VC lock is
+ * no yet held. */
+int _gnix_vc_requeue_work_req(struct gnix_fab_req *req)
+{
+	int ret;
+
+	COND_ACQUIRE(req->gnix_ep->requires_lock, &req->gnix_ep->vc_lock);
+	ret = _gnix_vc_queue_work_req(req);
+	COND_RELEASE(req->gnix_ep->requires_lock, &req->gnix_ep->vc_lock);
+
+	return ret;
+}
+
+/* Process deferred request work on the VC.
+ *
+ * Note: EP must be locked. */
 static int __gnix_vc_push_work_reqs(struct gnix_vc *vc)
 {
 	int ret, fi_rc = FI_SUCCESS;
 	struct gnix_fab_req *req;
 
-	while (fi_rc == FI_SUCCESS) {
-		COND_ACQUIRE(vc->ep->requires_lock, &vc->work_queue_lock);
+	while (1) {
 		req = dlist_first_entry(&vc->work_queue,
 					struct gnix_fab_req,
 					dlist);
-		if (req)
-			dlist_remove_init(&req->dlist);
-		COND_RELEASE(vc->ep->requires_lock, &vc->work_queue_lock);
+		if (!req)
+			break;
 
-		if (req) {
-			ret = req->work_fn(req);
-			if (ret == FI_SUCCESS) {
-				GNIX_INFO(FI_LOG_EP_DATA,
-					  "Request processed: %p\n", req);
-				continue;
-			}
+		dlist_remove_init(&req->dlist);
 
-			/* Work failed.  Reschedule to put this VC
-			 * back on the end of the list and return
-			 * -FI_EAGAIN */
-
-			COND_ACQUIRE(vc->ep->requires_lock,
-					&vc->work_queue_lock);
-			dlist_insert_tail(&req->dlist, &vc->work_queue);
-			COND_RELEASE(vc->ep->requires_lock,
-					&vc->work_queue_lock);
-
-			/* __gnix_vc_work_schedule() must come after the
-			 * request is inserted into the VC's work_queue. */
-			__gnix_vc_work_schedule(vc);
-
-			fi_rc = -FI_EAGAIN;
+		ret = req->work_fn(req);
+		if (ret != FI_SUCCESS) {
+			/* Re-schedule faield work. */
+			_gnix_vc_queue_work_req(req);
 
 			/* FI_ENOSPC is reserved to indicate a lack of
 			 * TXDs, which are shared by all VCs on the
 			 * NIC.  The other likely error is FI_EAGAIN
 			 * due to a lack of SMSG credits. */
-
 			if ((ret != -FI_ENOSPC) &&
 			    (ret != -FI_EAGAIN)) {
 				/* TODO report error? */
@@ -1954,44 +1792,16 @@ static int __gnix_vc_push_work_reqs(struct gnix_vc *vc)
 					   "Failed to push request %p: %s\n",
 					   req, fi_strerror(-ret));
 			}
+
+			fi_rc = -FI_EAGAIN;
+			break;
 		} else {
-			break; /* nothing left in the queue */
+			GNIX_INFO(FI_LOG_EP_DATA,
+				  "Request processed: %p\n", req);
 		}
 	}
 
 	return fi_rc;
-}
-
-static struct gnix_vc *__gnix_nic_next_pending_work_vc(struct gnix_nic *nic)
-{
-	struct gnix_vc *vc = NULL;
-
-	COND_ACQUIRE(nic->requires_lock, &nic->work_vc_lock);
-	vc = dlist_first_entry(&nic->work_vcs, struct gnix_vc, work_list);
-	if (vc)
-		dlist_remove_init(&vc->work_list);
-	COND_RELEASE(nic->requires_lock, &nic->work_vc_lock);
-
-	if (vc) {
-		GNIX_INFO(FI_LOG_EP_CTRL, "Dequeued work VC (%p)\n", vc);
-		_gnix_clear_bit(&vc->flags, GNIX_VC_FLAG_WORK_SCHEDULED);
-	}
-
-	return vc;
-}
-
-/* Progress VCs with deferred request work. */
-static int __gnix_vc_nic_work_progress(struct gnix_nic *nic)
-{
-	struct gnix_vc *vc;
-
-	while ((vc = __gnix_nic_next_pending_work_vc(nic))) {
-		if (__gnix_vc_push_work_reqs(vc) != FI_SUCCESS) {
-			break;
-		}
-	}
-
-	return FI_SUCCESS;
 }
 
 /******************************************************************************
@@ -2000,32 +1810,15 @@ static int __gnix_vc_nic_work_progress(struct gnix_nic *nic)
  *
  *****************************************************************************/
 
-/* Schedule the VC for TX progress. */
-int _gnix_vc_tx_schedule(struct gnix_vc *vc)
-{
-	struct gnix_nic *nic = vc->ep->nic;
-
-	/* Don't bother scheduling if there's no work to do. */
-	if (dlist_empty(&vc->tx_queue))
-		return FI_SUCCESS;
-
-	if (!_gnix_test_and_set_bit(&vc->flags, GNIX_VC_FLAG_TX_SCHEDULED)) {
-		COND_ACQUIRE(nic->requires_lock, &nic->tx_vc_lock);
-		dlist_insert_tail(&vc->tx_list, &nic->tx_vcs);
-		COND_RELEASE(nic->requires_lock, &nic->tx_vc_lock);
-		GNIX_INFO(FI_LOG_EP_CTRL, "Scheduled TX VC (%p)\n", vc);
-	}
-
-	return FI_SUCCESS;
-}
-
 /* Attempt to initiate a TX request.  If the TX queue is blocked (due to low
- * resources or a FI_FENCE request), schedule the request to be sent later. */
+ * resources or a FI_FENCE request), schedule the request to be sent later.
+ *
+ * Note: EP must be locked. */
 int _gnix_vc_queue_tx_req(struct gnix_fab_req *req)
 {
 	int rc = FI_SUCCESS, queue_tx = 0;
 	struct gnix_vc *vc = req->vc;
-	int connected, injecting;
+	int connected;
 
 	if (req->flags & FI_TRIGGER) {
 		rc = _gnix_trigger_queue_req(req);
@@ -2036,10 +1829,8 @@ int _gnix_vc_queue_tx_req(struct gnix_fab_req *req)
 			return FI_SUCCESS;
 	}
 
-	connected = !__gnix_vc_connected(vc); /* 0 on success */
-	injecting = (req->flags & FI_INJECT) ? 1 : 0;
+	connected = (vc->conn_state == GNIX_VC_CONNECTED);
 
-	COND_ACQUIRE(vc->ep->requires_lock, &vc->tx_queue_lock);
 	if ((req->flags & FI_FENCE) && atomic_get(&vc->outstanding_tx_reqs)) {
 		/* Fence request must be queued until all outstanding TX
 		 * requests are completed.  Subsequent requests will be queued
@@ -2071,29 +1862,6 @@ int _gnix_vc_queue_tx_req(struct gnix_fab_req *req)
 			  req);
 	}
 
-	/*
-	 * if this is an inject request and the vc is
-	 * not connected, and the domain being used has control_progress
-	 * auto enabled,  we will block here till connection is set up.
-	 * We keep the tx_queue_lock for this vc to make sure messages
-	 * stay in correct order.
-	 */
-
-	if (unlikely(!connected)) {
-		if (injecting &&
-		    (vc->ep->domain->control_progress == FI_PROGRESS_AUTO)) {
-			while ((vc->conn_state != GNIX_VC_CONNECTED)) {
-				rc = _gnix_cm_nic_progress(vc->ep->cm_nic);
-				if (rc != FI_SUCCESS) {
-					GNIX_WARN(FI_LOG_EP_CTRL,
-						"_gnix_cm_nic_progress returned %s\n",
-						fi_strerror(-rc));
-					break;
-				}
-			}
-		}
-	}
-
 	if (unlikely(queue_tx)) {
 		/*
 		 * TODO: for auto progress do something here
@@ -2102,39 +1870,17 @@ int _gnix_vc_queue_tx_req(struct gnix_fab_req *req)
 		_gnix_vc_tx_schedule(vc);
 	}
 
-	COND_RELEASE(vc->ep->requires_lock, &vc->tx_queue_lock);
-
-	/*
-	 * if injecting and queuing, push the tx queue for this vc
-	 * once before returning
-	 */
-	if (unlikely(queue_tx) && injecting) {
-		rc = __gnix_vc_push_tx_reqs(vc);
-		if ((rc != FI_SUCCESS) && (rc != -FI_EAGAIN)) {
-			GNIX_WARN(FI_LOG_EP_CTRL,
-				"__gnix_vc_push_tx_reqs returned %s\n",
-					fi_strerror(-rc));
-		}
-	}
-
 	return FI_SUCCESS;
 }
 
-/* Push TX requests queued on the VC. */
+/* Push TX requests queued on the VC.
+ *
+ * Note: EP must be locked. */
 static int __gnix_vc_push_tx_reqs(struct gnix_vc *vc)
 {
 	int ret, fi_rc = FI_SUCCESS;
 	struct gnix_fab_req *req;
 
-	ret = __gnix_vc_connected(vc); /* 0 on success */
-	if (ret) {
-		/* The CM will schedule the VC when the connection is
-		 * complete.*/
-		_gnix_vc_tx_schedule(vc);
-		return -FI_EAGAIN;
-	}
-
-	COND_ACQUIRE(vc->ep->requires_lock, &vc->tx_queue_lock);
 	req = dlist_first_entry(&vc->tx_queue, struct gnix_fab_req, dlist);
 	while (req) {
 		if ((req->flags & FI_FENCE) &&
@@ -2194,74 +1940,111 @@ static int __gnix_vc_push_tx_reqs(struct gnix_vc *vc)
 		/* Return success if the queue is emptied. */
 	}
 
-	COND_RELEASE(vc->ep->requires_lock, &vc->tx_queue_lock);
-
 	return fi_rc;
 }
 
-static struct gnix_vc *__gnix_nic_next_pending_tx_vc(struct gnix_nic *nic)
+/* Return next VC needing progress on the NIC. */
+static struct gnix_vc *__gnix_nic_next_pending_vc(struct gnix_nic *nic)
 {
 	struct gnix_vc *vc = NULL;
 
-	COND_ACQUIRE(nic->requires_lock, &nic->tx_vc_lock);
-	vc = dlist_first_entry(&nic->tx_vcs, struct gnix_vc, tx_list);
+	COND_ACQUIRE(nic->requires_lock, &nic->prog_vcs_lock);
+	vc = dlist_first_entry(&nic->prog_vcs, struct gnix_vc, prog_list);
 	if (vc)
-		dlist_remove_init(&vc->tx_list);
-	COND_RELEASE(nic->requires_lock, &nic->tx_vc_lock);
+		dlist_remove_init(&vc->prog_list);
+	COND_RELEASE(nic->requires_lock, &nic->prog_vcs_lock);
 
 	if (vc) {
-		GNIX_INFO(FI_LOG_EP_CTRL, "Dequeued TX VC (%p)\n", vc);
-		_gnix_clear_bit(&vc->flags, GNIX_VC_FLAG_TX_SCHEDULED);
+		GNIX_INFO(FI_LOG_EP_CTRL, "Dequeued progress VC (%p)\n", vc);
+		_gnix_clear_bit(&vc->flags, GNIX_VC_FLAG_SCHEDULED);
 	}
 
 	return vc;
 }
 
-/* Progress VC TXs.  Exit when all VCs TX queues are empty or stalled. */
-static int __gnix_vc_nic_tx_progress(struct gnix_nic *nic)
+/* Progress all NIC VCs needing work. */
+int _gnix_vc_nic_progress(struct gnix_nic *nic)
 {
 	struct gnix_vc *vc;
+	int ret;
 
-	while ((vc = __gnix_nic_next_pending_tx_vc(nic))) {
-		if (__gnix_vc_push_tx_reqs(vc) != FI_SUCCESS) {
-			break;
+	while ((vc = __gnix_nic_next_pending_vc(nic))) {
+		COND_ACQUIRE(vc->ep->requires_lock, &vc->ep->vc_lock);
+
+		if (vc->conn_state != GNIX_VC_CONNECTED) {
+			COND_RELEASE(vc->ep->requires_lock, &vc->ep->vc_lock);
+			continue;
 		}
+
+		ret = __gnix_vc_rx_progress(vc);
+		if (ret != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "__gnix_vc_rx_progress failed: %d\n", ret);
+
+		ret = __gnix_vc_push_work_reqs(vc);
+		if (ret != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "__gnix_vc_push_work_reqs failed: %d\n", ret);
+
+		ret = __gnix_vc_push_tx_reqs(vc);
+		if (ret != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "__gnix_vc_push_tx_reqs failed: %d\n", ret);
+
+		COND_RELEASE(vc->ep->requires_lock, &vc->ep->vc_lock);
 	}
 
 	return FI_SUCCESS;
 }
 
-/* Progress all NIC VCs needing work. */
-int _gnix_vc_nic_progress(struct gnix_nic *nic)
-{
-	/* Process VCs with RX traffic pending */
-	__gnix_vc_nic_rx_progress(nic);
-
-	/* Process deferred request work (deferred RX processing, etc.) */
-	__gnix_vc_nic_work_progress(nic);
-
-	/* Process VCs with TX traffic pending */
-	__gnix_vc_nic_tx_progress(nic);
-
-	return FI_SUCCESS;
-}
-
-/* Schedule VC to have all work queues processed.  This should only be needed
- * for newly connected VCs.
+/* Schedule VC for progress.
  *
- * TODO This is currently used to advance CM state.
- */
+ * Note: EP must be locked.
+ * TODO: Better implementation for rx/work/tx VC scheduling. */
 int _gnix_vc_schedule(struct gnix_vc *vc)
 {
-	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+	struct gnix_nic *nic = vc->ep->nic;
 
-	_gnix_vc_rx_schedule(vc);
-	__gnix_vc_work_schedule(vc);
-	_gnix_vc_tx_schedule(vc);
+	if (!_gnix_test_and_set_bit(&vc->flags, GNIX_VC_FLAG_SCHEDULED)) {
+		COND_ACQUIRE(nic->requires_lock, &nic->prog_vcs_lock);
+		dlist_insert_tail(&vc->prog_list, &nic->prog_vcs);
+		COND_RELEASE(nic->requires_lock, &nic->prog_vcs_lock);
+		GNIX_DEBUG(FI_LOG_EP_CTRL, "Scheduled VC (%p)\n", vc);
+	}
 
 	return FI_SUCCESS;
 }
 
+/* Schedule the VC for RX progress. */
+int _gnix_vc_rx_schedule(struct gnix_vc *vc)
+{
+	return _gnix_vc_schedule(vc);
+}
+
+/* Schedule the VC for work progress. */
+static int __gnix_vc_work_schedule(struct gnix_vc *vc)
+{
+	return _gnix_vc_schedule(vc);
+}
+
+/* Schedule the VC for TX progress. */
+int _gnix_vc_tx_schedule(struct gnix_vc *vc)
+{
+	return _gnix_vc_schedule(vc);
+}
+
+/* For a newly scheduled VC.  Do any queued work now that the connection is
+ * complete.
+ *
+ * Note: EP must be locked. */
+int _gnix_vc_sched_new_conn(struct gnix_vc *vc)
+{
+	return _gnix_vc_schedule(vc);
+}
+
+/* Look up an EP's VC using fi_addr_t.
+ *
+ * Note: EP must be locked. */
 int _gnix_vc_ep_get_vc(struct gnix_fid_ep *ep, fi_addr_t dest_addr,
 		       struct gnix_vc **vc_ptr)
 {
@@ -2278,15 +2061,11 @@ int _gnix_vc_ep_get_vc(struct gnix_fid_ep *ep, fi_addr_t dest_addr,
 			return ret;
 		}
 	} else if (ep->type == FI_EP_MSG) {
-		/* TODO Allow VC to be torn down. */
-		COND_ACQUIRE(ep->requires_lock, &ep->vc_lock);
 		if (GNIX_EP_CONNECTED(ep)) {
 			*vc_ptr = ep->vc;
 		} else {
-			COND_RELEASE(ep->requires_lock, &ep->vc_lock);
 			return -FI_EINVAL;
 		}
-		COND_RELEASE(ep->requires_lock, &ep->vc_lock);
 	} else {
 		GNIX_WARN(FI_LOG_EP_DATA, "Invalid endpoint type: %d\n",
 			  ep->type);
@@ -2342,3 +2121,4 @@ int _gnix_vc_cm_init(struct gnix_cm_nic *cm_nic)
 
 	return ret;
 }
+

--- a/prov/gni/test/cancel.c
+++ b/prov/gni/test/cancel.c
@@ -271,9 +271,7 @@ Test(gnix_cancel, cancel_ep_send)
 	cr_assert(!ret);
 
 	/* make a dummy request */
-	fastlock_acquire(&vc->tx_queue_lock);
 	dlist_insert_head(&req->dlist, &vc->tx_queue);
-	fastlock_release(&vc->tx_queue_lock);
 
 	/* cancel simulated request */
 	ret = fi_cancel(&ep[0]->fid, foobar_ptr);

--- a/prov/gni/test/rdm_tagged_sr.c
+++ b/prov/gni/test/rdm_tagged_sr.c
@@ -521,6 +521,7 @@ void do_tinject(int len)
 	cr_assert_eq(sz, 0);
 
 	while ((ret = fi_cq_read(msg_cq[1], &cqe, 1)) == -FI_EAGAIN) {
+		ret = fi_cq_read(msg_cq[0], &cqe, 1);
 		pthread_yield();
 	}
 

--- a/prov/gni/test/vc.c
+++ b/prov/gni/test/vc.c
@@ -554,9 +554,6 @@ Test(vc_management_auto, vc_connect)
 		state = _gnix_vc_state(vc_conn);
 	}
 
-	ret = _gnix_vc_disconnect(vc_conn);
-	cr_assert_eq(ret, FI_SUCCESS);
-
 	/* VC is destroyed by the EP */
 }
 
@@ -624,12 +621,6 @@ Test(vc_management_auto, vc_connect2)
 		pthread_yield();
 		state = _gnix_vc_state(vc_conn1);
 	}
-
-	ret = _gnix_vc_disconnect(vc_conn0);
-	cr_assert_eq(ret, FI_SUCCESS);
-
-	ret = _gnix_vc_disconnect(vc_conn1);
-	cr_assert_eq(ret, FI_SUCCESS);
 
 	/* VC is destroyed by the EP */
 }


### PR DESCRIPTION
Refactor EP locking to acommodate VC teardown.

-Protect EP connections/request queues/posted messages with the vc_lock field
  -Remove many extra, more fine grained locks
  -Pro: Less locks taken overall in transaction code paths
  -Pro: Adds the synch needed to safely remove VCs from an EP (future work)
  -Con: Concurrent, multi-threaded use of separate VCs on an EP is now
	serialized. (Concurrent use of a single EP was not a primary use case)
-Make CQ/CNTR progress code common
-Remove CM progress checks from gnix_vc.c for simplification, lock sanity
-Add CM progress checks to CQ/CNTR progress code paths

Signed-off-by: Zach <ztiffany@cray.com>

@hppritcha @sungeunchoi 

Testing:
-No gnitest failures
-fabtest status unchanged:
```
 Total Pass                                                52
 Total Notrun                                              12
 Total Fail                                                 4
 Percentage of Pass                                        92
```
-MPI testing still needed

@hppritcha The original fix for the oMPI inject issue is gone in this commit.  I assume oMPI still relies on it and we need a solution before this gets merged.  It needs to be fixed in a different way, though.  We should talk about this.