### PR TITLE
prov/gni: Use attr parameter passed to fi_t/rx_context

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Cray Inc.  All rights reserved.
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2015-2016 Cisco Systems, Inc.  All rights reserved.
@@ -600,7 +600,6 @@ struct gnix_fid_sep {
 	enum fi_ep_type type;
 	struct fid_domain *domain;
 	struct fi_info *info;
-	uint64_t op_flags;
 	uint64_t caps;
 	uint32_t cdm_id_base;
 	struct fid_ep **ep_table;


### PR DESCRIPTION
In fi_rx_context and fi_tx_context calls:
  Use op_flags passed in the attr parameter
  Return tx_attr/rx_attr in attr parameter
In scalable endpoint operations, use the tx_ep/rx_ep op_flags
Remove unused scalable endpoint op_flags

fixes ofi-cray/libfabric-cray#1133
Signed-off-by: Chuck Fossen <chuckf@cray.com>