### PR TITLE
prov/gni: initialize API-1.1 domain attributes

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -172,6 +172,8 @@
  * See capabilities section in fi_getinfo.3.
  */
 
+#define GNIX_DOM_CAPS (FI_REMOTE_COMM)
+
 /* Primary capabilities.  Each must be explicitly requested (unless the full
  * set is requested by setting input hints->caps to NULL). */
 #define GNIX_EP_PRIMARY_CAPS                                               \

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2014 Intel Corporation, Inc.  All rights reserved.
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -203,9 +203,12 @@ static struct fi_info *_gnix_allocinfo()
 	gnix_info->domain_attr->cq_data_size = sizeof(uint64_t);
 	gnix_info->domain_attr->mr_mode = FI_MR_BASIC;
 	gnix_info->domain_attr->resource_mgmt = FI_RM_ENABLED;
-	gnix_info->domain_attr->mr_key_size = sizeof(uint64_t),
+	gnix_info->domain_attr->mr_key_size = sizeof(uint64_t);
 	gnix_info->domain_attr->max_ep_tx_ctx = GNIX_SEP_MAX_CNT;
 	gnix_info->domain_attr->max_ep_rx_ctx = GNIX_SEP_MAX_CNT;
+	gnix_info->domain_attr->mr_iov_limit = 1;
+	gnix_info->domain_attr->caps = GNIX_DOM_CAPS;
+	gnix_info->domain_attr->mode = 0;
 
 	gnix_info->next = NULL;
 	gnix_info->addr_format = FI_ADDR_GNI;
@@ -475,6 +478,17 @@ static int _gnix_ep_getinfo(enum fi_ep_type ep_type, uint32_t version,
 				break;
 			default:
 				break;
+			}
+
+			if (hints->domain_attr->caps) {
+				if (hints->domain_attr->caps & ~GNIX_DOM_CAPS) {
+					GNIX_WARN(FI_LOG_FABRIC,
+						  "Invalid domain caps\n");
+					goto err;
+				}
+
+				gnix_info->domain_attr->caps =
+					hints->domain_attr->caps;
 			}
 
 			ret = fi_check_domain_attr(&gnix_prov,

--- a/prov/gni/test/api.c
+++ b/prov/gni/test/api.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -427,6 +427,29 @@ void api_send_recv(int len)
 		cr_assert(sz < 0, "fi_recv should fail caps:0x%lx err:%ld",
 			  caps, sz);
 	}
+}
+
+Test(api, dom_caps)
+{
+	int ret;
+
+	hints[0] = fi_allocinfo();
+	cr_assert(hints[0], "fi_allocinfo");
+
+	hints[0]->mode = ~0;
+	hints[0]->fabric_attr->prov_name = strdup("gni");
+
+	/* we only support REMOTE_COMM */
+	hints[0]->domain_attr->caps = FI_LOCAL_COMM;
+	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints[0], &fi[0]);
+	cr_assert_eq(ret, -FI_ENODATA, "fi_getinfo");
+
+	hints[0]->domain_attr->caps = FI_REMOTE_COMM;
+	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints[0], &fi[0]);
+	cr_assert_eq(ret, 0, "fi_getinfo");
+
+	fi_freeinfo(hints[0]);
+	fi_freeinfo(fi[0]);
 }
 
 Test(rdm_api, msg_no_caps)


### PR DESCRIPTION
Initialize domain attributes: mr_iov_limit, caps and mode.
Check domain attribute caps for supported capabilities.
Test caps bits

fixes ofi-cray/libfabric-cray#1151
fixes ofi-cray/libfabric-cray#1152

Signed-off-by: Chuck Fossen <chuckf@cray.com>
@sungeunchoi 