### PR TITLE
prov/gni: remove unused field from vc struct

### DIFF
--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -137,7 +137,6 @@ struct gnix_vc {
 	struct gnix_address peer_cm_nic_addr;
 	struct gnix_fid_ep *ep;
 	void *smsg_mbox;
-	struct gnix_datagram *dgram;
 	gni_ep_handle_t gni_ep;
 	atomic_t outstanding_tx_reqs;
 	enum gnix_vc_conn_state conn_state;

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -1616,15 +1616,6 @@ int _gnix_vc_destroy(struct gnix_vc *vc)
 		vc->smsg_mbox = NULL;
 	}
 
-	if (vc->dgram != NULL) {
-		ret = _gnix_dgram_free(vc->dgram);
-		if (ret != FI_SUCCESS)
-			GNIX_WARN(FI_LOG_EP_CTRL,
-			      "_gnix_dgram_free returned %s\n",
-			      fi_strerror(-ret));
-		vc->dgram = NULL;
-	}
-
 	ret = _gnix_nic_free_rem_id(nic, vc->vc_id);
 	if (ret != FI_SUCCESS)
 		GNIX_WARN(FI_LOG_EP_CTRL,


### PR DESCRIPTION
remove dgram pointer from vc struct.  It is no longer used.
Here's space for a new pointer to something.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>