### PR TITLE
prov/gni: Report unknown source address via err cqe

### DIFF
--- a/man/fi_gni.7.md
+++ b/man/fi_gni.7.md
@@ -265,6 +265,14 @@ gni;node;service;GNIX_AV_STR_ADDR_VERSION;device_addr;cdm_id;name_type;cm_nic_cd
 
 The GNI provider sets the domain attribute *cntr_cnt* to the the CQ limit divided by 2.
 
+Completion queue events may report unknown source address information when
+using *FI_SOURCE*. The source address information will be reported in the
+err_data member of the struct fi_cq_err_entry populated by fi_cq_readerr. The
+err_data member will contain the source address information in the FI_ADDR_GNI
+address format. In order to populate the remote peer's address vector
+with this mechanism, the application must call fi_cq_readerr to get the
+source address followed by fi_av_insert on the populated err_data member.
+
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -1007,7 +1007,6 @@ struct gnix_fab_req {
 	uint8_t                      *int_tx_buf;
 	gni_mem_handle_t             int_tx_mdh;
 
-	/* TODO: change the size of this for unaligned data? */
 	struct gnix_tx_descriptor *iov_txds[GNIX_MAX_MSG_IOV_LIMIT];
 	/*
 	 * special value of UINT_MAX is used to indicate

--- a/prov/gni/include/gnix_cq.h
+++ b/prov/gni/include/gnix_cq.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
+ *                         All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -45,6 +46,7 @@
 
 #define GNIX_CQ_DEFAULT_FORMAT struct fi_cq_entry
 #define GNIX_CQ_DEFAULT_SIZE   256
+#define GNIX_CQ_MAX_ERR_DATA_SIZE 64
 
 /* forward declaration */
 struct gnix_fid_ep;
@@ -73,8 +75,8 @@ struct gnix_fid_cq {
 	struct gnix_prog_set pset;
 
 	bool requires_lock;
+	char err_data[GNIX_CQ_MAX_ERR_DATA_SIZE];
 };
-
 
 ssize_t _gnix_cq_add_event(struct gnix_fid_cq *cq, struct gnix_fid_ep *ep,
 			   void *op_context, uint64_t flags, size_t len,
@@ -84,7 +86,8 @@ ssize_t _gnix_cq_add_event(struct gnix_fid_cq *cq, struct gnix_fid_ep *ep,
 ssize_t _gnix_cq_add_error(struct gnix_fid_cq *cq, void *op_context,
 			  uint64_t flags, size_t len, void *buf,
 			  uint64_t data, uint64_t tag, size_t olen,
-			  int err, int prov_errno, void *err_data);
+			  int err, int prov_errno, void *err_data,
+			  size_t err_data_size);
 
 int _gnix_cq_poll_obj_add(struct gnix_fid_cq *cq, void *obj,
 			  int (*prog_fn)(void *data));

--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -83,7 +83,7 @@ enum gnix_vc_conn_req_type {
 #define REMOTE_MBOX_RCVD (1UL << 1)
 
 /**
- * Virual Connection (VC) struct
+ * Virtual Connection (VC) struct
  *
  * @var prog_list            NIC VC progress list
  * @var work_queue           Deferred work request queue
@@ -101,7 +101,6 @@ enum gnix_vc_conn_req_type {
  *                           associated
  * @var smsg_mbox            pointer to GNI SMSG mailbox used by this VC
  *                           to exchange SMSG messages with its peer
- * @var dgram                pointer to dgram - used in connection setup
  * @var gni_ep               GNI endpoint for this VC
  * @var outstanding_fab_reqs Count of outstanding libfabric level requests
  *                           associated with this endpoint.
@@ -129,7 +128,7 @@ struct gnix_vc {
 	struct gnix_address peer_cm_nic_addr;
 	struct gnix_fid_ep *ep;
 	void *smsg_mbox;
-	struct gnix_datagram *dgram;
+	void *gnix_ep_name;
 	gni_ep_handle_t gni_ep;
 	atomic_t outstanding_tx_reqs;
 	enum gnix_vc_conn_state conn_state;

--- a/prov/gni/src/gnix_atomic.c
+++ b/prov/gni/src/gnix_atomic.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
- * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
+ *                         All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -53,7 +54,7 @@ static int __gnix_amo_send_err(struct gnix_fid_ep *ep,
 	if (ep->send_cq) {
 		rc = _gnix_cq_add_error(ep->send_cq, req->user_context,
 					flags, 0, 0, 0, 0, 0, error,
-					GNI_RC_TRANSACTION_ERROR, NULL);
+					GNI_RC_TRANSACTION_ERROR, NULL, 0);
 		if (rc) {
 			GNIX_WARN(FI_LOG_EP_DATA,
 				  "_gnix_cq_add_error() failed: %d\n", rc);

--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -254,7 +254,6 @@ static int __gnix_cq_progress(struct gnix_fid_cq *cq)
 	return _gnix_prog_progress(&cq->pset);
 }
 
-
 /*******************************************************************************
  * Exposed helper functions
  ******************************************************************************/
@@ -310,7 +309,8 @@ ssize_t _gnix_cq_add_event(struct gnix_fid_cq *cq, struct gnix_fid_ep *ep,
 ssize_t _gnix_cq_add_error(struct gnix_fid_cq *cq, void *op_context,
 			   uint64_t flags, size_t len, void *buf,
 			   uint64_t data, uint64_t tag, size_t olen,
-			   int err, int prov_errno, void *err_data)
+			   int err, int prov_errno, void *err_data,
+			   size_t err_data_size)
 {
 	struct fi_cq_err_entry *error;
 	struct gnix_cq_entry *event;
@@ -344,6 +344,7 @@ ssize_t _gnix_cq_add_error(struct gnix_fid_cq *cq, void *op_context,
 	error->err = err;
 	error->prov_errno = prov_errno;
 	error->err_data = err_data;
+	error->err_data_size = err_data_size;
 
 	_gnix_queue_enqueue(cq->errors, &event->item);
 
@@ -521,6 +522,8 @@ DIRECT_FN STATIC ssize_t gnix_cq_readerr(struct fid_cq *cq,
 	struct gnix_fid_cq *cq_priv;
 	struct gnix_cq_entry *event;
 	struct slist_entry *entry;
+	size_t err_data_cpylen;
+	struct fi_cq_err_entry *gnix_cq_err;
 
 	ssize_t read_count = 0;
 
@@ -538,8 +541,40 @@ DIRECT_FN STATIC ssize_t gnix_cq_readerr(struct fid_cq *cq,
 	}
 
 	event = container_of(entry, struct gnix_cq_entry, item);
+	gnix_cq_err = event->the_entry;
 
-	memcpy(buf, event->the_entry, sizeof(struct fi_cq_err_entry));
+	buf->op_context = gnix_cq_err->op_context;
+	buf->flags = gnix_cq_err->flags;
+	buf->len = gnix_cq_err->len;
+	buf->buf = gnix_cq_err->buf;
+	buf->data = gnix_cq_err->data;
+	buf->tag = gnix_cq_err->tag;
+	buf->olen = gnix_cq_err->olen;
+	buf->err = gnix_cq_err->err;
+	buf->prov_errno = gnix_cq_err->prov_errno;
+
+	if (gnix_cq_err->err_data != NULL) {
+		/*
+		 * TODO: check for api version once we figure out how to.
+		 * Note: If the api version is >= 1.5 then copy err_data into
+		 * buf->err_data and copy at most buf->err_data_size.
+		 * If buf->err_data_size is zero or the api version is < 1.5,
+		 * use the method implemented below.
+		 */
+
+		err_data_cpylen = sizeof(*cq_priv->err_data);
+
+		memcpy(cq_priv->err_data, gnix_cq_err->err_data,
+		       err_data_cpylen);
+
+		buf->err_data = cq_priv->err_data;
+		free(gnix_cq_err->err_data);
+		gnix_cq_err->err_data = NULL;
+		buf->err_data_size = err_data_cpylen;
+	} else {
+		buf->err_data = NULL;
+		buf->err_data_size = 0;
+	}
 
 	_gnix_queue_enqueue_free(cq_priv->errors, &event->item);
 
@@ -596,14 +631,13 @@ DIRECT_FN int gnix_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 
 	cq_ops = calloc(1, sizeof(*cq_ops));
 	if (!cq_ops) {
-		ret = -FI_ENOMEM;
-		goto err;
+		return -FI_ENOMEM;
 	}
 
 	fi_cq_ops = calloc(1, sizeof(*fi_cq_ops));
 	if (!fi_cq_ops) {
 		ret = -FI_ENOMEM;
-		goto err1;
+		goto free_cq_ops;
 	}
 
 	*cq_ops = gnix_cq_ops;
@@ -611,18 +645,18 @@ DIRECT_FN int gnix_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 
 	ret = verify_cq_attr(attr, cq_ops, fi_cq_ops);
 	if (ret)
-		goto err2;
+		goto free_fi_cq_ops;
 
 	domain_priv = container_of(domain, struct gnix_fid_domain, domain_fid);
 	if (!domain_priv) {
 		ret = -FI_EINVAL;
-		goto err2;
+		goto free_fi_cq_ops;
 	}
 
 	cq_priv = calloc(1, sizeof(*cq_priv));
 	if (!cq_priv) {
 		ret = -FI_ENOMEM;
-		goto err2;
+		goto free_fi_cq_ops;
 	}
 
 	cq_priv->requires_lock = (domain_priv->thread_model !=
@@ -651,34 +685,34 @@ DIRECT_FN int gnix_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	fastlock_init(&cq_priv->lock);
 	ret = gnix_cq_set_wait(cq_priv);
 	if (ret)
-		goto err3;
+		goto free_cq_priv;
 
 	ret = _gnix_queue_create(&cq_priv->events, alloc_cq_entry,
 				 free_cq_entry, cq_priv->entry_size,
 				 cq_priv->attr.size);
 	if (ret)
-		goto err3;
+		goto free_cq_priv;
 
 	ret = _gnix_queue_create(&cq_priv->errors, alloc_cq_entry,
 				 free_cq_entry, sizeof(struct fi_cq_err_entry),
 				 0);
 	if (ret)
-		goto err4;
+		goto free_gnix_queue;
 
 	*cq = &cq_priv->cq_fid;
 	return ret;
 
-err4:
+free_gnix_queue:
 	_gnix_queue_destroy(cq_priv->events);
-err3:
+free_cq_priv:
 	_gnix_ref_put(cq_priv->domain);
 	fastlock_destroy(&cq_priv->lock);
 	free(cq_priv);
-err2:
+free_fi_cq_ops:
 	free(fi_cq_ops);
-err1:
+free_cq_ops:
 	free(cq_ops);
-err:
+
 	return ret;
 }
 

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -2677,7 +2677,7 @@ DIRECT_FN STATIC ssize_t gnix_ep_cancel(fid_t fid, void *context)
 		flags = req->flags;
 
 		_gnix_cq_add_error(err_cq, context, flags, len, addr, 0 /* data */,
-				tag, len, FI_ECANCELED, FI_ECANCELED, 0);
+				tag, len, FI_ECANCELED, FI_ECANCELED, 0, 0);
 
 	}
 

--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
- * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -64,7 +64,7 @@ static int __gnix_rma_send_err(struct gnix_fid_ep *ep,
 	if (ep->send_cq) {
 		rc = _gnix_cq_add_error(ep->send_cq, req->user_context,
 					flags, 0, 0, 0, 0, 0, error,
-					GNI_RC_TRANSACTION_ERROR, NULL);
+					GNI_RC_TRANSACTION_ERROR, NULL, 0);
 		if (rc) {
 			GNIX_WARN(FI_LOG_EP_DATA,
 				  "_gnix_cq_add_error() failed: %d\n", rc);
@@ -93,7 +93,7 @@ static int __gnix_rma_send_completion(struct gnix_fid_ep *ep,
 				      struct gnix_fab_req *req)
 {
 	struct gnix_fid_cntr *cntr = NULL;
-	int rc = FI_SUCCESS;
+	int rc;
 	uint64_t flags = req->flags & GNIX_RMA_COMPLETION_FLAGS;
 
 	if ((req->flags & FI_COMPLETION) && ep->send_cq) {

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -317,7 +317,9 @@ static void __gnix_vc_pack_conn_req(char *sbuf,
 				    gni_smsg_attr_t *src_smsg_attr,
 				    gni_mem_handle_t *src_irq_cq_mhdl,
 				    uint64_t caps,
-				    xpmem_segid_t my_segid)
+				    xpmem_segid_t my_segid,
+				    uint8_t name_type,
+				    uint8_t rx_ctx_cnt)
 {
 	size_t __attribute__((unused)) len;
 	char *cptr = sbuf;
@@ -335,7 +337,10 @@ static void __gnix_vc_pack_conn_req(char *sbuf,
 	      sizeof(uint64_t) * 2 +
 	      sizeof(gni_smsg_attr_t) +
 	      sizeof(gni_mem_handle_t) +
-	      sizeof(xpmem_segid_t);
+	      sizeof(xpmem_segid_t) +
+	      sizeof(name_type) +
+	      sizeof(rx_ctx_cnt);
+
 	assert(len <= GNIX_CM_NIC_MAX_MSG_SIZE);
 
 	memcpy(cptr, &rtype, sizeof(rtype));
@@ -355,6 +360,10 @@ static void __gnix_vc_pack_conn_req(char *sbuf,
 	memcpy(cptr, &caps, sizeof(uint64_t));
 	cptr += sizeof(xpmem_segid_t);
 	memcpy(cptr, &my_segid, sizeof(xpmem_segid_t));
+	cptr += sizeof(name_type);
+	memcpy(cptr, &name_type, sizeof(name_type));
+	cptr += sizeof(rx_ctx_cnt);
+	memcpy(cptr, &rx_ctx_cnt, sizeof(rx_ctx_cnt));
 }
 
 /*
@@ -368,7 +377,9 @@ static void __gnix_vc_unpack_conn_req(char *rbuf,
 				      gni_smsg_attr_t *src_smsg_attr,
 				      gni_mem_handle_t *src_irq_cq_mhndl,
 				      uint64_t *caps,
-				      xpmem_segid_t *peer_segid)
+				      xpmem_segid_t *peer_segid,
+				      uint8_t *name_type,
+				      uint8_t *rx_ctx_cnt)
 {
 	size_t __attribute__((unused)) len;
 	char *cptr = rbuf;
@@ -395,6 +406,11 @@ static void __gnix_vc_unpack_conn_req(char *rbuf,
 	memcpy(caps, cptr, sizeof(uint64_t));
 	cptr += sizeof(uint64_t);
 	memcpy(peer_segid, cptr, sizeof(xpmem_segid_t));
+	cptr += sizeof(uint8_t);
+	memcpy(name_type, cptr, sizeof(*name_type));
+	cptr += sizeof(uint8_t);
+	memcpy(rx_ctx_cnt, cptr, sizeof(*rx_ctx_cnt));
+
 }
 
 /*
@@ -818,8 +834,10 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 	fi_addr_t fi_addr;
 	xpmem_segid_t peer_segid;
 	xpmem_apid_t peer_apid;
+	uint8_t name_type, rx_ctx_cnt;
 	bool accessible;
 	ssize_t __attribute__((unused)) len;
+	struct gnix_ep_name *error_data;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
@@ -835,7 +853,9 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 				  &src_smsg_attr,
 				  &tmp_mem_hndl,
 				  &peer_caps,
-				  &peer_segid);
+				  &peer_segid,
+				  &name_type,
+				  &rx_ctx_cnt);
 
 
 	GNIX_DEBUG(FI_LOG_EP_CTRL,
@@ -921,9 +941,30 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 					  vc, src_addr);
 
 				dlist_insert_tail(&vc->list, &ep->unmapped_vcs);
+
+				if (vc->ep->caps & FI_SOURCE) {
+					error_data =
+						calloc(1, sizeof(*error_data));
+					if (error_data == NULL) {
+						ret = -FI_ENOMEM;
+						goto err;
+					}
+					vc->gnix_ep_name = (void *) error_data;
+
+					error_data->gnix_addr = src_addr;
+					error_data->name_type = name_type;
+
+					error_data->cm_nic_cdm_id =
+						cm_nic->my_name.cm_nic_cdm_id;
+					error_data->cookie =
+						cm_nic->my_name.cookie;
+
+					error_data->rx_ctx_cnt = rx_ctx_cnt;
+				}
 			}
-		} else
+		} else {
 			vc->conn_state = GNIX_VC_CONNECTING;
+		}
 
 		vc->peer_caps = peer_caps;
 		/*
@@ -1315,7 +1356,9 @@ static int __gnix_vc_conn_req_prog_fn(void *data, int *complete_ptr)
 				&smsg_mbox_attr,
 				&ep->nic->irq_mem_hndl,
 				ep->caps,
-				my_segid);
+				my_segid,
+				ep->src_addr.name_type,
+				ep->src_addr.rx_ctx_cnt);
 
 	/*
 	 * try to send the message, if -FI_EAGAIN is returned, okay,
@@ -1555,15 +1598,6 @@ int _gnix_vc_destroy(struct gnix_vc *vc)
 			      "_gnix_mbox_free returned %s\n",
 			      fi_strerror(-ret));
 		vc->smsg_mbox = NULL;
-	}
-
-	if (vc->dgram != NULL) {
-		ret = _gnix_dgram_free(vc->dgram);
-		if (ret != FI_SUCCESS)
-			GNIX_WARN(FI_LOG_EP_CTRL,
-			      "_gnix_dgram_free returned %s\n",
-			      fi_strerror(-ret));
-		vc->dgram = NULL;
 	}
 
 	ret = _gnix_nic_free_rem_id(nic, vc->vc_id);
@@ -2117,9 +2151,7 @@ fi_addr_t _gnix_vc_peer_fi_addr(struct gnix_vc *vc)
 
 	/* If FI_SOURCE capability was requested, do a reverse lookup of a VC's
 	 * FI address once.  Skip translation on connected EPs (no AV). */
-	if (vc->ep->caps & FI_SOURCE &&
-	    vc->ep->av &&
-	    vc->peer_fi_addr == FI_ADDR_NOTAVAIL) {
+	if (vc->ep->av && vc->peer_fi_addr == FI_ADDR_NOTAVAIL) {
 		rc = _gnix_av_reverse_lookup(vc->ep->av,
 					     vc->peer_addr,
 					     &vc->peer_fi_addr);

--- a/prov/gni/test/cq.c
+++ b/prov/gni/test/cq.c
@@ -359,7 +359,7 @@ Test(reading, error)
 	cr_assert(!cq_priv->errors->free_list.head);
 
 	_gnix_cq_add_error(cq_priv, &input_ctx, flags, len, buf, data, tag,
-			   olen, err, prov_errno, 0);
+			   olen, err, prov_errno, 0, 0);
 
 	cr_assert(cq_priv->errors->item_list.head);
 
@@ -391,7 +391,7 @@ Test(reading, error)
 	cr_assert_eq(err_entry.olen, olen);
 	cr_assert_eq(err_entry.err, err);
 	cr_assert_eq(err_entry.prov_errno, prov_errno);
-	cr_assert_eq(err_entry.err_data, 0);
+	cr_assert(err_entry.err_data == NULL);
 }
 
 #define ENTRY_CNT 5
@@ -538,7 +538,7 @@ static void cq_fill_test(enum fi_cq_format format)
 	 */
 
 	_gnix_cq_add_error(cq_priv, &input_ctx, flags, len, 0, 0, 0, 0, 0, 0,
-			   0);
+			   0, 0);
 	cr_assert(cq_priv->errors->item_list.head);
 
 	ret = fi_cq_read(rcq, &entry, 1);

--- a/prov/gni/test/rdm_atomic.c
+++ b/prov/gni/test/rdm_atomic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/prov/gni/test/rdm_dgram_rma.c
+++ b/prov/gni/test/rdm_dgram_rma.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
@@ -2007,6 +2007,8 @@ void do_write_error(int len)
 	ssize_t sz;
 	struct fi_cq_tagged_entry cqe;
 	struct fi_cq_err_entry err_cqe;
+
+	err_cqe.err_data_size = 0;
 	uint64_t w[2] = {0}, r[2] = {0}, w_e[2] = {0}, r_e[2] = {0};
 
 	init_data(source, len, 0xab);

--- a/prov/gni/test/rdm_dgram_stx.c
+++ b/prov/gni/test/rdm_dgram_stx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
@@ -1692,6 +1692,8 @@ static void do_write_error(int len)
 	ssize_t sz;
 	struct fi_cq_tagged_entry cqe;
 	struct fi_cq_err_entry err_cqe;
+
+	err_cqe.err_data_size = 0;
 	uint64_t w[2] = {0}, r[2] = {0}, w_e[2] = {0}, r_e[2] = {0};
 
 	init_data(source, len, 0xab);
@@ -1765,6 +1767,8 @@ static void do_read_error(int len)
 	ssize_t sz;
 	struct fi_cq_tagged_entry cqe;
 	struct fi_cq_err_entry err_cqe;
+
+	err_cqe.err_data_size = 0;
 	uint64_t w[2] = {0}, r[2] = {0}, w_e[2] = {0}, r_e[2] = {0};
 
 	init_data(source, len, 0);

--- a/prov/gni/test/rdm_sr.c
+++ b/prov/gni/test/rdm_sr.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
+ *                         All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -80,6 +81,7 @@ const char *cdm_id[NUMEPS] = { "5000", "5001" };
 struct fi_info *hints;
 static int using_bnd_ep = 0;
 static int dgram_should_fail;
+static int peer_src_known = 1;
 
 #define BUF_SZ (1<<20)
 #define BUF_RNDZV (1<<14)
@@ -109,6 +111,7 @@ void rdm_sr_setup_common_eps(void)
 	int ret = 0, i = 0, j = 0;
 	struct fi_av_attr attr;
 	size_t addrlen = 0;
+	bool is_fi_source = !!(hints->caps & FI_SOURCE);
 
 	memset(&attr, 0, sizeof(attr));
 	attr.type = FI_AV_MAP;
@@ -187,11 +190,25 @@ void rdm_sr_setup_common_eps(void)
 	}
 
 	for (i = 0; i < NUMEPS; i++) {
-		/* Insert all gni addresses into each av */
-		for (j = 0; j < NUMEPS; j++) {
-			ret = fi_av_insert(av[i], ep_name[j], 1, &gni_addr[j],
-					   0, NULL);
-			cr_assert(ret == 1);
+		/*
+		 * To test API-1.1: Reporting of unknown source addresses --
+		 * only insert addresses into the sender's av
+		 */
+		if (is_fi_source && !peer_src_known && i < (NUMEPS / 2)) {
+			for (j = 0; j < NUMEPS; j++) {
+				dbg_printf("Only does src EP insertions\n");
+				ret = fi_av_insert(av[i], ep_name[j], 1,
+						   &gni_addr[j],
+						   0, NULL);
+				cr_assert(ret == 1);
+			}
+		} else if (peer_src_known) {
+			for (j = 0; j < NUMEPS; j++) {
+				ret = fi_av_insert(av[i], ep_name[j], 1,
+						   &gni_addr[j],
+						   0, NULL);
+				cr_assert(ret == 1);
+			}
 		}
 
 		ret = fi_ep_bind(ep[i], &av[i]->fid, 0);
@@ -245,6 +262,7 @@ void rdm_sr_setup_common(void)
 	}
 }
 
+/* Note: default ep type is FI_EP_RDM (used in rdm_sr_setup) */
 void rdm_sr_setup(bool is_noreg, enum fi_progress pm)
 {
 	int ret = 0, i = 0;
@@ -273,7 +291,7 @@ void rdm_sr_setup(bool is_noreg, enum fi_progress pm)
 	dgram_should_fail = 0;
 }
 
-void dgram_sr_setup(bool is_noreg, enum fi_progress pm)
+void dgram_sr_setup(uint32_t version, bool is_noreg, enum fi_progress pm)
 {
 	int ret = 0, i = 0;
 
@@ -290,7 +308,7 @@ void dgram_sr_setup(bool is_noreg, enum fi_progress pm)
 
 	/* Get info about fabric services with the provided hints */
 	for (; i < NUMEPS; i++) {
-		ret = fi_getinfo(fi_version(), NULL, 0, 0, hints, &fi[i]);
+		ret = fi_getinfo(version, NULL, 0, 0, hints, &fi[i]);
 		cr_assert(!ret, "fi_getinfo");
 	}
 
@@ -306,7 +324,19 @@ static void rdm_sr_setup_reg(void) {
 
 static void dgram_sr_setup_reg(void)
 {
-	dgram_sr_setup(false, FI_PROGRESS_AUTO);
+	dgram_sr_setup(fi_version(), false, FI_PROGRESS_AUTO);
+}
+
+static void dgram_sr_setup_reg_src_unk_api_version_old(void)
+{
+	peer_src_known = 0;
+	dgram_sr_setup(FI_VERSION(1, 0), false, FI_PROGRESS_AUTO);
+}
+
+static void dgram_sr_setup_reg_src_unk_api_version_cur(void)
+{
+	peer_src_known = 0;
+	dgram_sr_setup(fi_version(), false, FI_PROGRESS_AUTO);
 }
 
 static void rdm_sr_setup_noreg(void) {
@@ -476,6 +506,46 @@ void rdm_sr_xfer_for_each_size(void (*xfer)(int len), int slen, int elen)
 	}
 }
 
+static inline void rdm_sr_check_err_cqe(struct fi_cq_err_entry *cqe, void *ctx,
+					uint64_t flags, void *addr, size_t len,
+					uint64_t data, bool buf_is_non_null)
+{
+	cr_assert(cqe->op_context == ctx, "error CQE Context mismatch");
+	cr_assert(cqe->flags == flags, "error CQE flags mismatch");
+
+	if (flags & FI_RECV) {
+		if (cqe->len != len) {
+			cr_assert(cqe->olen == (len - cqe->len), "error CQE "
+				"olen mismatch");
+		} else {
+			cr_assert(cqe->olen == 0, "error CQE olen mismatch");
+		}
+
+		if (buf_is_non_null)
+			cr_assert(cqe->buf == addr, "error CQE address "
+				"mismatch");
+		else
+			cr_assert(cqe->buf == NULL, "error CQE address "
+				"mismatch");
+
+
+		if (flags & FI_REMOTE_CQ_DATA)
+			cr_assert(cqe->data == data, "error CQE data mismatch");
+	} else {
+		cr_assert(cqe->len == 0, "Invalid error CQE length");
+		cr_assert(cqe->buf == 0, "Invalid error CQE address");
+		cr_assert(cqe->data == 0, "Invalid error CQE data");
+	}
+
+	cr_assert(cqe->tag == 0, "Invalid error CQE tag");
+	cr_assert(cqe->err > 0, "Invalid error CQE err code");
+
+	/*
+	 * Note: cqe->prov_errno and cqe->err_data are not necessarily set --
+	 * see the fi_cq_readerr man page
+	 */
+}
+
 static inline void rdm_sr_check_cqe(struct fi_cq_tagged_entry *cqe, void *ctx,
 				    uint64_t flags, void *addr, size_t len,
 				    uint64_t data, bool buf_is_non_null)
@@ -548,12 +618,32 @@ void rdm_sr_lazy_dereg_disable(void)
 	}
 }
 
-static inline int rdm_sr_check_canceled(struct fid_cq *cq)
+static inline struct fi_cq_err_entry rdm_sr_check_canceled(struct fid_cq *cq)
 {
 	struct fi_cq_err_entry ee;
+	struct gnix_ep_name err_ep_name;
+
+	/*application provided error_data buffer and length*/
+	ee.err_data_size = sizeof(struct gnix_ep_name);
+	ee.err_data = &err_ep_name;
 
 	fi_cq_readerr(cq, &ee, 0);
-	return (ee.err == FI_ECANCELED);
+
+	/*
+	 * TODO: Check for api version once we figure out how to.
+	 * Note: The address of err_ep_name should be the same as ee.err_data
+	 * when using api version >= 1.5.
+	 */
+	cr_assert(ee.err_data != &err_ep_name, "Invalid err_data ptr");
+
+
+	/* To test API-1.1: Reporting of unknown source addresses */
+	if ((hints->caps & FI_SOURCE) && ee.err == FI_EADDRNOTAVAIL) {
+		int ret = fi_av_insert(av[1], ep_name[0], 1, ee.err_data, 0,
+				       NULL);
+		cr_assert(ret == 1);
+	}
+	return ee;
 }
 
 /*******************************************************************************
@@ -565,6 +655,15 @@ TestSuite(rdm_sr, .init = rdm_sr_setup_reg, .fini = rdm_sr_teardown,
 
 TestSuite(dgram_sr, .init = dgram_sr_setup_reg, .fini = rdm_sr_teardown,
 	  .disabled = false);
+
+TestSuite(dgram_sr_src_unk_api_version_old,
+	  .init = dgram_sr_setup_reg_src_unk_api_version_old,
+	  .fini = rdm_sr_teardown, .disabled = false);
+
+/* TODO: Enabled after 1.5 release */
+TestSuite(dgram_sr_src_unk_api_version_cur,
+	  .init = dgram_sr_setup_reg_src_unk_api_version_cur,
+	  .fini = rdm_sr_teardown, .disabled = true);
 
 TestSuite(rdm_sr_noreg, .init = rdm_sr_setup_noreg,
 	  .fini = rdm_sr_teardown_nounreg, .disabled = false);
@@ -589,14 +688,20 @@ void do_send(int len)
 {
 	int ret;
 	int source_done = 0, dest_done = 0;
-	int scanceled = 0, dcanceled = 0;
+	int scanceled = 0, dcanceled = 0, daddrnotavail = 0;
 	struct fi_cq_tagged_entry s_cqe = { (void *) -1, UINT_MAX, UINT_MAX,
 					    (void *) -1, UINT_MAX, UINT_MAX };
 	struct fi_cq_tagged_entry d_cqe = { (void *) -1, UINT_MAX, UINT_MAX,
 					    (void *) -1, UINT_MAX, UINT_MAX };
+	struct fi_cq_err_entry d_err_cqe;
+	struct fi_cq_err_entry s_err_cqe;
+
 	ssize_t sz;
 	uint64_t s[NUMEPS] = {0}, r[NUMEPS] = {0}, s_e[NUMEPS] = {0};
 	uint64_t r_e[NUMEPS] = {0};
+
+	memset(&d_err_cqe, -1, sizeof(struct fi_cq_err_entry));
+	memset(&s_err_cqe, -1, sizeof(struct fi_cq_err_entry));
 
 	rdm_sr_init_data(source, len, 0xab);
 	rdm_sr_init_data(target, len, 0);
@@ -614,7 +719,8 @@ void do_send(int len)
 			source_done = 1;
 		}
 		if (ret == -FI_EAVAIL) {
-			if (rdm_sr_check_canceled(msg_cq[0]))
+			s_err_cqe = rdm_sr_check_canceled(msg_cq[0]);
+			if (s_err_cqe.err == FI_ECANCELED)
 				scanceled = 1;
 		}
 		ret = fi_cq_read(msg_cq[1], &d_cqe, 1);
@@ -622,17 +728,33 @@ void do_send(int len)
 			dest_done = 1;
 		}
 		if (ret == -FI_EAVAIL) {
-			if (rdm_sr_check_canceled(msg_cq[1]))
+			d_err_cqe = rdm_sr_check_canceled(msg_cq[1]);
+			if (d_err_cqe.err == FI_ECANCELED)
 				dcanceled = 1;
+			else if (d_err_cqe.err == FI_EADDRNOTAVAIL &&
+				!peer_src_known)
+				daddrnotavail = 1;
 		}
-	} while (!((source_done || scanceled) && (dest_done || dcanceled)));
+	} while (!((source_done || scanceled) &&
+		(dest_done || dcanceled || daddrnotavail)));
 
 	/* no further checking needed */
 	if (dgram_should_fail && (scanceled || dcanceled))
 		return;
 
-	rdm_sr_check_cqe(&s_cqe, target, (FI_MSG|FI_SEND), 0, 0, 0, false);
-	rdm_sr_check_cqe(&d_cqe, source, (FI_MSG|FI_RECV), target, len, 0, false);
+	if (daddrnotavail || dcanceled)
+		rdm_sr_check_err_cqe(&d_err_cqe, source, (FI_MSG|FI_RECV),
+				     target, len, 0, false);
+	else
+		rdm_sr_check_cqe(&d_cqe, source, (FI_MSG|FI_RECV), target, len,
+				 0, false);
+
+	if (scanceled)
+		rdm_sr_check_err_cqe(&s_err_cqe, target, (FI_MSG|FI_SEND), 0,
+				     0, 0, false);
+	else
+		rdm_sr_check_cqe(&s_cqe, target, (FI_MSG|FI_SEND), 0, 0, 0,
+				 false);
 
 	s[0] = 1; r[1] = 1;
 	rdm_sr_check_cntrs(s, r, s_e, r_e);
@@ -656,6 +778,16 @@ Test(rdm_sr, send_retrans)
 Test(dgram_sr, send)
 {
 	rdm_sr_xfer_for_each_size(do_send, 1, BUF_SZ);
+}
+
+Test(dgram_sr_src_unk_api_version_old, send)
+{
+	rdm_sr_xfer_for_each_size(do_send, 1, 1);
+}
+
+Test(dgram_sr_src_unk_api_version_cur, send)
+{
+	rdm_sr_xfer_for_each_size(do_send, 1, 1);
 }
 
 Test(dgram_sr, send_retrans)
@@ -932,7 +1064,7 @@ void do_inject(int len)
 	s[0] = 1; r[1] = 1;
 	rdm_sr_check_cntrs(s, r, s_e, r_e);
 
-	/* make sure inject does not generate a send competion */
+	/* make sure inject does not generate a send completion */
 	cr_assert_eq(fi_cq_read(msg_cq[0], &cqe, 1), -FI_EAGAIN);
 
 	cr_assert(rdm_sr_check_data(source, target, len), "Data mismatch");


### PR DESCRIPTION
    - Updated _gnix_cq_addr_error to check API version and copy
    out the error data properly.
    
    - Replaced dgram member of VC struct with gnix_ep_name
    pointer.
    
    - Updated VC connection request routines to include
    required source address fields.
      - If FI_SOURCE is used and the remote peer's AV doesn't
       contain the source address the unknown source address
       is added to the VC.
    
    - Updated FI_EP_{RDM,DGM} receive completions to report
    source addresses via error CQEs.
    
    - Updated fi_gni man page and gnitest unit tests to reflect
    these changes.
    
    - Updated goto labels in gnix_cq_open for readability.


Fixes #1147.

Signed-off-by: Evan Harvey <eharvey@lanl.gov>