### PR TITLE
prov/gni: gnix_mr_key size is too large

### DIFF
--- a/prov/gni/include/gnix_mr.h
+++ b/prov/gni/include/gnix_mr.h
@@ -105,10 +105,8 @@ struct gnix_fid_mem_desc {
 typedef struct gnix_mr_key {
 	union {
 		struct {
-			struct {
-				uint64_t pfn: GNIX_MR_PFN_BITS;
-				uint64_t mdd: GNIX_MR_MDD_BITS;
-			};
+			uint64_t pfn: GNIX_MR_PFN_BITS;
+			uint64_t mdd: GNIX_MR_MDD_BITS;
 			uint64_t format : GNIX_MR_FMT_BITS;
 			uint64_t flags : GNIX_MR_FLAG_BITS;
 			uint64_t padding: GNIX_MR_PADDING_LENGTH;

--- a/prov/gni/src/gnix_mr.c
+++ b/prov/gni/src/gnix_mr.c
@@ -121,7 +121,7 @@ void _gnix_convert_key_to_mhdl(
  */
 uint64_t _gnix_convert_mhdl_to_key(gni_mem_handle_t *mhdl)
 {
-	gnix_mr_key_t key = {{{{0}}}};
+	gnix_mr_key_t key = {{{0}}};
 	key.pfn = GNI_MEMHNDL_GET_VA((*mhdl)) >> GNIX_MR_PAGE_SHIFT;
 	key.mdd = GNI_MEMHNDL_GET_MDH((*mhdl));
 	//key->format = GNI_MEMHNDL_NEW_FRMT((*mhdl));

--- a/prov/gni/test/mr.c
+++ b/prov/gni/test/mr.c
@@ -50,6 +50,7 @@
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
 #include "gnix.h"
+#include "gnix_mr.h"
 
 #define CHECK_HOOK(name, args...) \
 	({ \
@@ -308,6 +309,9 @@ static int __simple_post_dereg_hook(const char *func, int line,
 Test(mr_internal_bare, basic_init)
 {
 	int ret;
+
+	// ensure that the memory registration key is the right size
+	cr_assert_eq(sizeof(gnix_mr_key_t), 8);
 
 	ret = fi_mr_reg(dom, (void *) buf, buf_len, default_access,
 			default_offset, default_req_key,


### PR DESCRIPTION
This addresses an issue where the compiler does not pack the
two structures defined within a union.

Signed-off-by: James Swaro <jswaro@cray.com>

closes #1171 