### PR TITLE
prov/gni: If refill size is zero don't grow the list.

### DIFF
--- a/prov/gni/include/gnix_freelist.h
+++ b/prov/gni/include/gnix_freelist.h
@@ -77,7 +77,7 @@ struct gnix_freelist {
  * @param max_refill_size   Max refill size
  * @param fl                gnix_freelist
  * @return                  FI_SUCCESS on success, -FI_ENOMEM on failure
- * @note - If the refill_size is zero the freelist is not be growable.
+ * @note - If the refill_size is zero, then the freelist is not growable.
  */
 int _gnix_fl_init(int elem_size, int offset, int init_size,
 		   int refill_size, int growth_factor,
@@ -93,7 +93,7 @@ int _gnix_fl_init(int elem_size, int offset, int init_size,
  * @param max_refill_size   Max refill size
  * @param fl                gnix_freelist
  * @return                  FI_SUCCESS on success, -FI_ENOMEM on failure
- * @note - If the refill_size is zero the freelist is not be growable.
+ * @note - If the refill_size is zero, then the freelist is not growable.
  */
 int _gnix_fl_init_ts(int elem_size, int offset, int init_size,
 		      int refill_size, int growth_factor,
@@ -111,7 +111,8 @@ extern int __gnix_fl_refill(struct gnix_freelist *fl, int n);
  *
  * @param e     item
  * @param fl    gnix_freelist
- * @return      FI_SUCCESS on success, -FI_ENOMEM or -FI_EAGAIN on failure
+ * @return      FI_SUCCESS on success, -FI_ENOMEM or -FI_EAGAIN on failure,
+ *              or -FI_ECANCELED if the refill size is zero.
  */
 __attribute__((unused))
 static inline int _gnix_fl_alloc(struct dlist_entry **e, struct gnix_freelist *fl)
@@ -123,8 +124,14 @@ static inline int _gnix_fl_alloc(struct dlist_entry **e, struct gnix_freelist *f
 
     if (fl->ts)
         fastlock_acquire(&fl->lock);
-    
-    if (dlist_empty(&fl->freelist) && fl->refill_size) {
+
+    if (dlist_empty(&fl->freelist)) {
+
+        if (fl->refill_size == 0) {
+            ret = -FI_ECANCELED;
+            goto err;
+        }
+
         ret = __gnix_fl_refill(fl, fl->refill_size);
         if (ret != FI_SUCCESS)
             goto err;

--- a/prov/gni/include/gnix_freelist.h
+++ b/prov/gni/include/gnix_freelist.h
@@ -77,6 +77,7 @@ struct gnix_freelist {
  * @param max_refill_size   Max refill size
  * @param fl                gnix_freelist
  * @return                  FI_SUCCESS on success, -FI_ENOMEM on failure
+ * @note - If the refill_size is zero the freelist is not be growable.
  */
 int _gnix_fl_init(int elem_size, int offset, int init_size,
 		   int refill_size, int growth_factor,
@@ -92,6 +93,7 @@ int _gnix_fl_init(int elem_size, int offset, int init_size,
  * @param max_refill_size   Max refill size
  * @param fl                gnix_freelist
  * @return                  FI_SUCCESS on success, -FI_ENOMEM on failure
+ * @note - If the refill_size is zero the freelist is not be growable.
  */
 int _gnix_fl_init_ts(int elem_size, int offset, int init_size,
 		      int refill_size, int growth_factor,
@@ -121,8 +123,8 @@ static inline int _gnix_fl_alloc(struct dlist_entry **e, struct gnix_freelist *f
 
     if (fl->ts)
         fastlock_acquire(&fl->lock);
-
-    if (dlist_empty(&fl->freelist)) {
+    
+    if (dlist_empty(&fl->freelist) && fl->refill_size) {
         ret = __gnix_fl_refill(fl, fl->refill_size);
         if (ret != FI_SUCCESS)
             goto err;

--- a/prov/gni/test/freelist.c
+++ b/prov/gni/test/freelist.c
@@ -124,6 +124,38 @@ Test(gnix_freelist, freelist_refill_test)
 	_gnix_fl_destroy(&fl);
 }
 
+Test(gnix_freelist, freelist_zero_refill_test)
+{
+	struct gnix_freelist fl;
+	int i, ret;
+	const int num_elems = 71;
+	struct dlist_entry *elems[num_elems + 1];
+	const int refill_size = 0;
+
+	/* non-optimized code may not zero structures */
+	memset(&fl, 0x0, sizeof(struct gnix_freelist));
+
+	ret = _gnix_fl_init(sizeof(struct dlist_entry), 0,
+						num_elems, refill_size, 0, 0, &fl);
+	cr_assert_eq(ret, FI_SUCCESS, "Failed to initialize freelist");
+
+	for (i = 0; i < num_elems; i++) {
+		ret = _gnix_fl_alloc(&elems[i], &fl);
+		cr_assert_eq(ret, FI_SUCCESS, "Failed to obtain dlist_entry");
+	}
+
+	cr_assert(_gnix_fl_empty(&fl), "Freelist not empty");
+
+	ret = _gnix_fl_alloc(&elems[num_elems], &fl);
+	cr_assert_eq(ret, -FI_ECANCELED, "Unexpected return code from "
+                 "_gnix_fl_alloc");
+
+	for (i = num_elems-1; i >= 0 ; i--)
+		_gnix_fl_free(elems[i], &fl);
+
+	_gnix_fl_destroy(&fl);
+}
+
 struct list_ts {
 	char dummy[7];
 	struct dlist_entry e;
@@ -149,7 +181,7 @@ Test(gnix_freelist, freelist_random_alloc_free)
 
 	ret = _gnix_fl_init(sizeof(struct list_ts),
 			     offsetof(struct list_ts, e),
-			     0, 0, 0, 0, &fl);
+			     0, 1, 0, 0, &fl);
 	cr_assert_eq(ret, FI_SUCCESS, "Failed to initialize freelist");
 
 	for (i = 0; i < n; i++) {


### PR DESCRIPTION
- `_gnix_fl_alloc` will no longer grow the freelist if the list is initialized with a `refill_size` of zero.

@sungeunchoi 