### PR TITLE
prov/gni: Added support for FI_ADDR_STR.

### DIFF
--- a/man/fi_gni.7.md
+++ b/man/fi_gni.7.md
@@ -256,6 +256,13 @@ GNIX_FAB_RQ_NAMO_FAX (Fetch AND and XOR) and GNIX_FAB_RQ_NAMO_FAX_S
 
 #NOTES
 
+The default address format is FI_ADDR_GNI. This is the only address format
+used within the GNI provider for message passing. FI_ADDR_STR is always
+parsed and converted to FI_ADDR_GNI for use within the GNI provider.
+
+*FI_ADDR_STR* is formatted as follows:
+gni;node;service;GNIX_AV_STR_ADDR_VERSION;device_addr;cdm_id;name_type;cm_nic_cdm_id;cookie;rx_ctx_cnt
+
 The GNI provider sets the domain attribute *cntr_cnt* to the the CQ limit divided by 2.
 
 # SEE ALSO

--- a/prov/gni/Makefile.include
+++ b/prov/gni/Makefile.include
@@ -99,6 +99,7 @@ nodist_prov_gni_test_gnitest_SOURCES = \
 	prov/gni/test/dom.c \
 	prov/gni/test/ep.c \
 	prov/gni/test/eq.c \
+	prov/gni/test/fi_addr_str.c \
 	prov/gni/test/freelist.c \
 	prov/gni/test/hashtable.c \
 	prov/gni/test/mr.c \

--- a/prov/gni/gnix.map
+++ b/prov/gni/gnix.map
@@ -39,7 +39,7 @@
 		gnix_listen;
 		gnix_mr_bind;
 		gnix_mr_reg;
-		gnix_passive_ep_open;
+		gnix_pep_open;
 		gnix_pep_bind;
 		gnix_poll_add;
 		gnix_poll_del;

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2017 Cray Inc.  All rights reserved.
- * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2015-2016 Cisco Systems, Inc.  All rights reserved.
  *
@@ -42,6 +42,7 @@
 
 #include <stdlib.h>
 #include <stdbool.h>
+#include <inttypes.h>
 
 #include <rdma/fabric.h>
 #include <rdma/fi_atomic.h>
@@ -326,16 +327,22 @@ struct gnix_ep_name {
 #define GNIX_AV_STR_ADDR_VERSION  1
 
 /*
- * 49 is the number of characters printed out in gnix_av_straddr.
+ * 52 is the number of characters printed out in gnix_av_straddr.
  *  1 is for the null terminator
  */
-#define GNIX_AV_MAX_STR_ADDR_LEN  (49 + 1)
+#define GNIX_AV_MAX_STR_ADDR_LEN  (52 + 1)
 
 /*
  * 15 is the number of characters for the device addr.
  *  1 is for the null terminator
  */
 #define GNIX_AV_MIN_STR_ADDR_LEN  (15 + 1)
+
+/*
+ * 69 is the number of characters for the printable portion of the address
+ *  1 is for the null terminator
+ */
+#define GNIX_FI_ADDR_STR_LEN (69 + 1)
 
 /*
  * enum for blocking/non-blocking progress
@@ -386,6 +393,7 @@ struct gnix_fid_domain {
 	uint8_t ptag;
 	uint32_t cookie;
 	uint32_t cdm_id_seed;
+	uint32_t addr_format;
 	/* user tunable parameters accessed via open_ops functions */
 	struct gnix_ops_domain params;
 	/* additional gni cq modes to use for this domain */
@@ -429,6 +437,7 @@ struct gnix_fid_domain {
 struct gnix_fid_pep {
 	struct fid_pep pep_fid;
 	struct gnix_fid_fabric *fabric;
+	struct fi_info *info;
 	struct gnix_fid_eq *eq;
 	struct gnix_ep_name src_addr;
 	fastlock_t lock;
@@ -654,7 +663,7 @@ struct gnix_fid_stx {
  *
  * @var fid_av          embedded struct fid_stx field
  * @var domain          pointer to domain used to create the av
- * @var type
+ * @var type            the type of the AV, FI_AV_{TABLE,MAP}
  * @var table
  * @var valid_entry_vec
  * @var addrlen
@@ -1115,9 +1124,9 @@ int gnix_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 		   struct fid_ep **ep, void *context);
 
-int gnix_passive_ep_open(struct fid_fabric *fabric,
-			 struct fi_info *info, struct fid_pep **pep,
-			 void *context);
+int gnix_pep_open(struct fid_fabric *fabric,
+		  struct fi_info *info, struct fid_pep **pep,
+		  void *context);
 
 int gnix_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 		 struct fid_eq **eq, void *context);

--- a/prov/gni/include/gnix_ep.h
+++ b/prov/gni/include/gnix_ep.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
- * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -324,9 +324,9 @@ int _gnix_ep_enable(struct gnix_fid_ep *ep_priv);
  * @return -FI_ERRNO	upon an error
  * @return -FI_ENOSYS	if this operation is not supported
  */
-int gnix_passive_ep_open(struct fid_fabric *fabric,
-			 struct fi_info *info, struct fid_pep **pep,
-			 void *context);
+int gnix_pep_open(struct fid_fabric *fabric,
+		  struct fi_info *info, struct fid_pep **pep,
+		  void *context);
 
 int gnix_scalable_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags);
 

--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2017 Cray Inc.  All rights reserved.
- * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -115,6 +115,7 @@ enum gnix_vc_conn_req_type {
  * @var flags                Bitmap used to hold vc schedule state
  * @var peer_irq_mem_hndl    peer GNI memhndl used for delivering
  *                           GNI_PostCqWrite requests to remote peer
+ *
  */
 struct gnix_vc {
 	struct dlist_entry prog_list;	/* NIC VC progress list entry */

--- a/prov/gni/include/rdma/fi_direct_endpoint.h
+++ b/prov/gni/include/rdma/fi_direct_endpoint.h
@@ -40,8 +40,8 @@
 /*******************************************************************************
  * GNI API Functions
  ******************************************************************************/
-extern int gnix_passive_ep_open(struct fid_fabric *fabric, struct fi_info *info,
-				struct fid_pep **pep, void *context);
+extern int gnix_pep_open(struct fid_fabric *fabric, struct fi_info *info,
+			 struct fid_pep **pep, void *context);
 
 extern int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 			struct fid_ep **ep, void *context);
@@ -121,7 +121,7 @@ extern ssize_t gnix_ep_msg_injectdata(struct fid_ep *ep, const void *buf,
 static inline int fi_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 				struct fid_pep **pep, void *context)
 {
-	return gnix_passive_ep_open(fabric, info, pep, context);
+	return gnix_pep_open(fabric, info, pep, context);
 }
 
 static inline int fi_endpoint(struct fid_domain *domain, struct fi_info *info,

--- a/prov/gni/provider_FABRIC_1.0.map
+++ b/prov/gni/provider_FABRIC_1.0.map
@@ -42,7 +42,7 @@
 		gnix_mr_reg;
 		gnix_mr_regv;
 		gnix_mr_regattr;
-		gnix_passive_ep_open;
+		gnix_pep_open;
 		gnix_pep_bind;
 		gnix_poll_add;
 		gnix_poll_del;

--- a/prov/gni/src/gnix_av.c
+++ b/prov/gni/src/gnix_av.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
+ *                         All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -36,13 +37,13 @@
 //
 #include <stdlib.h>
 #include <string.h>
-#include <inttypes.h>
 #include <assert.h>
 
 #include "gnix.h"
 #include "gnix_util.h"
 #include "gnix_hashtable.h"
 #include "gnix_av.h"
+#include "gnix_cm.h"
 
 /*
  * local variables and structs
@@ -155,10 +156,9 @@ static int table_insert(struct gnix_fid_av *av_priv, const void *addr,
 			size_t count, fi_addr_t *fi_addr, uint64_t flags,
 			void *context)
 {
-	struct gnix_ep_name *temp = NULL;
+	struct gnix_ep_name ep_name;
 	int ret = count;
-	size_t index;
-	size_t i;
+	size_t index, i;
 	int *entry_err = context;
 
 	if (gnix_check_capacity(av_priv, count)) {
@@ -166,29 +166,32 @@ static int table_insert(struct gnix_fid_av *av_priv, const void *addr,
 	}
 
 	assert(av_priv->table);
+
 	for (index = av_priv->count, i = 0; i < count; index++, i++) {
-		temp = &((struct gnix_ep_name *)addr)[i];
+		_gnix_get_ep_name(addr, i, &ep_name, av_priv->domain);
 
 		/* check if this ep_name fits in the av context bits */
-		if (temp->name_type & GNIX_EPN_TYPE_SEP) {
-			if ((1 << av_priv->rx_ctx_bits) < temp->rx_ctx_cnt) {
+		if (ep_name.name_type & GNIX_EPN_TYPE_SEP) {
+			if ((1 << av_priv->rx_ctx_bits) < ep_name.rx_ctx_cnt) {
 				if (flags && FI_SYNC_ERR) {
 					entry_err[i] = -FI_EINVAL;
 					fi_addr[i] = FI_ADDR_NOTAVAIL;
 					ret = -FI_EINVAL;
 					continue;
 				}
+				GNIX_DEBUG(FI_LOG_AV, "ep_name doesn't fit "
+					"into the av context bits\n");
 				return -FI_EINVAL;
 			}
 		}
 
-		av_priv->table[index].gnix_addr = temp->gnix_addr;
+		av_priv->table[index].gnix_addr = ep_name.gnix_addr;
 		av_priv->valid_entry_vec[index] = 1;
-		av_priv->table[index].name_type = temp->name_type;
-		av_priv->table[index].cookie = temp->cookie;
-		av_priv->table[index].rx_ctx_cnt = temp->rx_ctx_cnt;
+		av_priv->table[index].name_type = ep_name.name_type;
+		av_priv->table[index].cookie = ep_name.cookie;
+		av_priv->table[index].rx_ctx_cnt = ep_name.rx_ctx_cnt;
 		av_priv->table[index].cm_nic_cdm_id =
-				temp->cm_nic_cdm_id;
+			ep_name.cm_nic_cdm_id;
 		if (fi_addr)
 			fi_addr[i] = index;
 
@@ -300,7 +303,7 @@ static int map_insert(struct gnix_fid_av *av_priv, const void *addr,
 		      void *context)
 {
 	int ret;
-	struct gnix_ep_name *temp = NULL;
+	struct gnix_ep_name ep_name;
 	struct gnix_av_addr_entry *the_entry;
 	gnix_ht_key_t key;
 	size_t i;
@@ -326,30 +329,32 @@ static int map_insert(struct gnix_fid_av *av_priv, const void *addr,
 	slist_insert_tail(&blk->slist, &av_priv->block_list);
 
 	for (i = 0; i < count; i++) {
-		temp = &((struct gnix_ep_name *)addr)[i];
+		_gnix_get_ep_name(addr, i, &ep_name, av_priv->domain);
 
 		/* check if this ep_name fits in the av context bits */
-		if (temp->name_type & GNIX_EPN_TYPE_SEP) {
-			if ((1 << av_priv->rx_ctx_bits) < temp->rx_ctx_cnt) {
+		if (ep_name.name_type & GNIX_EPN_TYPE_SEP) {
+			if ((1 << av_priv->rx_ctx_bits) < ep_name.rx_ctx_cnt) {
 				if (flags && FI_SYNC_ERR) {
 					entry_err[i] = -FI_EINVAL;
 					fi_addr[i] = FI_ADDR_NOTAVAIL;
 					ret_cnt = -FI_EINVAL;
 					continue;
 				}
+				GNIX_DEBUG(FI_LOG_DEBUG, "ep_name doesn't fit "
+					"into the av context bits\n");
 				return -FI_EINVAL;
 			}
 		}
 
-		((struct gnix_address *)fi_addr)[i] = temp->gnix_addr;
+		((struct gnix_address *)fi_addr)[i] = ep_name.gnix_addr;
 		the_entry =  &blk->base[i];
-		memcpy(&the_entry->gnix_addr, &temp->gnix_addr,
+		memcpy(&the_entry->gnix_addr, &ep_name.gnix_addr,
 		       sizeof(struct gnix_address));
-		the_entry->name_type = temp->name_type;
-		the_entry->cm_nic_cdm_id = temp->cm_nic_cdm_id;
-		the_entry->cookie = temp->cookie;
-		the_entry->rx_ctx_cnt = temp->rx_ctx_cnt;
-		memcpy(&key, &temp->gnix_addr, sizeof(gnix_ht_key_t));
+		the_entry->name_type = ep_name.name_type;
+		the_entry->cm_nic_cdm_id = ep_name.cm_nic_cdm_id;
+		the_entry->cookie = ep_name.cookie;
+		the_entry->rx_ctx_cnt = ep_name.rx_ctx_cnt;
+		memcpy(&key, &ep_name.gnix_addr, sizeof(gnix_ht_key_t));
 		ret = _gnix_ht_insert(av_priv->map_ht,
 				      key,
 				      the_entry);
@@ -694,7 +699,20 @@ DIRECT_FN const char *gnix_av_straddr(struct fid_av *av,
 {
 	char int_buf[GNIX_AV_MAX_STR_ADDR_LEN];
 	int size;
-	const struct gnix_ep_name *gnix_ep = addr;
+	struct gnix_ep_name ep_name;
+	struct gnix_fid_av *av_priv;
+
+	if (!av || !addr || !buf || !len) {
+		GNIX_DEBUG(FI_LOG_DEBUG, "NULL parameter in gnix_av_straddr\n");
+		return NULL;
+	}
+
+	av_priv = container_of(av, struct gnix_fid_av, av_fid);
+
+	if (av_priv->domain->addr_format == FI_ADDR_STR)
+		_gnix_resolve_str_ep_name(addr, 0, &ep_name);
+	else
+		ep_name = ((struct gnix_ep_name *) addr)[0];
 
 	/*
 	 * if additional information is added to this string, then
@@ -703,13 +721,14 @@ DIRECT_FN const char *gnix_av_straddr(struct fid_av *av,
 	 *   GNIX_AV_MAX_STR_ADDR_LEN, to be the number of characters printed
 	 */
 	size = snprintf(int_buf, sizeof(int_buf), "%04i:0x%08" PRIx32 ":0x%08"
-			PRIx32 ":%02i:0x%06" PRIx32 ":0x%08" PRIx32,
-			GNIX_AV_STR_ADDR_VERSION,
-			gnix_ep->gnix_addr.device_addr,
-			gnix_ep->gnix_addr.cdm_id,
-			gnix_ep->name_type,
-			gnix_ep->cm_nic_cdm_id,
-			gnix_ep->cookie);
+			PRIx32 ":%02i:0x%06" PRIx32 ":0x%08" PRIx32
+			":%02i", GNIX_AV_STR_ADDR_VERSION,
+			ep_name.gnix_addr.device_addr,
+			ep_name.gnix_addr.cdm_id,
+			ep_name.name_type,
+			ep_name.cm_nic_cdm_id,
+			ep_name.cookie,
+			ep_name.rx_ctx_cnt);
 
 	/*
 	 * snprintf returns the number of character written

--- a/prov/gni/src/gnix_cm.c
+++ b/prov/gni/src/gnix_cm.c
@@ -50,6 +50,189 @@ struct fi_ops gnix_pep_fi_ops;
 struct fi_ops_ep gnix_pep_ops_ep;
 struct fi_ops_cm gnix_pep_ops_cm;
 
+int _gnix_ep_name_to_str(struct gnix_ep_name *ep_name, char **out_buf)
+{
+	char *str;
+	size_t len = GNIX_FI_ADDR_STR_LEN;
+
+	GNIX_TRACE(FI_LOG_TRACE, "\n");
+
+	if (*out_buf == NULL) {
+		str = calloc(len, sizeof(char));
+		if (str == NULL) {
+			GNIX_WARN(FI_LOG_FABRIC, fi_strerror(FI_ENOMEM));
+			return -FI_ENOMEM;
+		}
+	} else {
+		str = *out_buf;
+	}
+
+	/* Convert raw address info to string */
+	snprintf(str, len, "gni;NONE;NONE;%04i;0x%08" PRIx32 ";0x%08" PRIx32
+		";%02i;0x%06" PRIx32 ";0x%08" PRIx32 ";%02i",
+		 GNIX_AV_STR_ADDR_VERSION,
+		 ep_name->gnix_addr.device_addr,
+		 ep_name->gnix_addr.cdm_id,
+		 ep_name->name_type,
+		 ep_name->cm_nic_cdm_id,
+		 ep_name->cookie,
+		 ep_name->rx_ctx_cnt);
+
+	return FI_SUCCESS;
+}
+
+int _gnix_ep_name_from_str(const char *addr,
+			    struct gnix_ep_name *resolved_addr)
+{
+	char *tok, *endptr;
+	int ret;
+	struct gnix_ep_name ep_name;
+	long tok_val;
+	char *dup_addr;
+
+	GNIX_TRACE(FI_LOG_TRACE, "\n");
+
+	if (!addr || !resolved_addr) {
+		GNIX_WARN(FI_LOG_WARN, "NULL parameter in "
+			"__gnix_resolved_name_from_str");
+		return -FI_EINVAL;
+	}
+
+	dup_addr = strdup(addr);
+	if (!dup_addr) {
+		return -FI_ENOMEM;
+	}
+
+	tok = strtok(dup_addr, ";");
+	if (!tok) {
+		GNIX_WARN(FI_LOG_WARN, "Invalid address.\n");
+		return -FI_EINVAL;
+	}
+
+	ret = memcmp(tok, "gni", 3);
+	if (ret) {
+		GNIX_WARN(FI_LOG_WARN, "Invalid address.\n");
+		free(dup_addr);
+		return -FI_EINVAL;
+	}
+
+	tok = strtok(NULL, ";");/*node*/
+	if (!tok) {
+		GNIX_WARN(FI_LOG_WARN, "Invalid address.\n");
+		free(dup_addr);
+		return -FI_EINVAL;
+	}
+
+	tok = strtok(NULL, ";");/*service*/
+	if (!tok) {
+		GNIX_WARN(FI_LOG_WARN, "Invalid address.\n");
+		free(dup_addr);
+		return -FI_EINVAL;
+	}
+
+	tok = strtok(NULL, ";");/*GNIX_AV_STR_ADDR_VERSION*/
+	if (!tok) {
+		GNIX_WARN(FI_LOG_WARN, "Invalid address.\n");
+		free(dup_addr);
+		return -FI_EINVAL;
+	}
+
+	/*device_addr*/
+	tok = strtok(NULL, ";");
+	if (!tok) {
+		GNIX_WARN(FI_LOG_WARN, "Invalid address.\n");
+		free(dup_addr);
+		return -FI_EINVAL;
+	}
+	tok_val = strtol(tok, &endptr, 16);
+	if (*endptr) {
+		GNIX_WARN(FI_LOG_WARN, "Invalid device_addr.\n");
+		free(dup_addr);
+		return -FI_EINVAL;
+	}
+	ep_name.gnix_addr.device_addr = (uint32_t) tok_val;
+
+	/*cdm_id*/
+	tok = strtok(NULL, ";");
+	if (!tok) {
+		GNIX_WARN(FI_LOG_WARN, "Invalid address.\n");
+		free(dup_addr);
+		return -FI_EINVAL;
+	}
+	tok_val = strtol(tok, &endptr, 16);
+	if (*endptr) {
+		GNIX_WARN(FI_LOG_WARN, "Invalid cdm_id.\n");
+		free(dup_addr);
+		return -FI_EINVAL;
+	}
+	ep_name.gnix_addr.cdm_id = (uint32_t) tok_val;
+
+	/*name_type*/
+	tok = strtok(NULL, ";");
+	if (!tok) {
+		GNIX_WARN(FI_LOG_WARN, "Invalid address.\n");
+		free(dup_addr);
+		return -FI_EINVAL;
+	}
+	tok_val = strtol(tok, &endptr, 10);
+	if (*endptr) {
+		GNIX_WARN(FI_LOG_WARN, "Invalid name_type.\n");
+		free(dup_addr);
+		return -FI_EINVAL;
+	}
+	ep_name.name_type = (uint32_t) tok_val;
+
+	/*cm_nic_cdm_id*/
+	tok = strtok(NULL, ";");
+	if (!tok) {
+		GNIX_WARN(FI_LOG_WARN, "Invalid address.\n");
+		free(dup_addr);
+		return -FI_EINVAL;
+	}
+	tok_val = strtol(tok, &endptr, 16);
+	if (*endptr) {
+		GNIX_WARN(FI_LOG_WARN, "Invalid cm_nic_cdm_id.\n");
+		free(dup_addr);
+		return -FI_EINVAL;
+	}
+	ep_name.cm_nic_cdm_id = (uint32_t) tok_val;
+
+	/*cookie*/
+	tok = strtok(NULL, ";");
+	if (!tok) {
+		GNIX_WARN(FI_LOG_WARN, "Invalid address.\n");
+		free(dup_addr);
+		return -FI_EINVAL;
+	}
+	tok_val = strtol(tok, &endptr, 16);
+	if (*endptr) {
+		GNIX_WARN(FI_LOG_WARN, "Invalid cookie.\n");
+		free(dup_addr);
+		return -FI_EINVAL;
+	}
+	ep_name.cookie = (uint32_t) tok_val;
+
+	/*rx_ctx_cnt*/
+	tok = strtok(NULL, ";");
+	if (!tok) {
+		GNIX_WARN(FI_LOG_WARN, "Invalid address.\n");
+		free(dup_addr);
+		return -FI_EINVAL;
+	}
+	tok_val = strtol(tok, &endptr, 10);
+	if (*endptr) {
+		GNIX_WARN(FI_LOG_WARN, "Invalid rx_ctx_cnt.\n");
+		free(dup_addr);
+		return -FI_EINVAL;
+	}
+	ep_name.rx_ctx_cnt = (uint32_t) tok_val;
+
+	*resolved_addr = ep_name;
+	free(dup_addr);
+
+	return FI_SUCCESS;
+}
+
 /******************************************************************************
  *
  * Common CM handling (supported for all types of endpoints).
@@ -62,9 +245,11 @@ struct fi_ops_cm gnix_pep_ops_cm;
  * addrlen: Should indicate the size of the addr buffer. On output will contain
  *     the size necessary to copy the proper address structure.
  *
- * addr: Pointer to memory that will conatin the address structure. Should be
+ * addr: Pointer to memory that will contain the address structure. Should be
  *     allocated and of size addrlen. If addrlen is less than necessary to copy
  *     the proper address structure then addr will contain a truncated address.
+ *     Depending on what hints were used during setup, addr will either be in
+ *     the FI_ADDR_STR or FI_ADDR_GNI format.
  *
  * return: FI_SUCCESS or negative error value.
  */
@@ -73,35 +258,70 @@ DIRECT_FN STATIC int gnix_getname(fid_t fid, void *addr, size_t *addrlen)
 	struct gnix_fid_ep *ep = NULL;
 	struct gnix_fid_sep *sep = NULL;
 	struct gnix_fid_pep *pep = NULL;
-	size_t len;
+	size_t len = 0, cpylen;
+	bool is_fi_addr_str;
+	struct fi_info *info;
+	struct gnix_ep_name *ep_name;
+	int ret;
 
-	if (!addr) {
-		*addrlen = sizeof(struct gnix_ep_name);
-		return -FI_ETOOSMALL;
+	if (unlikely(addrlen == NULL)) {
+		GNIX_WARN(FI_LOG_FABRIC, "parameter \"addrlen\" is NULL in "
+			"gnix_getname\n");
+		return -FI_EINVAL;
 	}
 
-	len = MIN(*addrlen, sizeof(struct gnix_ep_name));
 	switch (fid->fclass) {
 	case FI_CLASS_EP:
 		ep = container_of(fid, struct gnix_fid_ep, ep_fid.fid);
-		memcpy(addr, &ep->src_addr, len);
+		info = ep->info;
+		ep_name = &ep->src_addr;
 		break;
 	case FI_CLASS_SEP:
 		sep = container_of(fid, struct gnix_fid_sep, ep_fid);
-		memcpy(addr, &sep->my_name, len);
+		info = sep->info;
+		ep_name = &sep->my_name;
 		break;
 	case FI_CLASS_PEP:
-		pep = container_of(fid, struct gnix_fid_pep, pep_fid.fid);
-		memcpy(addr, &pep->src_addr, len);
+		pep = container_of(fid, struct gnix_fid_pep,
+				   pep_fid.fid);
+		info = pep->info;
+		ep_name = &pep->src_addr;
 		break;
 	default:
-		GNIX_INFO(FI_LOG_EP_CTRL, "Invalid fid class: %d\n",
+		GNIX_INFO(FI_LOG_EP_CTRL,
+			  "Invalid fid class: %d\n",
 			  fid->fclass);
 		return -FI_EINVAL;
 	}
 
-	*addrlen = sizeof(struct gnix_ep_name);
-	return (len == sizeof(struct gnix_ep_name)) ? 0 : -FI_ETOOSMALL;
+	is_fi_addr_str = info->addr_format == FI_ADDR_STR;
+
+	if (!addr) {
+		if (unlikely(is_fi_addr_str)) {
+			*addrlen = GNIX_FI_ADDR_STR_LEN;
+		} else {
+			*addrlen = sizeof(struct gnix_ep_name);
+		}
+
+		return -FI_ETOOSMALL;
+	}
+
+	if (unlikely(is_fi_addr_str)) {
+		ret = _gnix_ep_name_to_str(ep_name, (char **) &addr);
+
+		if (ret)
+			return ret;
+
+		len = GNIX_FI_ADDR_STR_LEN;
+		cpylen = MIN(len, *addrlen);
+	} else {
+		len = sizeof(struct gnix_ep_name);
+		cpylen = MIN(len, *addrlen);
+		memcpy(addr, ep_name, cpylen);
+	}
+
+	*addrlen = len;
+	return (len == cpylen) ? FI_SUCCESS : -FI_ETOOSMALL;
 }
 
 DIRECT_FN STATIC int gnix_setname(fid_t fid, void *addr, size_t addrlen)
@@ -109,24 +329,36 @@ DIRECT_FN STATIC int gnix_setname(fid_t fid, void *addr, size_t addrlen)
 	struct gnix_fid_ep *ep = NULL;
 	struct gnix_fid_sep *sep = NULL;
 	struct gnix_fid_pep *pep = NULL;
+	struct fi_info *info;
+	struct gnix_ep_name *ep_name;
+	size_t len;
+	int ret;
 
-	if (addrlen != sizeof(struct gnix_ep_name))
+	if (unlikely(addr == NULL)) {
+		GNIX_WARN(FI_LOG_FABRIC, "parameter \"addr\" is NULL in "
+			"gnix_setname\n");
 		return -FI_EINVAL;
+	}
+
+	len = sizeof(struct gnix_ep_name);
 
 	switch (fid->fclass) {
 	case FI_CLASS_EP:
 		ep = container_of(fid, struct gnix_fid_ep, ep_fid.fid);
-		memcpy(&ep->src_addr, addr, sizeof(struct gnix_ep_name));
+		info = ep->info;
+		ep_name = &ep->src_addr;
 		break;
 	case FI_CLASS_SEP:
 		sep = container_of(fid, struct gnix_fid_sep, ep_fid);
-		memcpy(&sep->my_name, addr, sizeof(struct gnix_ep_name));
+		info = sep->info;
+		ep_name = &sep->my_name;
 		break;
 	case FI_CLASS_PEP:
 		pep = container_of(fid, struct gnix_fid_pep, pep_fid.fid);
 		/* TODO: make sure we're unconnected. */
 		pep->bound = 1;
-		memcpy(&pep->src_addr, addr, sizeof(struct gnix_ep_name));
+		info = pep->info;
+		ep_name = &pep->src_addr;
 		break;
 	default:
 		GNIX_INFO(FI_LOG_EP_CTRL, "Invalid fid class: %d\n",
@@ -134,20 +366,80 @@ DIRECT_FN STATIC int gnix_setname(fid_t fid, void *addr, size_t addrlen)
 		return -FI_EINVAL;
 	}
 
-	return 0;
+	if (unlikely(info->addr_format == FI_ADDR_STR)) {
+		len = GNIX_FI_ADDR_STR_LEN;
+
+		if (addrlen != len)
+			return -FI_EINVAL;
+
+		ret = _gnix_ep_name_from_str((const char *) addr,
+					     ep_name);
+
+		if (ret)
+			return ret;
+
+		return FI_SUCCESS;
+	}
+
+	if (addrlen != len)
+		return -FI_EINVAL;
+
+	memcpy(ep_name, addr, len);
+
+	return FI_SUCCESS;
 }
 
 DIRECT_FN STATIC int gnix_getpeer(struct fid_ep *ep, void *addr,
 				  size_t *addrlen)
 {
 	struct gnix_fid_ep *ep_priv = NULL;
-	size_t len;
+	struct gnix_fid_sep *sep_priv = NULL;
+	struct gnix_ep_name *ep_name = NULL;
+	size_t len = 0, cpylen = 0;
+	struct fi_info *info = NULL;
+	int ret;
 
-	len = MIN(*addrlen, sizeof(struct gnix_ep_name));
-	ep_priv = container_of(ep, struct gnix_fid_ep, ep_fid.fid);
-	memcpy(addr, &ep_priv->dest_addr, len);
-	*addrlen = sizeof(struct gnix_ep_name);
-	return (len == sizeof(struct gnix_ep_name)) ? 0 : -FI_ETOOSMALL;
+	if (unlikely(addrlen == NULL || addr == NULL)) {
+		GNIX_WARN(FI_LOG_FABRIC, "parameter is NULL in gnix_getpeer\n");
+		return -FI_EINVAL;
+	}
+
+	switch (ep->fid.fclass) {
+	case FI_CLASS_EP:
+		ep_priv = container_of(ep, struct gnix_fid_ep, ep_fid.fid);
+		info = ep_priv->info;
+		ep_name = &ep_priv->dest_addr;
+		break;
+
+	case FI_CLASS_SEP:
+		sep_priv = container_of(ep, struct gnix_fid_sep, ep_fid);
+		info = sep_priv->info;
+		ep_name = info->dest_addr;
+		break;
+
+	default:
+		GNIX_INFO(FI_LOG_EP_CTRL, "Invalid fid class: %d\n",
+			  ep->fid.fclass);
+			return -FI_EINVAL;
+	}
+
+	if (info->addr_format == FI_ADDR_STR) {
+		ret = _gnix_ep_name_to_str(ep_name, (char **) &addr);
+
+		if (ret)
+			return ret;
+
+		len = GNIX_FI_ADDR_STR_LEN;
+		cpylen = MIN(len, *addrlen);
+	} else {
+		len = sizeof(struct gnix_ep_name);
+		cpylen = MIN(len, *addrlen);
+		memcpy(addr, ep_name, cpylen);
+	}
+
+	*addrlen = len;
+
+	return (len == cpylen) ? FI_SUCCESS : -FI_ETOOSMALL;
 }
 
 struct fi_ops_cm gnix_ep_ops_cm = {
@@ -955,12 +1247,13 @@ DIRECT_FN STATIC int gnix_reject(struct fid_pep *pep, fid_t handle,
 	return FI_SUCCESS;
 }
 
-DIRECT_FN int gnix_passive_ep_open(struct fid_fabric *fabric,
-				   struct fi_info *info, struct fid_pep **pep,
-				   void *context)
+DIRECT_FN int gnix_pep_open(struct fid_fabric *fabric,
+			    struct fi_info *info, struct fid_pep **pep,
+			    void *context)
 {
 	struct gnix_fid_fabric *fabric_priv;
 	struct gnix_fid_pep *pep_priv;
+	struct gnix_ep_name *ep_name;
 
 	if (!fabric || !info || !pep)
 		return -FI_EINVAL;
@@ -977,17 +1270,23 @@ DIRECT_FN int gnix_passive_ep_open(struct fid_fabric *fabric,
 	pep_priv->pep_fid.fid.ops = &gnix_pep_fi_ops;
 	pep_priv->pep_fid.ops = &gnix_pep_ops_ep;
 	pep_priv->pep_fid.cm = &gnix_pep_ops_cm;
+	pep_priv->fabric = fabric_priv;
+	pep_priv->info = fi_dupinfo(info);
+	pep_priv->info->addr_format = info->addr_format;
 
 	pep_priv->listen_fd = -1;
 	pep_priv->backlog = 5; /* TODO set via fi_control parameter. */
-	pep_priv->fabric = fabric_priv;
 	fastlock_init(&pep_priv->lock);
+
 	if (info->src_addr) {
+		ep_name = info->src_addr;
+		info->src_addrlen = sizeof(struct sockaddr_in);
+
 		pep_priv->bound = 1;
-		memcpy(&pep_priv->src_addr, info->src_addr,
-		       sizeof(struct sockaddr_in));
-	} else
+		memcpy(&pep_priv->src_addr, ep_name, info->src_addrlen);
+	} else {
 		pep_priv->bound = 0;
+	}
 
 	_gnix_ref_init(&pep_priv->ref_cnt, 1, __pep_destruct);
 

--- a/prov/gni/src/gnix_cm_nic.c
+++ b/prov/gni/src/gnix_cm_nic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
@@ -42,6 +42,7 @@
 #include "gnix.h"
 #include "gnix_datagram.h"
 #include "gnix_cm_nic.h"
+#include "gnix_cm.h"
 #include "gnix_nic.h"
 #include "gnix_hashtable.h"
 
@@ -582,6 +583,7 @@ int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 	gnix_hashtable_attr_t gnix_ht_attr = {0};
 	uint32_t name_type = GNIX_EPN_TYPE_UNBOUND;
 	struct gnix_nic_attr nic_attr = {0};
+	struct gnix_ep_name ep_name;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
@@ -595,10 +597,10 @@ int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 	 * and just use it.
 	 */
 
-	if (info->src_addr &&
-	    info->src_addrlen == sizeof(struct gnix_ep_name)) {
-		name_type = ((struct gnix_ep_name *)(info->src_addr))->
-								name_type;
+	if (info->src_addr) {
+		/*TODO (optimization): strchr to name_type and strtol */
+		_gnix_get_ep_name(info->src_addr, 0, &ep_name, domain);
+		name_type = ep_name.name_type;
 	}
 
 	GNIX_INFO(FI_LOG_EP_CTRL, "creating cm_nic for %u/0x%x/%u\n",

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
@@ -607,6 +607,7 @@ DIRECT_FN int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	domain->ptag = ptag;
 	domain->cookie = cookie;
 	domain->cdm_id_seed = getpid();  /* TODO: direct syscall better */
+	domain->addr_format = info->addr_format;
 
 	/* user tunables */
 	domain->params.msg_rendezvous_thresh = default_msg_rendezvous_thresh;
@@ -688,7 +689,7 @@ static struct fi_ops_mr gnix_domain_mr_ops = {
 	.size = sizeof(struct fi_ops_mr),
 	.reg = gnix_mr_reg,
 	.regv = gnix_mr_regv,
-	.regattr = gnix_mr_regattr, 
+	.regattr = gnix_mr_regattr,
 };
 
 static struct fi_ops_domain gnix_domain_ops = {

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
- * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -1054,8 +1054,8 @@ __gnix_fabric_ops_native_amo(struct fid_ep *ep, const void *buf, size_t count,
 
 	if (!ep)
 		return -FI_EINVAL;
-	if ((req_type < 0) || (req_type > GNIX_FAB_RQ_MAX_TYPES) || 
-		(req_type >= GNIX_FAB_RQ_END_NON_NATIVE && 
+	if ((req_type < 0) || (req_type > GNIX_FAB_RQ_MAX_TYPES) ||
+		(req_type >= GNIX_FAB_RQ_END_NON_NATIVE &&
 		 req_type < GNIX_FAB_RQ_START_NATIVE))
 		return -FI_EINVAL;
 
@@ -1991,8 +1991,6 @@ static int _gnix_ep_nic_init(struct gnix_fid_domain *domain,
 
 	name = (struct gnix_ep_name *)info->src_addr;
 	if (name && name->name_type == GNIX_EPN_TYPE_BOUND) {
-		name = (struct gnix_ep_name *)info->src_addr;
-
 		/* Endpoint was bound to a specific source address.  Create a
 		 * new CM NIC to listen on this address. */
 		ret = _gnix_cm_nic_alloc(domain, info, name->gnix_addr.cdm_id,
@@ -2178,16 +2176,21 @@ DIRECT_FN int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 	ep_priv->requires_lock = (domain_priv->thread_model !=
 				  FI_THREAD_COMPLETION);
 	ep_priv->info = fi_dupinfo(info);
+	ep_priv->info->addr_format = info->addr_format;
 
-	if (ep_priv->info->src_addr)
-		memcpy(&ep_priv->src_addr,
-		       ep_priv->info->src_addr,
-		       sizeof(struct gnix_ep_name));
+	GNIX_DEBUG(FI_LOG_DEBUG, "ep(%p) is using addr_format(%s)\n", ep_priv,
+		  ep_priv->info->addr_format == FI_ADDR_STR ? "FI_ADDR_STR" :
+		  "FI_ADDR_GNI");
 
-	if (ep_priv->info->dest_addr)
-		memcpy(&ep_priv->dest_addr,
-		       ep_priv->info->dest_addr,
+	if (info->src_addr) {
+		memcpy(&ep_priv->src_addr, info->src_addr,
 		       sizeof(struct gnix_ep_name));
+	}
+
+	if (info->dest_addr) {
+		memcpy(&ep_priv->dest_addr, info->dest_addr,
+		       sizeof(struct gnix_ep_name));
+	}
 
 	ret = __init_tag_storages(ep_priv, GNIX_TAG_LIST,
 				  ep_priv->type == FI_EP_MSG ? 0 : 1);

--- a/prov/gni/src/gnix_sep.c
+++ b/prov/gni/src/gnix_sep.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2016 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2016-2017 Los Alamos National Security, LLC.
+ *                         All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -742,6 +743,7 @@ int gnix_sep_open(struct fid_domain *domain, struct fi_info *info,
 	sep_priv->domain = domain;
 
 	sep_priv->info = fi_dupinfo(info);
+	sep_priv->info->addr_format = info->addr_format;
 	if (!sep_priv->info) {
 		GNIX_WARN(FI_LOG_EP_CTRL,
 			    "fi_dupinfo NULL\n");
@@ -783,9 +785,8 @@ int gnix_sep_open(struct fid_domain *domain, struct fi_info *info,
 	 * via a node/service option to fi_getinfo
 	 */
 
-	if ((info->src_addr != NULL) &&
-		info->src_addrlen == sizeof(struct gnix_ep_name)) {
-		name = (struct gnix_ep_name *)info->src_addr;
+	if (info->src_addr != NULL) {
+		name = (struct gnix_ep_name *) info->src_addr;
 
 		if (name->name_type & GNIX_EPN_TYPE_BOUND) {
 			cdm_id_base = name->gnix_addr.cdm_id;
@@ -811,7 +812,7 @@ int gnix_sep_open(struct fid_domain *domain, struct fi_info *info,
 	 * allocate cm_nic for this SEP
 	 */
 	ret = _gnix_cm_nic_alloc(domain_priv,
-				 info,
+				 sep_priv->info,
 				 cdm_id,
 				 &sep_priv->cm_nic);
 	if (ret != FI_SUCCESS) {

--- a/prov/gni/src/gnix_util.c
+++ b/prov/gni/src/gnix_util.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014 Intel Corporation, Inc.  All rights reserved.
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
+ *                         All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -393,6 +394,8 @@ static int __gnix_app_init(void)
 int gnixu_get_rdma_credentials(void *addr, uint8_t *ptag, uint32_t *cookie)
 {
 	int ret = FI_SUCCESS;
+
+	/*TODO: If addr is used, ensure that ep->info->addr_format is checked*/
 
 	if ((ptag == NULL) || (cookie == NULL)) {
 		return -FI_EINVAL;

--- a/prov/gni/test/av.c
+++ b/prov/gni/test/av.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
+ *                         All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc.  All rights reserved.
  * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  *
@@ -890,6 +891,16 @@ static void straddr_test(void)
 
 	/* verify the cookie has been returned. */
 	cr_assert_eq(simple_ep_names[0].cookie, value, "Invalid cookie");
+
+	/* extract the seventh component */
+	buf = strtok(NULL, ":");
+	cr_assert_not_null(buf, "number of contexts not found");
+
+	value = strtol(buf, &pend, 10);
+
+	/* verify the rx_ctx_cnt has been returned. */
+	cr_assert_eq(simple_ep_names[0].rx_ctx_cnt, value,
+		     "Invalid number of contexts");
 
 	/* check to see if additional component are specified */
 	buf = strtok(NULL, ":");

--- a/prov/gni/test/fi_addr_str.c
+++ b/prov/gni/test/fi_addr_str.c
@@ -1,0 +1,1693 @@
+/*
+ * Copyright (c) 2017 Los Alamos National Security, LLC. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <getopt.h>
+#include <poll.h>
+#include <time.h>
+#include <string.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <limits.h>
+#include <assert.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <inttypes.h>
+
+#include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+#include "fi_ext_gni.h"
+#include "gnix.h"
+#include "common.h"
+
+#if 1
+#define dbg_printf(...)
+#else
+#define dbg_printf(...)                                \
+	do {                                        \
+		printf(__VA_ARGS__);                \
+		fflush(stdout);                        \
+	} while (0)
+#endif
+
+#define NUMEPS 2
+#define NUMCONTEXTS (NUMEPS * 2)
+
+static struct fid_fabric *fab;
+static struct fid_domain *dom[NUMEPS];
+static struct fi_gni_ops_domain *gni_domain_ops[NUMEPS];
+
+static struct fid_ep *ep[NUMEPS];
+static struct fid_pep *pep[NUMEPS];
+static struct fid_ep **tx_ep[NUMEPS], **rx_ep[NUMEPS];
+static struct fid_cq **tx_cq[NUMEPS];
+static struct fid_cq **rx_cq[NUMEPS];
+static struct fid_av *av[NUMEPS];
+static struct fid_cq *msg_cq[NUMEPS];
+static fi_addr_t gni_addr[NUMEPS];
+static struct fi_info *fi[NUMEPS];
+static struct fi_info *hints;
+
+static struct fi_cq_attr cq_attr;
+static struct fi_av_attr attr;
+
+static void *ep_name[NUMEPS];
+static size_t ep_name_len[NUMEPS];
+
+#define BUF_SZ (1<<15)
+static char *target[NUMEPS];
+static char *source[NUMEPS];
+
+static struct fid_cntr *send_cntr[NUMEPS], *recv_cntr[NUMEPS];
+static struct fi_cntr_attr cntr_attr = {
+	.events = FI_CNTR_EVENTS_COMP,
+	.flags = 0
+};
+static uint64_t sends[NUMEPS] = {0}, recvs[NUMEPS] = {0};
+
+
+static bool use_str_fmt = true;
+static enum ep_type_e {
+	EP, PEP, SEP
+} ep_type;
+
+static fid_t (*get_fid[3])(int);
+
+static int ctx_cnt;
+
+/******************************************************************************
+* Begin help routines
+******************************************************************************/
+static fid_t get_ep_fid(int i)
+{
+	return &ep[i]->fid;
+}
+
+static fid_t get_pep_fid(int i)
+{
+	return &pep[i]->fid;
+}
+
+static fid_t get_sep_fid(int i)
+{
+	return get_ep_fid(i);
+}
+
+struct fid_ep *get_fid_ep(int i, void **info, void **dest_addr,
+			  void **src_addr)
+{
+	struct gnix_fid_ep *ep = NULL;
+	struct gnix_fid_sep *sep = NULL;
+	struct gnix_fid_pep *pep = NULL;
+
+	switch (ep_type) {
+	case EP:
+		ep = container_of(get_fid[ep_type](i),
+				  struct gnix_fid_ep,
+				  ep_fid.fid);
+		if (info)
+			*info = (void *) ep->info;
+		if (dest_addr)
+			*dest_addr = (void *) &ep->dest_addr;
+		if (src_addr)
+			*src_addr = (void *) &ep->src_addr;
+
+		return &ep->ep_fid;
+	case SEP:
+		sep = container_of(get_fid[ep_type](i),
+				   struct gnix_fid_sep,
+				   ep_fid);
+		if (info)
+			*info = (void *) sep->info;
+		if (dest_addr) {
+			if (!sep->info->dest_addr) {
+				sep->info->dest_addr = malloc
+					(sep->info->dest_addrlen);
+				cr_assert(sep->info->dest_addr, "malloc "
+					"failed");
+			}
+			*dest_addr = sep->info->dest_addr;
+		}
+		if (src_addr)
+			*src_addr = (void *) &sep->my_name;
+
+		return &sep->ep_fid;
+	case PEP:
+		pep = container_of(get_fid[ep_type](i),
+				   struct gnix_fid_pep,
+				   pep_fid.fid);
+		if (info)
+			*info = (void *) pep->info;
+		if (dest_addr)
+			*dest_addr = pep->info->dest_addr;
+		if (src_addr)
+			*src_addr = (void *) &pep->src_addr;
+		break;
+	default:
+		cr_assert_fail("Unknown endpoint type.");
+	}
+
+	return NULL;
+}
+
+/*
+ * FI_ADDR_STR; "gni;NODE;SERVICE;GNIX_AV_STR_ADD_VERSION;device_addr;cdm_id;
+ * name_type;cm_nic_cdm_id;cookie;rx_ctx_cnt
+ */
+int generate_rand_fas(char **node)
+{
+	char rand_str[GNIX_FI_ADDR_STR_LEN] = {0};
+	char byte;
+	size_t nbytes;
+
+	if (node) {
+		/*gni:3*/
+		sprintf(rand_str, "gni;");
+
+		/*node:[0-9]+*/
+		byte = (rand() % ('Z' - 'A')) + 'A';
+		nbytes = 4;
+		memset(rand_str + strlen(rand_str), byte, nbytes);
+		rand_str[strlen(rand_str)] = ';';
+		dbg_printf(BLUE "rand_str = %s\n" COLOR_RESET, rand_str);
+
+		/*service:[0-9]+*/
+		byte = (rand() % ('Z' - 'A')) + 'A';
+		nbytes = 4;
+		memset(rand_str + strlen(rand_str), byte, nbytes);
+		rand_str[strlen(rand_str)] = ';';
+		dbg_printf(BLUE "rand_str = %s\n" COLOR_RESET, rand_str);
+
+		/*GNIX_AV_STR_ADDR_VERSION:4*/
+		sprintf(rand_str + strlen(rand_str), "%04i",
+			GNIX_AV_STR_ADDR_VERSION);
+		rand_str[strlen(rand_str)] = ';';
+		dbg_printf(BLUE "rand_str = %s\n" COLOR_RESET, rand_str);
+
+		/*device_addr:10*/
+		byte = (rand() % 10) + '0';
+		nbytes = 8;
+		sprintf(rand_str + strlen(rand_str), "0x");
+		memset(rand_str + strlen(rand_str), byte, nbytes);
+		rand_str[strlen(rand_str)] = ';';
+		dbg_printf(BLUE "rand_str = %s\n" COLOR_RESET, rand_str);
+
+		/*cdm_id:10*/
+		byte = (rand() % 10) + '0';
+		nbytes = 8;
+		sprintf(rand_str + strlen(rand_str), "0x");
+		memset(rand_str + strlen(rand_str), byte, nbytes);
+		rand_str[strlen(rand_str)] = ';';
+		dbg_printf(BLUE "rand_str = %s\n" COLOR_RESET, rand_str);
+
+		/*name_type:2*/
+		byte = (rand() % ('9' - '0')) + '0';
+		nbytes = 2;
+		memset(rand_str + strlen(rand_str), byte, nbytes);
+		rand_str[strlen(rand_str)] = ';';
+		dbg_printf(BLUE "rand_str = %s\n" COLOR_RESET, rand_str);
+
+		/*cm_nic_cdm_id:8*/
+		byte = (rand() % 10) + '0';
+		nbytes = 6;
+		sprintf(rand_str + strlen(rand_str), "0x");
+		memset(rand_str + strlen(rand_str), byte, nbytes);
+		rand_str[strlen(rand_str)] = ';';
+		dbg_printf(BLUE "rand_str = %s\n" COLOR_RESET, rand_str);
+
+		/*cookie:10*/
+		byte = (rand() % 10) + '0';
+		nbytes = 8;
+		sprintf(rand_str + strlen(rand_str), "0x");
+		memset(rand_str + strlen(rand_str), byte, nbytes);
+		rand_str[strlen(rand_str)] = ';';
+		dbg_printf(BLUE "rand_str = %s\n" COLOR_RESET, rand_str);
+
+		/*rx_ctx_cnt:3*/
+		byte = (rand() % 10) + '0';
+		nbytes = 3;
+		memset(rand_str + strlen(rand_str), byte, nbytes);
+		dbg_printf(BLUE "rand_str = %s\n" COLOR_RESET, rand_str);
+
+		sprintf(node[0], rand_str);
+	}
+	return 0;
+}
+/******************************************************************************
+* End help routines
+******************************************************************************/
+
+/******************************************************************************
+* Begin setup routines
+******************************************************************************/
+static void fas_setup_common(uint32_t version)
+{
+	int i, ret;
+
+	srand(time(NULL));
+
+	get_fid[EP]  = get_ep_fid;
+	get_fid[PEP] = get_pep_fid;
+	get_fid[SEP] = get_sep_fid;
+
+	/* This is sufficient for verifying FI_ADDR_STR with seps */
+	ctx_cnt = 1;
+
+	hints = fi_allocinfo();
+	cr_assert(hints, "fi_allocinfo");
+
+	hints->domain_attr->cq_data_size = NUMEPS * 2;
+	hints->domain_attr->data_progress = FI_PROGRESS_AUTO;
+	hints->domain_attr->control_progress = FI_PROGRESS_AUTO;
+	hints->mode = ~0;
+	hints->fabric_attr->prov_name = strdup("gni");
+	hints->addr_format = use_str_fmt ? FI_ADDR_STR : FI_ADDR_GNI;
+	if (ep_type == SEP) {
+		hints->ep_attr->tx_ctx_cnt = NUMCONTEXTS;
+		hints->ep_attr->rx_ctx_cnt = NUMCONTEXTS;
+	}
+
+	/* Get info about fabric services with the provided hints */
+	for (i = 0; i < NUMEPS; i++) {
+		ret = fi_getinfo(version, NULL, 0, 0, hints,
+				 &fi[i]);
+		cr_assert(!ret, "fi_getinfo returned: %s", fi_strerror(-ret));
+
+		tx_cq[i] = calloc(ctx_cnt, sizeof(*tx_cq));
+		rx_cq[i] = calloc(ctx_cnt, sizeof(*rx_cq));
+		tx_ep[i] = calloc(ctx_cnt, sizeof(*tx_ep));
+		rx_ep[i] = calloc(ctx_cnt, sizeof(*rx_ep));
+	}
+
+	memset(&attr, 0, sizeof(attr));
+	attr.rx_ctx_bits = ctx_cnt;
+	attr.count = NUMEPS;
+
+	cq_attr.format = FI_CQ_FORMAT_TAGGED;
+	cq_attr.size = 1024;
+	cq_attr.wait_obj = 0;
+
+	for (i = 0; i < NUMEPS; i++) {
+		target[i] = malloc(BUF_SZ);
+		cr_assert(target[i], "malloc returned: %s", strerror(errno));
+
+		source[i] = malloc(BUF_SZ);
+		cr_assert(source[i], "malloc returned: %s", strerror(errno));
+	}
+
+	ret = fi_fabric(fi[0]->fabric_attr, &fab, NULL);
+	cr_assert(!ret, "fi_fabric returned: %s", fi_strerror(-ret));
+}
+
+static void fas_ep_setup(void)
+{
+	int ret, i, j;
+	size_t addrlen = 0;
+
+	fas_setup_common(fi_version());
+	ctx_cnt = MIN(ctx_cnt, fi[0]->domain_attr->rx_ctx_cnt);
+	ctx_cnt = MIN(ctx_cnt, fi[0]->domain_attr->tx_ctx_cnt);
+
+	for (i = 0; i < NUMEPS; i++) {
+		fi[i]->ep_attr->tx_ctx_cnt = ctx_cnt;
+		fi[i]->ep_attr->rx_ctx_cnt = ctx_cnt;
+
+		ret = fi_domain(fab, fi[i], dom + i, NULL);
+		cr_assert(!ret, "fi_domain returned: %s", fi_strerror(-ret));
+
+		ret = fi_open_ops(&dom[i]->fid, FI_GNI_DOMAIN_OPS_1,
+				  0, (void **) (gni_domain_ops + i), NULL);
+		cr_assert(ret == FI_SUCCESS, "fi_ops_open returned: %s",
+			  fi_strerror(-ret));
+
+		ret = fi_cntr_open(dom[i], &cntr_attr, send_cntr + i, 0);
+		cr_assert(!ret, "fi_cntr_open returned: %s", fi_strerror(-ret));
+
+		ret = fi_cntr_open(dom[i], &cntr_attr, recv_cntr + i, 0);
+		cr_assert(!ret, "fi_cntr_open returned: %s", fi_strerror(-ret));
+
+		switch (ep_type) {
+		case EP:
+			ret = fi_endpoint(dom[i], fi[i], ep + i, NULL);
+			cr_assert(!ret, "fi_endpoint returned: %s",
+				  fi_strerror(-ret));
+			break;
+		case SEP:
+			ret = fi_scalable_ep(dom[i], fi[i], ep + i,
+					     NULL);
+			cr_assert(!ret, "fi_endpoint returned: %s",
+				  fi_strerror(-ret));
+			break;
+		case PEP:
+			ret = fi_passive_ep(fab, fi[i], pep + i,
+					    NULL);
+			cr_assert(!ret, "fi_endpoint returned: %s",
+				  fi_strerror(-ret));
+			ret = fi_getname(get_fid[ep_type](i), NULL,
+					 &addrlen);
+			if (use_str_fmt) {
+				cr_assert(addrlen == GNIX_FI_ADDR_STR_LEN,
+					  "fi_getname returned: %s",
+					  fi_strerror(-ret));
+			} else {
+				cr_assert(addrlen ==
+					  sizeof(struct gnix_ep_name),
+					  "fi_getname returned: %s",
+					  fi_strerror(-ret));
+			}
+			ep_name_len[i] = addrlen;
+			continue;
+		default:
+			cr_assert_fail("Unknown endpoint type.");
+		}
+
+		ret = fi_av_open(dom[i], &attr, av + i, NULL);
+		cr_assert(!ret, "fi_av_open returned: %s", fi_strerror(-ret));
+
+		switch (ep_type) {
+		case EP:
+		case PEP:
+			ret = fi_cq_open(dom[i], &cq_attr, msg_cq + i,
+					 0);
+			cr_assert(!ret, "fi_cq_open returned: %s",
+				  fi_strerror(-ret));
+
+			ret = fi_ep_bind(ep[i], &msg_cq[i]->fid,
+					 FI_SEND | FI_RECV);
+			cr_assert(!ret, "fi_ep_bind returned: %s",
+				  fi_strerror(-ret));
+			break;
+		case SEP:
+			dbg_printf(BLUE
+					   "ctx_cnt = %d\n"
+					   COLOR_RESET,
+				   ctx_cnt);
+
+			for (j = 0; j < ctx_cnt; j++) {
+				ret = fi_tx_context(ep[i], j, NULL,
+						    &tx_ep[i][j], NULL);
+				cr_assert(!ret,
+					  "fi_tx_context  returned: %s",
+					  fi_strerror(-ret));
+
+				ret = fi_cq_open(dom[i], &cq_attr,
+						 &tx_cq[i][j],
+						 NULL);
+				cr_assert(!ret,
+					  "fi_cq_open  returned: %s",
+					  fi_strerror(-ret));
+
+				ret = fi_rx_context(ep[i], j, NULL,
+						    &rx_ep[i][j], NULL);
+				cr_assert(!ret,
+					  "fi_rx_context  returned: %s",
+					  fi_strerror(-ret));
+
+				ret = fi_cq_open(dom[i], &cq_attr,
+						 &rx_cq[i][j],
+						 NULL);
+				cr_assert(!ret,
+					  "fi_cq_open  returned: %s",
+					  fi_strerror(-ret));
+			}
+			break;
+		default:
+			cr_assert_fail("Unknown endpoint type.");
+		}
+
+		ret = fi_getname(get_fid[ep_type](i), NULL, &addrlen);
+		if (use_str_fmt) {
+			cr_assert(addrlen > sizeof(struct gnix_ep_name),
+				  "fi_getname returned: %s",
+				  fi_strerror(-ret));
+		} else {
+			cr_assert(addrlen == sizeof(struct gnix_ep_name),
+				  "fi_getname returned: %s",
+				  fi_strerror(-ret));
+		}
+
+		ep_name[i] = malloc(addrlen);
+		ep_name_len[i] = addrlen;
+
+		dbg_printf(BLUE
+				   "ep_name_len[%d] = %lu\n"
+				   COLOR_RESET, i,
+			   ep_name_len[i]);
+		cr_assert(ep_name[i] != NULL, "malloc returned: %s",
+			  strerror(errno));
+
+		ret = fi_getname(get_fid[ep_type](i), ep_name[i], &addrlen);
+		cr_assert(ret == FI_SUCCESS, "fi_getname returned: %s",
+			  fi_strerror(-ret));
+	}
+
+	/* Just testing setname / getname for passive endpoints */
+	if (ep_type == PEP)
+		return;
+
+	for (i = 0; i < NUMEPS; i++) {
+		/*Insert all gni addresses into each av*/
+		for (j = 0; j < NUMEPS; j++) {
+			ret = fi_av_insert(av[i], ep_name[j], 1, &gni_addr[j],
+					   0, NULL);
+			cr_assert(ret == 1, "fi_av_insert returned: %s",
+				  fi_strerror(-ret));
+		}
+
+		switch (ep_type) {
+		case EP:
+			ret = fi_ep_bind(ep[i], &av[i]->fid, 0);
+			cr_assert(!ret, "fi_ep_bind returned: %s",
+				  fi_strerror(-ret));
+
+			ret = fi_ep_bind(ep[i], &send_cntr[i]->fid,
+					 FI_SEND);
+			cr_assert(!ret, "fi_ep_bind returned: %s",
+				  fi_strerror(-ret));
+
+			ret = fi_ep_bind(ep[i], &recv_cntr[i]->fid,
+					 FI_RECV);
+			cr_assert(!ret, "fi_ep_bind returned: %s",
+				  fi_strerror(-ret));
+			break;
+		case SEP:
+			ret = fi_scalable_ep_bind(ep[i], &av[i]->fid,
+						  0);
+			cr_assert(!ret,
+				  "fi_scalable_ep_bind returned: %s",
+				  fi_strerror(-ret));
+			dbg_printf(BLUE
+					   "ctx_cnt = %d\n"
+					   COLOR_RESET,
+				   ctx_cnt);
+			for (j = 0; j < ctx_cnt; j++) {
+				ret = fi_ep_bind(tx_ep[i][j],
+						 &tx_cq[i][j]->fid,
+						 FI_TRANSMIT);
+				cr_assert(!ret,
+					  "fi_ep_bind  returned: %s",
+					  fi_strerror(-ret));
+
+				ret = fi_ep_bind(tx_ep[i][j],
+						 &send_cntr[i]->fid,
+						 FI_SEND);
+				cr_assert(!ret,
+					  "fi_ep_bind  returned: %s",
+					  fi_strerror(-ret));
+
+				ret = fi_enable(tx_ep[i][j]);
+				cr_assert(!ret,
+					  "fi_enable  returned: %s",
+					  fi_strerror(-ret));
+
+				ret = fi_ep_bind(rx_ep[i][j],
+						 &rx_cq[i][j]->fid,
+						 FI_RECV);
+				cr_assert(!ret,
+					  "fi_ep_bind  returned: %s",
+					  fi_strerror(-ret));
+
+				ret = fi_ep_bind(rx_ep[i][j],
+						 &recv_cntr[i]->fid,
+						 FI_RECV);
+				cr_assert(!ret,
+					  "fi_ep_bind  returned: %s",
+					  fi_strerror(-ret));
+
+				ret = fi_enable(rx_ep[i][j]);
+				cr_assert(!ret,
+					  "fi_enable  returned: %s",
+					  fi_strerror(-ret));
+
+			}
+			break;
+		case PEP:
+			break;
+		default:
+			cr_assert_fail("Unknown endpoint type.");
+		}
+
+		ret = fi_enable(ep[i]);
+		cr_assert(!ret, "fi_ep_enable returned: %s", fi_strerror(-ret));
+
+		if (ep_type != SEP) {
+			ret = fi_enable(ep[i]);
+			cr_assert_eq(ret, -FI_EOPBADSTATE,
+				     "fi_enable returned: %s",
+				     fi_strerror(-ret));
+		}
+	}
+}
+
+static void fas_getinfo_setup(void)
+{
+	srand(time(NULL));
+
+	hints = fi_allocinfo();
+	cr_assert(hints, "fi_allocinfo");
+
+	hints->domain_attr->cq_data_size = NUMEPS * 2;
+	hints->domain_attr->data_progress = FI_PROGRESS_AUTO;
+	hints->domain_attr->control_progress = FI_PROGRESS_AUTO;
+	hints->mode = ~0;
+	hints->fabric_attr->prov_name = strdup("gni");
+	hints->addr_format = use_str_fmt ? FI_ADDR_STR : FI_ADDR_GNI;
+}
+
+static void fas_getinfo_teardown(void)
+{
+	fi_freeinfo(hints);
+}
+
+static void fas_ep_setup_gni_fmt_av_map(void)
+{
+	use_str_fmt = false;
+	ep_type = EP;
+	attr.type = FI_AV_MAP;
+
+	fas_ep_setup();
+}
+
+static void fas_ep_setup_str_fmt_av_map(void)
+{
+	use_str_fmt = true;
+	ep_type = EP;
+	attr.type = FI_AV_MAP;
+
+	fas_ep_setup();
+}
+
+static void fas_sep_setup_gni_fmt_av_map(void)
+{
+	use_str_fmt = false;
+	ep_type = SEP;
+	attr.type = FI_AV_MAP;
+
+	fas_ep_setup();
+}
+
+static void fas_sep_setup_str_fmt_av_map(void)
+{
+	use_str_fmt = true;
+	ep_type = SEP;
+	attr.type = FI_AV_MAP;
+
+	fas_ep_setup();
+}
+
+static void fas_pep_setup_gni_fmt_av_map(void)
+{
+	use_str_fmt = false;
+	ep_type = PEP;
+	attr.type = FI_AV_MAP;
+
+	fas_ep_setup();
+}
+
+static void fas_pep_setup_str_fmt_av_map(void)
+{
+	use_str_fmt = true;
+	ep_type = PEP;
+	attr.type = FI_AV_MAP;
+
+	fas_ep_setup();
+}
+
+static void fas_ep_setup_gni_fmt_av_tbl(void)
+{
+	use_str_fmt = false;
+	ep_type = EP;
+	attr.type = FI_AV_TABLE;
+
+	fas_ep_setup();
+}
+
+static void fas_ep_setup_str_fmt_av_tbl(void)
+{
+	use_str_fmt = true;
+	ep_type = EP;
+	attr.type = FI_AV_TABLE;
+
+	fas_ep_setup();
+}
+
+static void fas_sep_setup_gni_fmt_av_tbl(void)
+{
+	use_str_fmt = false;
+	ep_type = SEP;
+	attr.type = FI_AV_TABLE;
+
+	fas_ep_setup();
+}
+
+static void fas_sep_setup_str_fmt_av_tbl(void)
+{
+	use_str_fmt = true;
+	ep_type = SEP;
+	attr.type = FI_AV_TABLE;
+
+	fas_ep_setup();
+}
+
+static void fas_pep_setup_gni_fmt_av_tbl(void)
+{
+	use_str_fmt = false;
+	ep_type = PEP;
+	attr.type = FI_AV_TABLE;
+
+	fas_ep_setup();
+}
+
+static void fas_pep_setup_str_fmt_av_tbl(void)
+{
+	use_str_fmt = true;
+	ep_type = PEP;
+	attr.type = FI_AV_TABLE;
+
+	fas_ep_setup();
+}
+
+static void fas_teardown_common(void)
+{
+	int ret = 0, i = 0, j;
+
+	for (; i < NUMEPS; i++) {
+		switch (ep_type) {
+		case EP:
+			ret = fi_close(&msg_cq[i]->fid);
+			cr_assert(!ret, "failure in closing msg cq.");
+			break;
+		case SEP:
+			for (j = 0; j < ctx_cnt; j++) {
+				ret = fi_close(&tx_ep[i][j]->fid);
+				cr_assert(!ret,
+					  "failure closing tx_ep.");
+
+				ret = fi_close(&rx_ep[i][j]->fid);
+				cr_assert(!ret,
+					  "failure closing rx_ep.");
+
+				ret = fi_close(&tx_cq[i][j]->fid);
+				cr_assert(!ret,
+					  "failure closing tx cq.");
+
+				ret = fi_close(&rx_cq[i][j]->fid);
+				cr_assert(!ret,
+					  "failure closing rx cq.");
+			}
+			break;
+		case PEP:
+			continue;
+			break;
+		default:
+			cr_assert_fail("Unknown endpoint type.");
+			break;
+		}
+
+		ret = fi_close(&recv_cntr[i]->fid);
+		cr_assert(!ret, "failure in closing recv cntr.");
+
+		ret = fi_close(&send_cntr[i]->fid);
+		cr_assert(!ret, "failure in closing send cntr.");
+
+		ret = fi_close(get_fid[ep_type](i));
+		cr_assert(!ret, "failure in closing ep.");
+
+		ret = fi_close(&av[i]->fid);
+		cr_assert(!ret, "failure in closing av.");
+
+		ret = fi_close(&dom[i]->fid);
+		cr_assert(!ret, "failure in closing domain.");
+
+		fi_freeinfo(fi[i]);
+
+		free(ep_name[i]);
+		free(target[i]);
+		free(source[i]);
+	}
+
+	fi_freeinfo(hints);
+	ret = fi_close(&fab->fid);
+	cr_assert(!ret, "failure in closing fabric.");
+}
+/******************************************************************************
+* End setup and teardown routines
+******************************************************************************/
+
+/******************************************************************************
+* Begin verification routines
+******************************************************************************/
+static void fas_to_ep_name(char *ep_name_str, struct gnix_ep_name *rebuilt)
+{
+	char *buf;
+
+	dbg_printf(BLUE
+			   "ep_name_str(%p) = %s.\n"
+			   COLOR_RESET, ep_name_str, ep_name_str);
+
+	buf = strtok(ep_name_str, ";");
+
+	cr_assert_not_null(buf, "address family not found");
+
+	dbg_printf(BLUE
+			   "buf = %s\nbuf_len = %lu\n"
+			   COLOR_RESET, buf,
+		   strlen(buf));
+	cr_assert(!memcmp(buf, "gni", 3));
+
+	buf = strtok(NULL, ";");
+	cr_assert_not_null(buf, "node not found");
+	dbg_printf(BLUE
+			   "buf = %s\nbuf_len = %lu\n"
+			   COLOR_RESET, buf,
+		   strlen(buf));
+
+	buf = strtok(NULL, ";");
+	cr_assert_not_null(buf, "service not found");
+	dbg_printf(BLUE
+			   "buf = %s\nbuf_len = %lu\n"
+			   COLOR_RESET, buf, strlen(buf));
+
+
+	buf = strtok(NULL, ";");
+	cr_assert_not_null(buf, "zeroth additional field "
+		"(GNIX_AV_STR_ADDR_VERSION) not found");
+	dbg_printf(BLUE
+			   "buf = %s\nbuf_len = %lu\n"
+			   COLOR_RESET, buf, strlen(buf));
+
+	buf = strtok(NULL, ";");
+	cr_assert_not_null(buf, "first additional field (device address) not "
+		"found");
+	rebuilt->gnix_addr.device_addr = strtol(buf, NULL, 16);
+	dbg_printf(BLUE
+			   "buf = %s\nbuf_len = %lu\n"
+			   COLOR_RESET, buf, strlen(buf));
+
+	buf = strtok(NULL, ";");
+	cr_assert_not_null(buf, "second additional field (cdm id) not found");
+	rebuilt->gnix_addr.cdm_id = strtol(buf, NULL, 16);
+	dbg_printf(BLUE
+			   "buf = %s\nbuf_len = %lu\n"
+			   COLOR_RESET, buf, strlen(buf));
+
+	buf = strtok(NULL, ";");
+	cr_assert_not_null(buf, "third additional field (name type) not found");
+	rebuilt->name_type = strtol(buf, NULL, 10);
+	dbg_printf(BLUE
+			   "buf = %s\nbuf_len = %lu\n"
+			   COLOR_RESET, buf, strlen(buf));
+
+	buf = strtok(NULL, ";");
+	cr_assert_not_null(buf, "forth additional field (cm_nic_cdm_id) not "
+		"found");
+	rebuilt->cm_nic_cdm_id = strtol(buf, NULL, 16);
+	dbg_printf(BLUE
+			   "buf = %s\nbuf_len = %lu\n"
+			   COLOR_RESET, buf, strlen(buf));
+
+	buf = strtok(NULL, ";");
+	cr_assert_not_null(buf, "fifth additional field (cookie) not found");
+	rebuilt->cookie = strtol(buf, NULL, 16);
+	dbg_printf(BLUE
+			   "buf = %s\nbuf_len = %lu\n"
+			   COLOR_RESET, buf, strlen(buf));
+
+	buf = strtok(NULL, ";");
+	cr_assert_not_null(buf, "sixth additional field (rx_ctx_cnt) not "
+		"found");
+	rebuilt->rx_ctx_cnt = strtol(buf, NULL, 10);
+	dbg_printf(BLUE
+			   "buf = %s\nbuf_len = %lu\n"
+			   COLOR_RESET, buf, strlen(buf));
+}
+
+static void check_ep_name(struct gnix_ep_name actual,
+			  struct gnix_ep_name expected)
+{
+	cr_assert_eq(expected.gnix_addr.cdm_id, actual.gnix_addr.cdm_id,
+		     "Invalid cdm_id: expected(%x) actual(%x)",
+		     actual.gnix_addr.cdm_id, expected.gnix_addr.cdm_id);
+
+	cr_assert_eq(expected.name_type, actual.name_type, "Invalid name_type: "
+		"expected(%x) actual(%x)", actual.name_type,
+		     expected.name_type);
+
+	cr_assert_eq(expected.cm_nic_cdm_id, actual.cm_nic_cdm_id, "Invalid "
+		"cm_nic_cmd_id: expected(%x) actual(%x)", actual.cm_nic_cdm_id,
+		     expected.cm_nic_cdm_id);
+
+	cr_assert_eq(expected.cookie, actual.cookie, "Invalid cookie: expected"
+		"(%x) actual(%x)", actual.cookie, expected.cookie);
+
+	cr_assert_eq(expected.rx_ctx_cnt, actual.rx_ctx_cnt, "Invalid "
+		"rx_ctx_cnt: expected(%x) actual(%x)", actual.rx_ctx_cnt,
+		     expected.rx_ctx_cnt);
+}
+
+static void check_ep_name_str(struct gnix_ep_name actual, void *expected,
+			      size_t ep_name_len)
+{
+	char *ep_name_str;
+	struct gnix_ep_name rebuilt;
+
+	ep_name_str = (char *) mem_dup(expected, ep_name_len);
+
+	fas_to_ep_name(ep_name_str, &rebuilt);
+
+	check_ep_name(actual, rebuilt);
+
+	free(ep_name_str);
+}
+
+void init_bufs(void **bufs, int nbufs, int len)
+{
+	int i;
+	char byte = (char) rand();
+
+	for (i = 0; i < nbufs; i++, byte = (char) rand()) {
+		memset(bufs[i], byte, len);
+	}
+}
+
+void check_buf(char *expected, char *buf, int len)
+{
+	int idx;
+
+	for (idx = 0; idx < len; idx++) {
+		cr_assert(expected[idx] == buf[idx], "data mismatch: "
+			"expected[%d] = 0x%x, buf[%d] = 0x%x", idx,
+			  expected[idx], idx, buf[idx]);
+	}
+}
+
+void check_tagged_cqe(struct fi_cq_tagged_entry expected_tcqe,
+		      struct fi_cq_tagged_entry fi_tcqe)
+{
+	cr_assert_eq(expected_tcqe.op_context, fi_tcqe.op_context,
+		     "Invalid op_context: expected(%p) actual(%p)",
+		     expected_tcqe.op_context, fi_tcqe.op_context);
+
+	cr_assert_eq(expected_tcqe.flags, fi_tcqe.flags,
+		     "Invalid flags: expected(0x%lx) actual(0x%lx",
+		     expected_tcqe.flags, fi_tcqe.flags);
+
+	cr_assert_eq(expected_tcqe.len, fi_tcqe.len,
+		     "Invalid len: expected(%lu) actual(%lu)",
+		     expected_tcqe.len, fi_tcqe.len);
+
+	cr_assert_eq(expected_tcqe.buf, fi_tcqe.buf,
+		     "Invalid buf: expected(%p) actual(%p)",
+		     expected_tcqe.buf, fi_tcqe.buf);
+
+	cr_assert_eq(expected_tcqe.data, fi_tcqe.data,
+		     "Invalid data: expected(0x%lx) actual(0x%lx)",
+		     expected_tcqe.data, fi_tcqe.data);
+
+	cr_assert_eq(expected_tcqe.tag, fi_tcqe.tag,
+		     "Invalid tag: expected(0x%lx) actual(0x%lx)",
+		     expected_tcqe.tag, fi_tcqe.tag);
+}
+/******************************************************************************
+* End verification routines
+******************************************************************************/
+
+/******************************************************************************
+* Begin test running routines
+******************************************************************************/
+void do_getname(void)
+{
+	int i, ret;
+	size_t addrlen;
+	void *addr;
+	struct gnix_ep_name *src_addr;
+
+	ret = fi_getname(get_fid[ep_type](0), NULL, NULL);
+	cr_assert(ret == -FI_EINVAL, "fi_getname returned: %s",
+		  fi_strerror(-ret));
+
+	for (i = 0; i < NUMEPS; i++) {
+		ret = fi_getname(get_fid[ep_type](i), NULL, &addrlen);
+		cr_assert(ret == -FI_ETOOSMALL, "fi_getname returned: %s",
+			  fi_strerror(-ret));
+		if (use_str_fmt) {
+			cr_assert(addrlen == GNIX_FI_ADDR_STR_LEN,
+				  "addrlen: %lu does not match size for "
+					  "FI_ADDR_STR", addrlen);
+		} else {
+			cr_assert(addrlen == sizeof(struct gnix_ep_name),
+				  "addrlen: %lu does not match the size for"
+					  " FI_ADDR_GNI", addrlen);
+		}
+
+		addr = malloc(addrlen);
+		ret = errno;
+		cr_assert_not_null(addr, "malloc returned: %s", strerror(ret));
+
+		ret = fi_getname(get_fid[ep_type](i), addr, &addrlen);
+		cr_assert(ret == FI_SUCCESS, "fi_getname returned: %s",
+			  fi_strerror(-ret));
+
+		if (use_str_fmt) {
+			cr_assert(addrlen == GNIX_FI_ADDR_STR_LEN,
+				  "addrlen: %lu does not match size for "
+					  "FI_ADDR_STR", addrlen);
+		} else {
+			cr_assert(addrlen == sizeof(struct gnix_ep_name),
+				  "addrlen: %lu does not match the size for "
+					  "FI_ADDR_GNI", addrlen);
+		}
+
+		get_fid_ep(i, NULL, NULL, (void **) &src_addr);
+
+		dbg_printf(BLUE "ep_name = %p\n" COLOR_RESET, src_addr);
+
+		if (use_str_fmt)
+			check_ep_name_str(*src_addr, addr, ep_name_len[i]);
+		free(addr);
+	}
+}
+
+void do_setname(void)
+{
+	int i, ret;
+	void *addr;
+	struct gnix_ep_name *src_addr = NULL, rebuilt;
+	struct fi_info *info = NULL;
+
+	ret = fi_setname(get_fid[ep_type](0), NULL, 0xbabbbcbd);
+	cr_assert(ret == -FI_EINVAL, "fi_setname returned: %s",
+		  fi_strerror(-ret));
+
+	for (i = 0; i < NUMEPS; i++) {
+		addr = malloc(ep_name_len[i]);
+		ret = errno;
+		cr_assert_not_null(addr, "malloc returned: %s", strerror(ret));
+
+		if (use_str_fmt)
+			generate_rand_fas((char **) &addr);
+		else
+			init_bufs(&addr, 1, ep_name_len[i]);
+
+		ret = fi_setname(get_fid[ep_type](i), addr, ep_name_len[i]);
+		cr_assert(ret == FI_SUCCESS, "fi_setname returned: %s",
+			  fi_strerror(-ret));
+
+		get_fid_ep(i, (void **) &info, (void **) NULL, (void **)
+			&src_addr);
+
+		/* Ensure that the address was set properly. */
+		if (use_str_fmt) {
+			fas_to_ep_name(addr, &rebuilt);
+			check_ep_name(rebuilt, *src_addr);
+		} else {
+			check_ep_name(((struct gnix_ep_name *)addr)[0],
+				      *src_addr);
+		}
+
+
+		free(addr);
+	}
+}
+
+void do_getpeer(void)
+{
+	int i = 0, ret;
+	size_t addrlen;
+	void *addr;
+	struct gnix_ep_name *dest_addr, rebuilt;
+	struct fid_ep *ep_fid;
+
+	ret = fi_getpeer(get_fid_ep(0, NULL, NULL, NULL), NULL, NULL);
+	cr_assert(ret == -FI_EINVAL, "fi_getpeer returned: %s",
+		  fi_strerror(-ret));
+
+	for (i = 0; i < NUMEPS; i++) {
+		ep_fid = get_fid_ep(i, NULL, (void **) &dest_addr, NULL);
+		addrlen = ep_name_len[i];
+		addr = malloc(addrlen);
+		ret = errno;
+		cr_assert_not_null(addr, "malloc returned: %s", strerror(ret));
+		init_bufs(&addr, 1, addrlen);
+
+		addrlen = 0;
+		ret = fi_getpeer(ep_fid, addr, &addrlen);
+		cr_assert(ret == -FI_ETOOSMALL, "fi_getpeer returned: %s",
+			  fi_strerror(-ret));
+
+		ret = fi_getpeer(ep_fid, addr, &addrlen);
+		cr_assert(ret == FI_SUCCESS, "fi_getpeer returned: %s",
+			  fi_strerror(-ret));
+
+		if (use_str_fmt) {
+			dbg_printf(BLUE "strlen(addr) = %lu\n" COLOR_RESET,
+				   strlen(addr));
+
+			fas_to_ep_name(addr, &rebuilt);
+			check_ep_name(*dest_addr, rebuilt);
+		} else {
+			check_ep_name(*dest_addr,
+				      ((struct gnix_ep_name *) addr)[0]);
+		}
+
+		free(addr);
+	}
+}
+
+void do_getname_enosys(void)
+{
+	int ret, i;
+
+	for (i = 0; i < NUMEPS; i++) {
+		ret = fi_getname(get_fid[ep_type](i), NULL, NULL);
+		cr_assert_eq(ret, -FI_ENOSYS, "Invalid return value: %s",
+			     fi_strerror(-ret));
+	}
+}
+
+void do_setname_enosys(void)
+{
+	int ret, i;
+
+	for (i = 0; i < NUMEPS; i++) {
+		ret = fi_setname(get_fid[ep_type](i), NULL, 0);
+		cr_assert_eq(ret, -FI_ENOSYS, "Invalid return value: %s",
+			     fi_strerror(-ret));
+	}
+}
+
+void do_getpeer_enosys(void)
+{
+	int ret = 0, i;
+	struct gnix_fid_pep *gnix_pep;
+	struct fid_ep *ep_fid = NULL;
+
+	for (i = 0; i < NUMEPS; i++) {
+		switch (ep_type) {
+		case EP:
+			ep_fid = get_fid_ep(i, NULL, NULL, NULL);
+			ret = fi_getpeer(ep_fid, NULL, NULL);
+			break;
+		case SEP:
+			ep_fid = get_fid_ep(i, NULL, NULL, NULL);
+			ret = fi_getpeer(ep_fid, NULL, NULL);
+			break;
+		case PEP:
+			gnix_pep = container_of(get_fid[ep_type](i),
+						struct gnix_fid_pep,
+						pep_fid.fid);
+			ret = gnix_pep->pep_fid.cm->getpeer(NULL, NULL,
+							    NULL);
+			break;
+		default:
+			cr_assert_fail("Unknown endpoint type.");
+		}
+
+		cr_assert_eq(ret, -FI_ENOSYS, "Invalid return value: %s",
+			     fi_strerror(-ret));
+	}
+}
+
+void do_ep_send_recv_iter(int len)
+{
+	ssize_t sz;
+	int i = 0;
+	uint64_t cntr;
+	ssize_t ret, src_done, dest_done;
+	struct fi_cq_tagged_entry s_cqe = {(void *) -1, UINT_MAX, UINT_MAX,
+					   (void *) -1, UINT_MAX, UINT_MAX};
+	struct fi_cq_tagged_entry d_cqe = {(void *) -1, UINT_MAX, UINT_MAX,
+					   (void *) -1, UINT_MAX, UINT_MAX};
+	struct fi_cq_tagged_entry s_expected_cqe, d_expected_cqe;
+
+	init_bufs((void **) source, NUMEPS, len);
+	init_bufs((void **) target, NUMEPS, len);
+
+	for (i = 0; i < NUMEPS; i++) {
+		dbg_printf(BLUE
+				   "From ep(%d) to ep(%d) of xfer size %d\n"
+				   COLOR_RESET, i, NUMEPS - 1 - i, len);
+
+		s_expected_cqe.buf = NULL;
+		s_expected_cqe.data = 0;
+		s_expected_cqe.flags = (FI_MSG | FI_SEND);
+		s_expected_cqe.len = 0;
+		s_expected_cqe.op_context = target[NUMEPS - 1 - i];
+		s_expected_cqe.tag = 0;
+
+		sz = fi_send(ep[i], source[i], len, NULL,
+			     gni_addr[NUMEPS - 1 - i], target[NUMEPS - 1 - i]);
+
+		cr_assert(sz == FI_SUCCESS, "Invalid return value: %s",
+			  fi_strerror((int) -sz));
+
+		d_expected_cqe.buf = NULL;
+		d_expected_cqe.data = 0;
+		d_expected_cqe.flags = (FI_MSG | FI_RECV);
+		d_expected_cqe.len = len;
+		d_expected_cqe.op_context = source[i];
+		d_expected_cqe.tag = 0;
+
+		sz = fi_recv(ep[NUMEPS - 1 - i], target[NUMEPS - 1 - i], len,
+			     NULL, gni_addr[i], source[i]);
+
+		cr_assert(sz == FI_SUCCESS, "Invalid return value: %s",
+			  fi_strerror((int) -sz));
+
+		src_done = dest_done = 0;
+		/* Progress sender and receiver */
+		do {
+			ret = fi_cq_read(msg_cq[i], &s_cqe, 1);
+			if (ret == 1)
+				src_done = 1;
+
+			ret = fi_cq_read(msg_cq[NUMEPS - 1 - i],
+					 &d_cqe, 1);
+			if (ret == 1)
+				dest_done = 1;
+		} while (src_done != 1 || dest_done != 1);
+
+		cntr = fi_cntr_read(send_cntr[i]);
+		cr_assert(cntr == ++sends[i],
+			  "Invalid send counter: actual(%lu), expected(%lu)",
+			  cntr, sends[i]);
+
+		cntr = fi_cntr_read(recv_cntr[NUMEPS - 1 - i]);
+		cr_assert(cntr == ++recvs[NUMEPS - 1 - i],
+			  "Invalid recv counter: actual(%lu), expected(%lu)",
+			  cntr, recvs[NUMEPS - 1 - i]);
+
+		check_tagged_cqe(s_expected_cqe, s_cqe);
+		check_tagged_cqe(d_expected_cqe, d_cqe);
+
+		check_buf(source[i], target[NUMEPS - 1 - i], len);
+	}
+}
+
+void do_sep_send_recv_iter(int idx, int len)
+{
+	ssize_t sz;
+	int i = 0;
+	uint64_t cntr;
+	ssize_t ret, src_done, dest_done;
+	struct fi_cq_tagged_entry s_cqe = {(void *) -1, UINT_MAX, UINT_MAX,
+					   (void *) -1, UINT_MAX, UINT_MAX};
+	struct fi_cq_tagged_entry d_cqe = {(void *) -1, UINT_MAX, UINT_MAX,
+					   (void *) -1, UINT_MAX, UINT_MAX};
+	struct fi_cq_tagged_entry s_expected_cqe, d_expected_cqe;
+
+	init_bufs((void **) source, NUMEPS, len);
+	init_bufs((void **) target, NUMEPS, len);
+
+	for (i = 0; i < NUMEPS; i++) {
+		dbg_printf(BLUE
+				   "From ep(%d) to ep(%d) of xfer size %d\n"
+				   COLOR_RESET, i, NUMEPS - 1 - i, len);
+
+		s_expected_cqe.buf = NULL;
+		s_expected_cqe.data = 0;
+		s_expected_cqe.flags = (FI_MSG | FI_TRANSMIT/*FI_SEND*/);
+		s_expected_cqe.len = 0;
+		s_expected_cqe.op_context = target[NUMEPS - 1 - i];
+		s_expected_cqe.tag = 0;
+
+		sz = fi_send(tx_ep[i][idx], source[i], len, NULL,
+			     gni_addr[NUMEPS - 1 - i], target[NUMEPS - 1 - i]);
+
+		cr_assert(sz == FI_SUCCESS, "Invalid return value: %s",
+			  fi_strerror((int) -sz));
+
+		d_expected_cqe.buf = NULL;
+		d_expected_cqe.data = 0;
+		d_expected_cqe.flags = (FI_MSG | FI_RECV);
+		d_expected_cqe.len = len;
+		d_expected_cqe.op_context = source[i];
+		d_expected_cqe.tag = 0;
+
+		sz = fi_recv(rx_ep[NUMEPS - 1 - i][idx],
+			     target[NUMEPS - 1 - i], len,
+			     NULL, gni_addr[i], source[i]);
+
+		cr_assert(sz == FI_SUCCESS, "Invalid return value: %s",
+			  fi_strerror((int) -sz));
+
+		src_done = dest_done = 0;
+		/* Progress sender and receiver */
+		do {
+			ret = fi_cq_read(tx_cq[i][idx], &s_cqe, 1);
+			if (ret == 1)
+				src_done = 1;
+
+			ret = fi_cq_read(rx_cq[NUMEPS - 1 - i][idx],
+					 &d_cqe, 1);
+			if (ret == 1)
+				dest_done = 1;
+		} while (src_done != 1 || dest_done != 1);
+
+		cntr = fi_cntr_read(send_cntr[i]);
+		cr_assert(cntr == ++sends[i],
+			  "Invalid send counter: actual(%lu), expected(%lu)",
+			  cntr, sends[i]);
+
+		cntr = fi_cntr_read(recv_cntr[NUMEPS - 1 - i]);
+		cr_assert(cntr == ++recvs[NUMEPS - 1 - i],
+			  "Invalid recv counter: actual(%lu), expected(%lu)",
+			  cntr, recvs[NUMEPS - 1 - i]);
+
+		check_tagged_cqe(s_expected_cqe, s_cqe);
+		check_tagged_cqe(d_expected_cqe, d_cqe);
+
+		check_buf(source[i], target[NUMEPS - 1 - i], len);
+	}
+}
+
+void do_send_recv(void)
+{
+	int len, i, j;
+
+	switch (ep_type) {
+	case EP:
+		for (len = 2; len <= BUF_SZ; len *= 2) {
+			do_ep_send_recv_iter(len);
+		}
+		break;
+
+	case SEP:
+		for (j = 0; j < ctx_cnt; j++) {
+			for (len = 2; len <= BUF_SZ; len *= 2) {
+				do_sep_send_recv_iter(j, len);
+			}
+
+			for (i = 0; i < NUMEPS; i++) {
+				fi_cntr_set(send_cntr[i], 0);
+				fi_cntr_set(recv_cntr[i], 0);
+			}
+		}
+		break;
+	case PEP:
+		break;
+
+	default:
+		cr_assert_fail("Invalid endpoint type.");
+	}
+}
+
+/*
+ * Note: the default addr_format is FI_ADDR_STR unless use_str_fmt is otherwise
+ * set to false.
+ */
+void do_invalid_fi_getinfo(void)
+{
+	int i, ret;
+
+	for (i = 0; i < NUMEPS; i++) {
+		/*
+		 * This test is to ensure that gni provider fails to provide
+		 * info if the FI_ADDR_STR format is being used and both the
+		 * node and service parameters are non-NULL.
+		 *
+		 * See the fi_getinfo man page DESCRIPTION section.
+		 */
+		ret = fi_getinfo(FI_VERSION(1, 5), "this is a test", "testing",
+				 0, hints, &fi[i]);
+		cr_assert(ret == -FI_ENODATA, "fi_getinfo returned: %s",
+			  fi_strerror(-ret));
+
+		fi_freeinfo(fi[i]);
+
+		/*
+		 * This test is to ensure that the gni provider does not allow
+		 * FI_ADDR_STR to be used with api versions <= 1.5.
+		 */
+		ret = fi_getinfo(FI_VERSION(1, 0), NULL, NULL, 0, hints,
+				 &fi[i]);
+		cr_assert(ret == -FI_ENODATA, "fi_getinfo returned: %s",
+			  fi_strerror(-ret));
+
+		fi_freeinfo(fi[i]);
+	}
+}
+
+void do_valid_fi_getinfo_with_fas(void)
+{
+	int i, ret;
+	char *fas = calloc(GNIX_FI_ADDR_STR_LEN, sizeof(char));
+	struct gnix_ep_name ep_name;
+
+	/*
+	 * This test ensures the gni provider can set addresses properly with
+	 * FI_ADDR_STR and no flags set.
+	 */
+	for (i = 0; i < NUMEPS; i++) {
+		generate_rand_fas(&fas);
+
+		ret = fi_getinfo(fi_version(), fas, NULL, 0, hints, &fi[i]);
+		cr_assert(ret == FI_SUCCESS, "fi_getinfo returned: %s",
+			  fi_strerror(-ret));
+
+		dbg_printf(BLUE "fi[%d]->dest_addr = %s\n" COLOR_RESET,
+			   i, (char *) fi[i]->dest_addr);
+
+		fas_to_ep_name(fas, &ep_name);
+		check_ep_name(((struct gnix_ep_name *) fi[i]->dest_addr)[0],
+			      ep_name);
+
+		fi_freeinfo(fi[i]);
+	}
+
+	/*
+	 * This test ensures the gni provider can set addresses properly with
+	 * FI_ADDR_STR and the FI_SOURCE set.
+	 */
+	for (i = 0; i < NUMEPS; i++) {
+		generate_rand_fas(&fas);
+
+		ret = fi_getinfo(fi_version(), fas, NULL, FI_SOURCE, hints,
+				 &fi[i]);
+		cr_assert(ret == FI_SUCCESS, "fi_getinfo returned: %s",
+			  fi_strerror(-ret));
+
+		fas_to_ep_name(fas, &ep_name);
+		check_ep_name(((struct gnix_ep_name *) fi[i]->src_addr)[0],
+			      ep_name);
+
+		fi_freeinfo(fi[i]);
+	}
+
+	free(fas);
+}
+/******************************************************************************
+* End test running routines
+******************************************************************************/
+
+/******************************************************************************
+* Begin test invocation routines - FI_AV_MAP
+******************************************************************************/
+TestSuite(fas_ep_str_fmt_av_map, .init = fas_ep_setup_str_fmt_av_map,
+	  .fini = fas_teardown_common, .disabled = false);
+
+Test(fas_ep_str_fmt_av_map, getname)
+{
+	do_getname();
+}
+
+Test(fas_ep_str_fmt_av_map, setname)
+{
+	do_setname();
+}
+
+Test(fas_ep_str_fmt_av_map, getpeer)
+{
+	do_getpeer();
+}
+
+Test(fas_ep_str_fmt_av_map, send_recv)
+{
+	do_send_recv();
+}
+
+TestSuite(fas_ep_gni_fmt_av_map, .init = fas_ep_setup_gni_fmt_av_map,
+	  .fini = fas_teardown_common, .disabled = false);
+
+Test(fas_ep_gni_fmt_av_map, getname)
+{
+	do_getname();
+}
+
+Test(fas_ep_gni_fmt_av_map, setname)
+{
+	do_setname();
+}
+
+Test(fas_ep_gni_fmt_av_map, getpeer)
+{
+	do_getpeer();
+}
+
+Test(fas_ep_gni_fmt_av_map, send_recv)
+{
+	do_send_recv();
+}
+
+TestSuite(fas_sep_str_fmt_av_map, .init = fas_sep_setup_str_fmt_av_map,
+	  .fini = fas_teardown_common, .disabled = false);
+
+Test(fas_sep_str_fmt_av_map, getname)
+{
+	do_getname();
+}
+
+Test(fas_sep_str_fmt_av_map, setname)
+{
+	do_setname();
+}
+
+Test(fas_sep_str_fmt_av_map, getpeer)
+{
+	do_getpeer();
+}
+
+Test(fas_sep_str_fmt_av_map, send_recv)
+{
+	do_send_recv();
+}
+
+TestSuite(fas_sep_gni_fmt_av_map, .init = fas_sep_setup_gni_fmt_av_map,
+	  .fini = fas_teardown_common, .disabled = false);
+
+Test(fas_sep_gni_fmt_av_map, getname)
+{
+	do_getname();
+}
+
+Test(fas_sep_gni_fmt_av_map, setname)
+{
+	do_setname();
+}
+
+Test(fas_sep_gni_fmt_av_map, getpeer)
+{
+	do_getpeer();
+}
+
+Test(fas_sep_gni_fmt_av_map, send_recv)
+{
+	do_send_recv();
+}
+
+TestSuite(fas_pep_str_fmt_av_map, .init = fas_pep_setup_str_fmt_av_map,
+	  .fini = fas_teardown_common, .disabled = false);
+
+Test(fas_pep_str_fmt_av_map, getname)
+{
+	do_getname();
+}
+
+Test(fas_pep_str_fmt_av_map, setname)
+{
+	do_setname();
+}
+
+Test(fas_pep_str_fmt_av_map, getpeer)
+{
+	do_getpeer_enosys();
+}
+
+TestSuite(fas_pep_gni_fmt_av_map, .init = fas_pep_setup_gni_fmt_av_map,
+	  .fini = fas_teardown_common, .disabled = false);
+
+Test(fas_pep_gni_fmt_av_map, getname)
+{
+	do_getname();
+}
+
+Test(fas_pep_gni_fmt_av_map, setname)
+{
+	do_setname();
+}
+
+Test(fas_pep_gni_fmt_av_map, getpeer)
+{
+	do_getpeer_enosys();
+}
+/******************************************************************************
+ * Begin FI_AV_TABLE
+ ******************************************************************************/
+TestSuite(fas_ep_str_fmt_av_tbl, .init = fas_ep_setup_str_fmt_av_tbl,
+	  .fini = fas_teardown_common, .disabled = false);
+
+Test(fas_ep_str_fmt_av_tbl, getname)
+{
+	do_getname();
+}
+
+Test(fas_ep_str_fmt_av_tbl, setname)
+{
+	do_setname();
+}
+
+Test(fas_ep_str_fmt_av_tbl, getpeer)
+{
+	do_getpeer();
+}
+
+Test(fas_ep_str_fmt_av_tbl, send_recv)
+{
+	do_send_recv();
+}
+
+TestSuite(fas_ep_gni_fmt_av_tbl, .init = fas_ep_setup_gni_fmt_av_tbl,
+	  .fini = fas_teardown_common, .disabled = false);
+
+Test(fas_ep_gni_fmt_av_tbl, getname)
+{
+	do_getname();
+}
+
+Test(fas_ep_gni_fmt_av_tbl, setname)
+{
+	do_setname();
+}
+
+Test(fas_ep_gni_fmt_av_tbl, getpeer)
+{
+	do_getpeer();
+}
+
+Test(fas_ep_gni_fmt_av_tbl, send_recv)
+{
+	do_send_recv();
+}
+
+TestSuite(fas_sep_str_fmt_av_tbl, .init = fas_sep_setup_str_fmt_av_tbl,
+	  .fini = fas_teardown_common, .disabled = false);
+
+Test(fas_sep_str_fmt_av_tbl, getname)
+{
+	do_getname();
+}
+
+Test(fas_sep_str_fmt_av_tbl, setname)
+{
+	do_setname();
+}
+
+Test(fas_sep_str_fmt_av_tbl, getpeer)
+{
+	do_getpeer();
+}
+
+Test(fas_sep_str_fmt_av_tbl, send_recv)
+{
+	do_send_recv();
+}
+
+TestSuite(fas_sep_gni_fmt_av_tbl, .init = fas_sep_setup_gni_fmt_av_tbl,
+	  .fini = fas_teardown_common, .disabled = false);
+
+Test(fas_sep_gni_fmt_av_tbl, getname)
+{
+	do_getname();
+}
+
+Test(fas_sep_gni_fmt_av_tbl, setname)
+{
+	do_setname();
+}
+
+Test(fas_sep_gni_fmt_av_tbl, getpeer)
+{
+	do_getpeer();
+}
+
+Test(fas_sep_gni_fmt_av_tbl, send_recv)
+{
+	do_send_recv();
+}
+
+TestSuite(fas_pep_str_fmt_av_tbl, .init = fas_pep_setup_str_fmt_av_tbl,
+	  .fini = fas_teardown_common, .disabled = false);
+
+Test(fas_pep_str_fmt_av_tbl, getname)
+{
+	do_getname();
+}
+
+Test(fas_pep_str_fmt_av_tbl, setname)
+{
+	do_setname();
+}
+
+Test(fas_pep_str_fmt_av_tbl, getpeer)
+{
+	do_getpeer_enosys();
+}
+
+TestSuite(fas_pep_gni_fmt_av_tbl, .init = fas_pep_setup_gni_fmt_av_tbl,
+	  .fini = fas_teardown_common, .disabled = false);
+
+Test(fas_pep_gni_fmt_av_tbl, getname)
+{
+	do_getname();
+}
+
+Test(fas_pep_gni_fmt_av_tbl, setname)
+{
+	do_setname();
+}
+
+Test(fas_pep_gni_fmt_av_tbl, getpeer)
+{
+	do_getpeer_enosys();
+}
+
+TestSuite(fas_getinfo_str_fmt, .init = fas_getinfo_setup, .fini =
+	fas_getinfo_teardown, .disabled = false);
+
+/* TODO: uncomment the ifdef below after the 1.5 release */
+#if 0
+Test(fas_getinfo_str_fmt, getinfo_invalid_param)
+{
+	do_invalid_fi_getinfo();
+}
+#endif
+
+Test(fas_getinfo_str_fmt, getinfo_valid_param)
+{
+	do_valid_fi_getinfo_with_fas();
+}
+/******************************************************************************
+ * End test invocation routines
+ ******************************************************************************/


### PR DESCRIPTION
 - Changed gnix_passive_ep_open to gnix_pep_open.
 - Added GNIX_FI_ADDR_STR_LEN to allocate a FI_ADDR_STR.
 - Added __gnix_resolve_str_ep_name to "rebuild" FI_ADDR_STR
 ptr to FI_ADDR_GNI ptr.
 - Added __gnix_resolve_gni_ep_name to do a noop for the
 above conversion.
   - This primarily is to reduce branching.
 - Updated {table, map}_insert to handle FI_ADDR_STR format.
 - Updated gnix_av_straddr to include rx_ctx_cnt field and
 check for FI_ADDR_STR.
 - Added addr_format field to gnix_fid_domain.
   - This is so av insertions can check for FI_ADDR_STR
   format.
 - Updated gnix_{ep, sep, pep}_open to handle FI_ADDR_STR.
 - Updated _gnix_getinfo to accept FI_ADDR_STR in node
 parameter.
 - Added __gnix_ep_name_to_str to convert a FI_ADDR_GNI
 address to a FI_ADDR_STR address when calling gnix_getinfo.
   - Updated __gnix_getinfo_resolve_node accordingly.
 - Added parameter checks to fi_{getname, setname, getpeer}.
   - Updated to handle FI_ADDR_STR.
   - Updated gnix_getpeer to handle scalable endpoint types.
 - Updated _gnix_cm_nic_alloc, gnix_ep_open, to resolve
 FI_ADDR_STR to FI_ADDR_GNI.
 - Added a small debug statement for scalable endpoint av
 insertions.

prov/gni: Added unit tests for FI_ADDR_STR.
- For the fi_addr_str tests added support for:
  - Testing both FI_AV_MAP and FI_AV_TABLE;
  - both FI_ADDR_STR and FI_ADDR_GNI;
  - all endpoint types;
  - FI_ADDR_STR input for fi_getinfo.

prov/gni: Updated fi_gni manpage.
- Added FI_ADDR_STR format for the provider.

Fixes #1189, #1223 

These changes are passing gnitest and cray-tests. To test FI_ADDR_STR with cray-tests see ofi-cray/cray-tests#54.
Signed-off-by: Evan Harvey <eharvey@lanl.gov>