### PR TITLE
prov/gni: Fix problems with GNI cm nic progress

### DIFF
--- a/prov/gni/include/gnix_cm_nic.h
+++ b/prov/gni/include/gnix_cm_nic.h
@@ -180,4 +180,29 @@ int _gnix_cm_nic_create_cdm_id(struct gnix_fid_domain *domain, uint32_t *id);
 int _gnix_get_new_cdm_id_set(struct gnix_fid_domain *domain, int nids,
 				uint32_t *id);
 
+/**
+ * @brief helper function to quickly check whether progress is required on
+ *        a cm_nic
+ *
+ * @param cm_nic  pointer to previously allocated gnix_cm_nic struct
+ * @return true if progress is needed, otherwise false
+ */
+static inline bool _gnix_cm_nic_need_progress(struct gnix_cm_nic *cm_nic)
+{
+	bool ret;
+
+	/*
+	 * if control progress is manual, always need to progress
+	 */
+	if (cm_nic->domain->control_progress == FI_PROGRESS_MANUAL)
+		return true;
+
+	/*
+	 * otherwise we only need to see if the wq has stuff to
+	 * progress
+	 */
+	ret = (dlist_empty(&cm_nic->cm_nic_wq)) ? false : true;
+	return ret;
+}
+
 #endif /* _GNIX_CM_NIC_H_ */

--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -252,6 +252,7 @@ err:
 static int __gnix_cq_progress(struct gnix_fid_cq *cq)
 {
 	struct gnix_cq_poll_nic *pnic, *tmp;
+	struct gnix_cm_nic *cm_nic = cq->domain->cm_nic;
 	int rc;
 
 	COND_READ_ACQUIRE(cq->requires_lock, &cq->nic_lock);
@@ -266,13 +267,21 @@ static int __gnix_cq_progress(struct gnix_fid_cq *cq)
 
 	COND_RW_RELEASE(cq->requires_lock, &cq->nic_lock);
 
-	if (unlikely(cq->domain->control_progress != FI_PROGRESS_AUTO)) {
-		if (cq->domain->cm_nic != NULL) {
-			rc = _gnix_cm_nic_progress(cq->domain->cm_nic);
+	/*
+	 * check to see if we need to poke the cm nic to progress
+	 * backlogged datagram requests.  This is needed even if
+	 * control_progress is set to FI_PROGRESS_AUTO since we
+	 * don't get notification back from kGNI when a previously
+	 * posted bound datagram has actually completed, allowing
+	 * subsequent pending bound datagrams to be posted to kGNI.
+	 */
+
+	if (cm_nic != NULL &&
+		_gnix_cm_nic_need_progress(cm_nic)) {
+			rc = _gnix_cm_nic_progress(cm_nic);
 			if (rc)
 				GNIX_WARN(FI_LOG_CQ,
 				  "_gnix_cm_nic_progress returned: %d\n", rc);
-		}
 	}
 
 	return FI_SUCCESS;
@@ -584,6 +593,12 @@ DIRECT_FN STATIC ssize_t gnix_cq_readerr(struct fid_cq *cq,
 		return -FI_EINVAL;
 
 	cq_priv = container_of(cq, struct gnix_fid_cq, cq_fid);
+
+	/*
+	 * we need to progress cq.  some apps may be only using
+	 * cq to check for errors.
+	 */
+	__gnix_cq_progress(cq_priv);
 
 	COND_ACQUIRE(cq_priv->requires_lock, &cq_priv->lock);
 

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -686,6 +686,12 @@ static int __gnix_vc_connect_to_self(struct gnix_vc *vc)
 			  "_gnix_vc_schedule returned %s\n",
 			  fi_strerror(-ret));
 
+	ret = __gnix_vc_push_tx_reqs(vc);
+	if (ret != FI_SUCCESS)
+		GNIX_WARN(FI_LOG_EP_DATA,
+			  "_gnix_vc_push_tx_reqs returned %s\n",
+			  fi_strerror(-ret));
+
 	GNIX_DEBUG(FI_LOG_EP_CTRL, "moving vc %p state to connected\n", vc);
 	return ret;
 
@@ -800,6 +806,11 @@ static int __gnix_vc_hndl_conn_resp(struct gnix_cm_nic *cm_nic,
 	if (ret != FI_SUCCESS)
 		GNIX_WARN(FI_LOG_EP_DATA,
 			  "_gnix_vc_schedule returned %s\n",
+			  fi_strerror(-ret));
+	ret = __gnix_vc_push_tx_reqs(vc);
+	if (ret != FI_SUCCESS)
+		GNIX_WARN(FI_LOG_EP_DATA,
+			  "_gnix_vc_push_tx_reqs returned %s\n",
 			  fi_strerror(-ret));
 
 	return ret;
@@ -1048,6 +1059,12 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 			GNIX_WARN(FI_LOG_EP_CTRL,
 				"_gnix_cm_nic_progress returned %s\n",
 				fi_strerror(-ret));
+
+		ret = __gnix_vc_push_tx_reqs(vc);
+		if (ret != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_EP_DATA,
+				  "_gnix_vc_push_tx_reqs returned %s\n",
+				  fi_strerror(-ret));
 	}
 
 	vc->peer_caps = peer_caps;
@@ -1242,6 +1259,11 @@ static int __gnix_vc_conn_ack_prog_fn(void *data, int *complete_ptr)
 		if (ret != FI_SUCCESS)
 			GNIX_WARN(FI_LOG_EP_DATA,
 				  "_gnix_vc_schedule returned %s\n",
+				  fi_strerror(-ret));
+		ret = __gnix_vc_push_tx_reqs(vc);
+		if (ret != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_EP_DATA,
+				  "_gnix_vc_push_tx_reqs returned %s\n",
 				  fi_strerror(-ret));
 
 	} else if (ret == -FI_EAGAIN) {


### PR DESCRIPTION
It turns out there are certain kGNI datagram exchange
patterns that result in the current GNI provider
CM NIC mechanism not making forward progress when
FI_PROGRESS_AUTO is requested for control progress.

This situation can arise when multiple datagrams
using the same Aries NIC/cookie/cdm_id are being processed
by the progress thread.  The underlying problem is that the
kGNI datagram mechanism only allows one outstanding datagram
for a given target nic/cookie/cdm_id to be posted to the
state engine at a time, and the fact that there is no notification
to the application when a previously posted, bound datagram
transaction completes.  As a consequence, there can be cases where
a process posts a series of connection requests to a target process
with same cookie/cdm_id, that results in the target responding
to the first, then getting GNI_RC_RESOURCE_ERROR for the second because
the first has not completed.

The first response completes, but the progress thread is not woken
up, i.e. does not break out of GNI_PostdataProbeWaitById to progress
the backlog of connection management responses.

We do not see this problem with MPI tests nor simple OpenSHMEM tests
because each process is only using a single endpoint, and thus its
not possible to get this multiple connection requests with same
target aries/cookie/cdm_id.

However we can see this with both shared TXs and with scalable EPs
since in both cases we can have multiple EP's using the same gnix_cm_nic.
Shared TX's are being used in a new version of SOS OpenSHMEM, and
that's where this problem was observed.

One way to fix this problem would be to have a timeout on the
GNI_PostdataProbeWaitById and add a method for the progress thread to progress
backlogged connection management requests.  This has the disadvantage that
we are adding noise by having the progress thread periodically wake up.

In this PR, an alternate solution is implemented where, as part of the general
gnix_cm_nic progress mechanism, we check the connection management request
list regardless of whether the application has requested FI_PROGRESS_AUTO or
not for control progress.

In addressing this issue,  another problem was found with the progression
mechanism.  Namely, we do need to progress the GNI provider state when an
application executes a fi_cq_readerr on a GNI provider CQ.  See the sockets
provider for the correct way to do this.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>