### PR TITLE
prov/gni: return error on cntr_err being set

### DIFF
--- a/prov/gni/src/gnix_cntr.c
+++ b/prov/gni/src/gnix_cntr.c
@@ -276,7 +276,7 @@ static int gnix_cntr_wait_sleep(struct gnix_fid_cntr *cntr_priv,
 		}
 	}
 
-	return ret;
+	return (atomic_get(&cntr_priv->cnt_err)) ? -FI_EAVAIL : ret;
 }
 
 


### PR DESCRIPTION
Currently when using gnix_cntr_wait when cnt_err is set
FI_SUCCESS is returned instead of an error code.
Add -FI_EAVAIL if cnt_err is not 0.

fixes ofi-cray/libfabric-cray#1150

Signed-off-by: James Shimek <jshimek@cray.com>

Testing:
 -no gnitest failures

@sungeunchoi @hppritcha