### PR TITLE
prov/gni: Return -FI_EOPNOTSUPP from invalid atomic commands as per the man page

### DIFF
--- a/prov/gni/src/gnix_atomic.c
+++ b/prov/gni/src/gnix_atomic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -360,16 +360,16 @@ int _gnix_atomic_cmd(enum fi_datatype dt, enum fi_op op,
 	      (fr_type == GNIX_FAB_RQ_NAMO_AX_S) ||
 	      (fr_type == GNIX_FAB_RQ_NAMO_FAX_S)) &&
 	    (dt >= FI_DATATYPE_LAST || op >= FI_ATOMIC_OP_LAST)) {
-		return -FI_ENOENT;
+		return -FI_EOPNOTSUPP;
 	}
 
 	switch(fr_type) {
 	case GNIX_FAB_RQ_AMO:
-		return __gnix_amo_cmds[op][dt] ?: -FI_ENOENT;
+		return __gnix_amo_cmds[op][dt] ?: -FI_EOPNOTSUPP;
 	case GNIX_FAB_RQ_FAMO:
-		return __gnix_fetch_amo_cmds[op][dt] ?: -FI_ENOENT;
+		return __gnix_fetch_amo_cmds[op][dt] ?: -FI_EOPNOTSUPP;
 	case GNIX_FAB_RQ_CAMO:
-		return __gnix_cmp_amo_cmds[op][dt] ?: -FI_ENOENT;
+		return __gnix_cmp_amo_cmds[op][dt] ?: -FI_EOPNOTSUPP;
 	case GNIX_FAB_RQ_NAMO_AX:
 		return GNI_FMA_ATOMIC2_AX;
 	case GNIX_FAB_RQ_NAMO_AX_S:
@@ -382,7 +382,7 @@ int _gnix_atomic_cmd(enum fi_datatype dt, enum fi_op op,
 		break;
 	}
 
-	return -FI_ENOENT;
+	return -FI_EOPNOTSUPP;
 }
 
 int _gnix_amo_post_req(void *data)

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
  *                         All rights reserved.
  *
@@ -977,7 +977,7 @@ DIRECT_FN int gnix_ep_atomic_valid(struct fid_ep *ep,
 		*count = 1;
 
 	return _gnix_atomic_cmd(datatype, op, GNIX_FAB_RQ_AMO) >= 0 ?
-		0 : -FI_ENOENT;
+		0 : -FI_EOPNOTSUPP;
 }
 
 DIRECT_FN int gnix_ep_fetch_atomic_valid(struct fid_ep *ep,
@@ -988,7 +988,7 @@ DIRECT_FN int gnix_ep_fetch_atomic_valid(struct fid_ep *ep,
 		*count = 1;
 
 	return _gnix_atomic_cmd(datatype, op, GNIX_FAB_RQ_FAMO) >= 0 ?
-		0 : -FI_ENOENT;
+		0 : -FI_EOPNOTSUPP;
 }
 
 DIRECT_FN int gnix_ep_cmp_atomic_valid(struct fid_ep *ep,
@@ -999,7 +999,7 @@ DIRECT_FN int gnix_ep_cmp_atomic_valid(struct fid_ep *ep,
 		*count = 1;
 
 	return _gnix_atomic_cmd(datatype, op, GNIX_FAB_RQ_CAMO) >= 0 ?
-		0 : -FI_ENOENT;
+		0 : -FI_EOPNOTSUPP;
 }
 
 size_t
@@ -1063,7 +1063,7 @@ gnix_ep_atomic_write(struct fid_ep *ep, const void *buf, size_t count,
 	uint64_t flags;
 
 	if (gnix_ep_atomic_valid(ep, datatype, op, NULL))
-		return -FI_ENOENT;
+		return -FI_EOPNOTSUPP;
 
 	if (!ep)
 		return -FI_EINVAL;
@@ -1114,7 +1114,7 @@ gnix_ep_atomic_writemsg(struct fid_ep *ep, const struct fi_msg_atomic *msg,
 	struct gnix_fid_ep *gnix_ep;
 
 	if (gnix_ep_atomic_valid(ep, msg->datatype, msg->op, NULL))
-		return -FI_ENOENT;
+		return -FI_EOPNOTSUPP;
 
 	if (!ep)
 		return -FI_EINVAL;
@@ -1140,7 +1140,7 @@ gnix_ep_atomic_inject(struct fid_ep *ep, const void *buf, size_t count,
 	uint64_t flags;
 
 	if (gnix_ep_atomic_valid(ep, datatype, op, NULL))
-		return -FI_ENOENT;
+		return -FI_EOPNOTSUPP;
 
 	if (!ep)
 		return -FI_EINVAL;
@@ -1183,7 +1183,7 @@ gnix_ep_atomic_readwrite(struct fid_ep *ep, const void *buf, size_t count,
 	uint64_t flags;
 
 	if (gnix_ep_fetch_atomic_valid(ep, datatype, op, NULL))
-		return -FI_ENOENT;
+		return -FI_EOPNOTSUPP;
 
 	if (!ep)
 		return -FI_EINVAL;
@@ -1242,7 +1242,7 @@ gnix_ep_atomic_readwritemsg(struct fid_ep *ep, const struct fi_msg_atomic *msg,
 	struct gnix_fid_ep *gnix_ep;
 
 	if (gnix_ep_fetch_atomic_valid(ep, msg->datatype, msg->op, NULL))
-		return -FI_ENOENT;
+		return -FI_EOPNOTSUPP;
 
 	if (!ep)
 		return -FI_EINVAL;
@@ -1274,7 +1274,7 @@ gnix_ep_atomic_compwrite(struct fid_ep *ep, const void *buf, size_t count,
 	uint64_t flags;
 
 	if (gnix_ep_cmp_atomic_valid(ep, datatype, op, NULL))
-		return -FI_ENOENT;
+		return -FI_EOPNOTSUPP;
 
 	if (!ep)
 		return -FI_EINVAL;
@@ -1350,7 +1350,7 @@ DIRECT_FN STATIC ssize_t gnix_ep_atomic_compwritemsg(struct fid_ep *ep,
 	struct gnix_fid_ep *gnix_ep;
 
 	if (gnix_ep_cmp_atomic_valid(ep, msg->datatype, msg->op, NULL))
-		return -FI_ENOENT;
+		return -FI_EOPNOTSUPP;
 
 	if (!ep)
 		return -FI_EINVAL;

--- a/prov/gni/src/gnix_sep.c
+++ b/prov/gni/src/gnix_sep.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -1249,7 +1249,7 @@ gnix_sep_atomic_write(struct fid_ep *ep, const void *buf, size_t count,
 		return -FI_EINVAL;
 
 	if (_gnix_atomic_cmd(datatype, op, GNIX_FAB_RQ_AMO) < 0)
-		return -FI_ENOENT;
+		return -FI_EOPNOTSUPP;
 
 	trx_ep = container_of(ep, struct gnix_fid_trx, ep_fid);
 	assert(GNIX_EP_RDM_DGM_MSG(trx_ep->ep->type));
@@ -1299,7 +1299,7 @@ gnix_sep_atomic_writemsg(struct fid_ep *ep, const struct fi_msg_atomic *msg,
 		return -FI_EINVAL;
 
 	if (_gnix_atomic_cmd(msg->datatype, msg->op, GNIX_FAB_RQ_AMO) < 0)
-		return -FI_ENOENT;
+		return -FI_EOPNOTSUPP;
 
 	trx_ep = container_of(ep, struct gnix_fid_trx, ep_fid);
 	assert(GNIX_EP_RDM_DGM_MSG(trx_ep->ep->type));
@@ -1325,7 +1325,7 @@ gnix_sep_atomic_inject(struct fid_ep *ep, const void *buf, size_t count,
 		return -FI_EINVAL;
 
 	if (_gnix_atomic_cmd(datatype, op, GNIX_FAB_RQ_AMO) < 0)
-		return -FI_ENOENT;
+		return -FI_EOPNOTSUPP;
 
 	trx_ep = container_of(ep, struct gnix_fid_trx, ep_fid);
 	assert(GNIX_EP_RDM_DGM_MSG(trx_ep->ep->type));
@@ -1365,7 +1365,7 @@ gnix_sep_atomic_readwrite(struct fid_ep *ep, const void *buf, size_t count,
 	uint64_t flags;
 
 	if (_gnix_atomic_cmd(datatype, op, GNIX_FAB_RQ_FAMO) < 0)
-		return -FI_ENOENT;
+		return -FI_EOPNOTSUPP;
 
 	if (!ep)
 		return -FI_EINVAL;
@@ -1427,7 +1427,7 @@ gnix_sep_atomic_readwritemsg(struct fid_ep *ep, const struct fi_msg_atomic *msg,
 		return -FI_EINVAL;
 
 	if (_gnix_atomic_cmd(msg->datatype, msg->op, GNIX_FAB_RQ_FAMO) < 0)
-		return -FI_ENOENT;
+		return -FI_EOPNOTSUPP;
 
 	trx_ep = container_of(ep, struct gnix_fid_trx, ep_fid);
 	assert(GNIX_EP_RDM_DGM_MSG(trx_ep->ep->type));
@@ -1458,7 +1458,7 @@ gnix_sep_atomic_compwrite(struct fid_ep *ep, const void *buf, size_t count,
 		return -FI_EINVAL;
 
 	if (_gnix_atomic_cmd(datatype, op, GNIX_FAB_RQ_CAMO) < 0)
-		return -FI_ENOENT;
+		return -FI_EOPNOTSUPP;
 
 	trx_ep = container_of(ep, struct gnix_fid_trx, ep_fid);
 	assert(GNIX_EP_RDM_DGM_MSG(trx_ep->ep->type));
@@ -1526,7 +1526,7 @@ gnix_sep_atomic_compwritemsg(struct fid_ep *ep, const struct fi_msg_atomic *msg,
 		return -FI_EINVAL;
 
 	if (_gnix_atomic_cmd(msg->datatype, msg->op, GNIX_FAB_RQ_CAMO) < 0)
-		return -FI_ENOENT;
+		return -FI_EOPNOTSUPP;
 
 	trx_ep = container_of(ep, struct gnix_fid_trx, ep_fid);
 	assert(GNIX_EP_RDM_DGM_MSG(trx_ep->ep->type));

--- a/prov/gni/test/rdm_atomic.c
+++ b/prov/gni/test/rdm_atomic.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -430,10 +430,10 @@ void do_invalid_atomic(enum fi_datatype dt, enum fi_op op)
 			       loc_mr[0], gni_addr[1], (uint64_t)target,
 			       mr_key[1], dt, op, target);
 
-		cr_assert(sz == -FI_ENOENT);
+		cr_assert(sz == -FI_EOPNOTSUPP);
 
 		sz = fi_atomicvalid(ep[0], dt, op, &count);
-		cr_assert(sz == -FI_ENOENT, "fi_atomicvalid() succeeded\n");
+		cr_assert(sz == -FI_EOPNOTSUPP, "fi_atomicvalid() succeeded\n");
 	} else {
 		sz = fi_atomicvalid(ep[0], dt, op, &count);
 		cr_assert(!sz, "fi_atomicvalid() failed\n");
@@ -2042,10 +2042,10 @@ void do_invalid_fetch_atomic(enum fi_datatype dt, enum fi_op op)
 				     source, loc_mr[0],
 				     gni_addr[1], (uint64_t)target, mr_key[1],
 				     dt, op, target);
-		cr_assert(sz == -FI_ENOENT);
+		cr_assert(sz == -FI_EOPNOTSUPP);
 
 		sz = fi_fetch_atomicvalid(ep[0], dt, op, &count);
-		cr_assert(sz == -FI_ENOENT, "fi_atomicvalid() succeeded\n");
+		cr_assert(sz == -FI_EOPNOTSUPP, "fi_atomicvalid() succeeded\n");
 	} else {
 		sz = fi_fetch_atomicvalid(ep[0], dt, op, &count);
 		cr_assert(!sz, "fi_atomicvalid() failed\n");
@@ -3735,10 +3735,10 @@ void do_invalid_compare_atomic(enum fi_datatype dt, enum fi_op op)
 				       source, loc_mr,
 				       gni_addr[1], (uint64_t)target, mr_key[1],
 				       dt, op, target);
-		cr_assert(sz == -FI_ENOENT);
+		cr_assert(sz == -FI_EOPNOTSUPP);
 
 		sz = fi_compare_atomicvalid(ep[0], dt, op, &count);
-		cr_assert(sz == -FI_ENOENT, "fi_atomicvalid() succeeded\n");
+		cr_assert(sz == -FI_EOPNOTSUPP, "fi_atomicvalid() succeeded\n");
 	} else {
 		sz = fi_compare_atomicvalid(ep[0], dt, op, &count);
 		cr_assert(!sz, "fi_atomicvalid() failed\n");

--- a/prov/gni/test/sep.c
+++ b/prov/gni/test/sep.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -1893,10 +1893,10 @@ void sep_invalid_compare_atomic(enum fi_datatype dt, enum fi_op op)
 				       &op2, NULL, source, loc_mr,
 				       rx_addr[0], (uint64_t)target, mr_key[1],
 				       dt, op, target);
-		cr_assert(sz == -FI_ENOENT);
+		cr_assert(sz == -FI_EOPNOTSUPP);
 
 		sz = fi_compare_atomicvalid(tx_ep[0][0], dt, op, &count);
-		cr_assert(sz == -FI_ENOENT, "fi_atomicvalid() succeeded\n");
+		cr_assert(sz == -FI_EOPNOTSUPP, "fi_atomicvalid() succeeded\n");
 	} else {
 		sz = fi_compare_atomicvalid(tx_ep[0][0], dt, op, &count);
 		cr_assert(!sz, "fi_atomicvalid() failed\n");
@@ -1915,10 +1915,10 @@ void sep_invalid_fetch_atomic(enum fi_datatype dt, enum fi_op op)
 				     source, loc_mr[0],
 				     rx_addr[0], (uint64_t)target, mr_key[1],
 				     dt, op, target);
-		cr_assert(sz == -FI_ENOENT);
+		cr_assert(sz == -FI_EOPNOTSUPP);
 
 		sz = fi_fetch_atomicvalid(tx_ep[0][0], dt, op, &count);
-		cr_assert(sz == -FI_ENOENT, "fi_atomicvalid() succeeded\n");
+		cr_assert(sz == -FI_EOPNOTSUPP, "fi_atomicvalid() succeeded\n");
 	} else {
 		sz = fi_fetch_atomicvalid(tx_ep[0][0], dt, op, &count);
 		cr_assert(!sz, "fi_atomicvalid() failed\n");


### PR DESCRIPTION
Fixes #1048 

@chuckfossen 

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>