### PR TITLE
prov/gni: Ensure the CQE flags are set properly for ABI-1.1

### DIFF
--- a/prov/gni/include/gnix_cq.h
+++ b/prov/gni/include/gnix_cq.h
@@ -45,6 +45,9 @@
 #define GNIX_CQ_DEFAULT_FORMAT struct fi_cq_entry
 #define GNIX_CQ_DEFAULT_SIZE   256
 
+/* forward declaration */
+struct gnix_fid_ep;
+
 struct gnix_cq_entry {
 	void *the_entry;
 	fi_addr_t src_addr;
@@ -79,9 +82,10 @@ struct gnix_fid_cq {
 };
 
 
-ssize_t _gnix_cq_add_event(struct gnix_fid_cq *cq, void *op_context,
-			  uint64_t flags, size_t len, void *buf,
-			  uint64_t data, uint64_t tag, fi_addr_t src_addr);
+ssize_t _gnix_cq_add_event(struct gnix_fid_cq *cq, struct gnix_fid_ep *ep,
+			   void *op_context, uint64_t flags, size_t len,
+			   void *buf, uint64_t data, uint64_t tag,
+			   fi_addr_t src_addr);
 
 ssize_t _gnix_cq_add_error(struct gnix_fid_cq *cq, void *op_context,
 			  uint64_t flags, size_t len, void *buf,

--- a/prov/gni/src/gnix_atomic.c
+++ b/prov/gni/src/gnix_atomic.c
@@ -91,7 +91,7 @@ static int __gnix_amo_send_completion(struct gnix_fid_ep *ep,
 	uint64_t flags = req->flags & GNIX_AMO_COMPLETION_FLAGS;
 
 	if ((req->flags & FI_COMPLETION) && ep->send_cq) {
-		rc = _gnix_cq_add_event(ep->send_cq, req->user_context,
+		rc = _gnix_cq_add_event(ep->send_cq, ep, req->user_context,
 					flags, 0, 0, 0, 0, FI_ADDR_NOTAVAIL);
 		if (rc) {
 			GNIX_WARN(FI_LOG_EP_DATA,

--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -283,28 +283,29 @@ static int __gnix_cq_progress(struct gnix_fid_cq *cq)
  * Exposed helper functions
  ******************************************************************************/
 ssize_t _gnix_cq_add_event(struct gnix_fid_cq *cq, struct gnix_fid_ep *ep,
-                           void *op_context, uint64_t flags, size_t len,
-                           void *buf, uint64_t data, uint64_t tag,
-                           fi_addr_t src_addr)
+			   void *op_context, uint64_t flags, size_t len,
+			   void *buf, uint64_t data, uint64_t tag,
+			   fi_addr_t src_addr)
 {
 	struct gnix_cq_entry *event;
 	struct slist_entry *item;
-        uint64_t op_flags;
+	uint64_t op_flags, mask;
 
-        if (ep) {
-                op_flags = ep->op_flags;
+	/* TODO: Move below conditional to gnix_cq.h and make static/inline */
+	if (ep) {
+		op_flags = ep->op_flags;
 
-                if (op_flags & FI_NOTIFY_FLAGS_ONLY) {
-                        uint64_t mask = (FI_REMOTE_CQ_DATA | FI_MULTI_RECV);
+		if (op_flags & FI_NOTIFY_FLAGS_ONLY) {
+			mask = (FI_REMOTE_CQ_DATA | FI_MULTI_RECV);
 
-                        if (op_flags & FI_RMA_EVENT) {
-                                mask |= (FI_REMOTE_READ | FI_REMOTE_WRITE |
-                                         FI_RMA);
-                        }
+			if (op_flags & FI_RMA_EVENT) {
+				mask |= (FI_REMOTE_READ | FI_REMOTE_WRITE |
+					 FI_RMA);
+			}
 
-                        flags &= mask;
-                }
-        }
+			flags &= mask;
+		}
+	}
 
 	COND_ACQUIRE(cq->requires_lock, &cq->lock);
 

--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -282,12 +282,29 @@ static int __gnix_cq_progress(struct gnix_fid_cq *cq)
 /*******************************************************************************
  * Exposed helper functions
  ******************************************************************************/
-ssize_t _gnix_cq_add_event(struct gnix_fid_cq *cq, void *op_context,
-			   uint64_t flags, size_t len, void *buf,
-			   uint64_t data, uint64_t tag, fi_addr_t src_addr)
+ssize_t _gnix_cq_add_event(struct gnix_fid_cq *cq, struct gnix_fid_ep *ep,
+                           void *op_context, uint64_t flags, size_t len,
+                           void *buf, uint64_t data, uint64_t tag,
+                           fi_addr_t src_addr)
 {
 	struct gnix_cq_entry *event;
 	struct slist_entry *item;
+        uint64_t op_flags;
+
+        if (ep) {
+                op_flags = ep->op_flags;
+
+                if (op_flags & FI_NOTIFY_FLAGS_ONLY) {
+                        uint64_t mask = (FI_REMOTE_CQ_DATA | FI_MULTI_RECV);
+
+                        if (op_flags & FI_RMA_EVENT) {
+                                mask |= (FI_REMOTE_READ | FI_REMOTE_WRITE |
+                                         FI_RMA);
+                        }
+
+                        flags &= mask;
+                }
+        }
 
 	COND_ACQUIRE(cq->requires_lock, &cq->lock);
 

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -335,7 +335,7 @@ static int __recv_completion(
 	int rc;
 
 	if ((req->msg.recv_flags & FI_COMPLETION) && ep->recv_cq) {
-		rc = _gnix_cq_add_event(ep->recv_cq, context, flags, len,
+		rc = _gnix_cq_add_event(ep->recv_cq, ep, context, flags, len,
 					addr, data, tag, src_addr);
 		if (rc != FI_SUCCESS)  {
 			GNIX_WARN(FI_LOG_EP_DATA,
@@ -419,9 +419,8 @@ static int __gnix_msg_send_completion(struct gnix_fid_ep *ep,
 	GNIX_DEBUG(FI_LOG_EP_DATA, "send_cq = %p\n", ep->send_cq);
 
 	if ((req->msg.send_flags & FI_COMPLETION) && ep->send_cq) {
-		rc = _gnix_cq_add_event(ep->send_cq,
-				req->user_context,
-				flags, 0, 0, 0, 0, FI_ADDR_NOTAVAIL);
+		rc = _gnix_cq_add_event(ep->send_cq, ep, req->user_context,
+					flags, 0, 0, 0, 0, FI_ADDR_NOTAVAIL);
 		if (rc != FI_SUCCESS)  {
 			GNIX_WARN(FI_LOG_EP_DATA,
 					"_gnix_cq_add_event returned %d\n",

--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -97,7 +97,7 @@ static int __gnix_rma_send_completion(struct gnix_fid_ep *ep,
 	uint64_t flags = req->flags & GNIX_RMA_COMPLETION_FLAGS;
 
 	if ((req->flags & FI_COMPLETION) && ep->send_cq) {
-		rc = _gnix_cq_add_event(ep->send_cq, req->user_context,
+		rc = _gnix_cq_add_event(ep->send_cq, ep, req->user_context,
 					flags, 0, 0, 0, 0, FI_ADDR_NOTAVAIL);
 		if (rc) {
 			GNIX_WARN(FI_LOG_EP_DATA,
@@ -251,8 +251,8 @@ int __smsg_rma_data(void *data, void *msg)
 	gni_return_t status;
 
 	if (hdr->flags & FI_REMOTE_CQ_DATA && ep->recv_cq) {
-		ret = _gnix_cq_add_event(ep->recv_cq, NULL, hdr->user_flags, 0,
-					 0, hdr->user_data, 0,
+		ret = _gnix_cq_add_event(ep->recv_cq, ep, NULL, hdr->user_flags,
+					 0, 0, hdr->user_data, 0,
 					 FI_ADDR_NOTAVAIL);
 		if (ret != FI_SUCCESS)  {
 			GNIX_WARN(FI_LOG_EP_DATA,

--- a/prov/gni/test/cq.c
+++ b/prov/gni/test/cq.c
@@ -256,7 +256,7 @@ Test(insertion, single)
 
 	cr_assert(!cq_priv->events->item_list.head);
 
-	_gnix_cq_add_event(cq_priv, &input_ctx, 0, 0, 0, 0, 0, 0);
+	_gnix_cq_add_event(cq_priv, NULL, &input_ctx, 0, 0, 0, 0, 0, 0);
 
 	cr_assert(cq_priv->events->item_list.head);
 	cr_assert_eq(cq_priv->events->item_list.head,
@@ -278,12 +278,12 @@ Test(insertion, limit)
 	const size_t cq_size = cq_priv->attr.size;
 
 	for (size_t i = 0; i < cq_size; i++)
-		_gnix_cq_add_event(cq_priv, &input_ctx, 0, 0, 0, 0, 0, 0);
+		_gnix_cq_add_event(cq_priv, NULL, &input_ctx, 0, 0, 0, 0, 0, 0);
 
 	cr_assert(cq_priv->events->item_list.head);
 	cr_assert(!cq_priv->events->free_list.head);
 
-	_gnix_cq_add_event(cq_priv, &input_ctx, 0, 0, 0, 0, 0, 0);
+	_gnix_cq_add_event(cq_priv, NULL, &input_ctx, 0, 0, 0, 0, 0, 0);
 
 	for (size_t i = 0; i < cq_size + 1; i++) {
 		ret = fi_cq_read(rcq, &entry, 1);
@@ -371,7 +371,7 @@ Test(reading, issue192)
 	char input_ctx = 'a';
 	struct fi_cq_entry entries[ENTRY_CNT];
 
-	_gnix_cq_add_event(cq_priv, &input_ctx, 0, 0, 0, 0, 0, 0);
+	_gnix_cq_add_event(cq_priv, NULL, &input_ctx, 0, 0, 0, 0, 0, 0);
 
 	ret = fi_cq_read(rcq, &entries, ENTRY_CNT);
 	cr_assert_eq(ret, 1);
@@ -444,7 +444,7 @@ static void cq_add_read(enum fi_cq_format format)
 
 	cr_assert(!cq_priv->events->item_list.head);
 
-	_gnix_cq_add_event(cq_priv, expected.op_context, expected.flags,
+	_gnix_cq_add_event(cq_priv, NULL, expected.op_context, expected.flags,
 			   expected.len, expected.buf, expected.data,
 			   expected.tag, 0x0);
 
@@ -483,7 +483,7 @@ static void cq_fill_test(enum fi_cq_format format)
 
 	cq_size = cq_priv->attr.size;
 	for (size_t i = 0; i < cq_size; i++) {
-		_gnix_cq_add_event(cq_priv, expected.op_context,
+		_gnix_cq_add_event(cq_priv, NULL, expected.op_context,
 				   expected.flags, expected.len,
 				   expected.buf, expected.data,
 				   expected.tag, 0x0);
@@ -492,7 +492,7 @@ static void cq_fill_test(enum fi_cq_format format)
 	cr_assert(cq_priv->events->item_list.head);
 	cr_assert(!cq_priv->events->free_list.head);
 
-	_gnix_cq_add_event(cq_priv, expected.op_context,
+	_gnix_cq_add_event(cq_priv, NULL, expected.op_context,
 			   expected.flags, 2 * expected.len, expected.buf,
 			   expected.data, expected.tag, 0x0);
 
@@ -552,7 +552,7 @@ static void cq_multi_read_test(enum fi_cq_format format)
 	cr_assert(!cq_priv->events->item_list.head);
 
 	for (size_t i = 0; i < count; i++) {
-		_gnix_cq_add_event(cq_priv, expected.op_context,
+		_gnix_cq_add_event(cq_priv, NULL, expected.op_context,
 				   expected.flags, expected.len,
 				   expected.buf, expected.data,
 				   expected.tag, 0x0);
@@ -671,7 +671,7 @@ Test(cq_msg, multi_sread, .init = cq_wait_unspec_setup, .disabled = false)
 	cr_assert_eq(ret, -FI_EAGAIN);
 
 	for (size_t i = 0; i < count; i++)
-		_gnix_cq_add_event(cq_priv, 0, (uint64_t) i, 0, 0, 0, 0, 0);
+		_gnix_cq_add_event(cq_priv, NULL, 0, (uint64_t) i, 0, 0, 0, 0, 0);
 
 	cr_assert(cq_priv->events->item_list.head);
 

--- a/prov/gni/test/cq.c
+++ b/prov/gni/test/cq.c
@@ -52,6 +52,8 @@
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
+static struct gnix_fid_ep *ep;
+static struct fid_ep *fid_ep;
 static struct fid_cq *rcq;
 static struct fi_info *hints;
 static struct fi_info *fi;
@@ -166,10 +168,34 @@ void cq_wait_mutex_cond_setup(void)
 	cq_create(FI_CQ_FORMAT_MSG, FI_WAIT_MUTEX_COND, 8);
 }
 
+void cq_notify_setup(void)
+{
+	int ret;
+
+	setup();
+
+	ret = fi_endpoint(dom, fi, &fid_ep, NULL);
+	cr_assert(!ret, "fi_endpoint");
+	cr_assert(fid_ep != NULL);
+
+	ep = container_of(fid_ep, struct gnix_fid_ep, ep_fid);
+	cr_assert(ep, "ep not allocated");
+
+	cq_create(FI_CQ_FORMAT_MSG, FI_WAIT_NONE, 0);
+}
+
 void cq_teardown(void)
 {
 	cr_assert(!fi_close(&rcq->fid), "failure in closing cq.");
 	teardown();
+}
+
+void cq_notify_teardown(void)
+{
+	cr_assert(!fi_close(&rcq->fid), "failure in closing cq.");
+	cr_assert(!fi_close(&fid_ep->fid), "failure in closing ep.");
+	teardown();
+
 }
 
 /*******************************************************************************
@@ -822,4 +848,62 @@ Test(cq_wait_set, fd, .init = setup, .disabled = true)
 	cr_expect_eq(FI_SUCCESS, ret, "failure in closing waitset.");
 
 	teardown();
+}
+
+TestSuite(cq_notify_flags, .init = cq_notify_setup, .fini = cq_notify_teardown);
+
+void do_cq_notify(uint64_t op_flags)
+{
+	ssize_t ret;
+	struct fi_cq_msg_entry entry;
+	uint64_t expected_flags = ~((uint64_t) 0);
+
+	ep->op_flags = op_flags;
+
+	ret = _gnix_cq_add_event(cq_priv, ep, NULL, expected_flags, 0, NULL,
+				 0, 0, 0);
+	cr_assert(ret == FI_SUCCESS, "failing in _gnix_cq_add_event");
+
+	ret = fi_cq_read(rcq, &entry, 1);
+	cr_assert(ret == 1, "failing in fi_cq_read");
+
+	switch(op_flags) {
+		case 0:
+			break;
+		case FI_RMA_EVENT:
+			break;
+		case FI_NOTIFY_FLAGS_ONLY:
+			expected_flags &= (FI_REMOTE_CQ_DATA | FI_MULTI_RECV);
+			break;
+		case (FI_RMA_EVENT | FI_NOTIFY_FLAGS_ONLY):
+			expected_flags &= (FI_REMOTE_READ | FI_REMOTE_WRITE |
+					   FI_RMA | FI_REMOTE_CQ_DATA |
+					   FI_MULTI_RECV);
+			break;
+		default:
+			cr_assert(0, "invalid op flags");
+
+	}
+
+	cr_assert_eq(expected_flags, entry.flags, "unexpected cq entry flags");
+}
+
+Test(cq_notify_flags, notify_and_rma_event_unset)
+{
+	do_cq_notify(0);
+}
+
+Test(cq_notify_flags, notify_unset_and_rma_event_set)
+{
+	do_cq_notify(FI_RMA_EVENT);
+}
+
+Test(cq_notify_flags, notify_set_and_rma_event_unset)
+{
+	do_cq_notify(FI_NOTIFY_FLAGS_ONLY);
+}
+
+Test(cq_notify_flags, notify_set_and_rma_event_set)
+{
+	do_cq_notify(FI_NOTIFY_FLAGS_ONLY | FI_RMA_EVENT);
 }


### PR DESCRIPTION
- If EP op_flags have FI_NOTIFY_FLAGS_ONLY set, mask off the
CQE flags.

fixes #1180 