### PR TITLE
prov/gni: squash a compiler warning

### DIFF
--- a/prov/gni/test/freelist.c
+++ b/prov/gni/test/freelist.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2017 Los Alamos National Security, LLC.
+ *                    All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -174,7 +176,7 @@ Test(gnix_freelist, freelist_random_alloc_free) {
 	int i, ret, refill_size = 0;
 	const int n = 719;
 	int perm[n];
-	struct dlist_entry *de;
+	struct dlist_entry *de = NULL;
 	struct list_ts *ts[n];
 
 	while (++refill_size <= 23) {


### PR DESCRIPTION
gcc 6.2 with --enable-debug complains about uninitialized
variable

@sungeunchoi 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>