### PR TITLE
prov/gni: Fix use of FI_REMOTE_CQ_DATA.

### DIFF
--- a/prov/gni/include/gnix_util.h
+++ b/prov/gni/include/gnix_util.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
+ *                         All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  *
@@ -272,6 +273,15 @@ struct gnix_reference {
 #define _gnix_ref_get(ptr) __ref_get(ptr, ref_cnt)
 #define _gnix_ref_put(ptr) __ref_put(ptr, ref_cnt)
 
+/**
+ * Only allow FI_REMOTE_CQ_DATA when the EP cap, FI_RMA_EVENT, is also set.
+ *
+ * @return zero if FI_REMOTE_CQ_DATA is not permitted; otherwise one.
+ */
+#define GNIX_ALLOW_FI_REMOTE_CQ_DATA(_flags, _ep_caps) \
+					(((_flags) & FI_REMOTE_CQ_DATA) && \
+					 ((_ep_caps) & FI_RMA_EVENT))
+
 static inline void _gnix_ref_init(
 		struct gnix_reference *ref,
 		int initial_value,
@@ -306,7 +316,7 @@ static inline void _gnix_ref_init(
 	__COND_FUNC((cond), (lock), rwlock_unlock)
 #ifdef __GNUC__
 #define __PREFETCH(addr, rw, locality) __builtin_prefetch(addr, rw, locality)
-#else 
+#else
 #define __PREFETCH(addr, rw, locality) ((void *) 0)
 #endif
 

--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -114,7 +114,7 @@ enum gnix_vc_conn_req_type {
  * @var flags                Bitmap used to hold vc schedule state
  * @var peer_irq_mem_hndl    peer GNI memhndl used for delivering
  *                           GNI_PostCqWrite requests to remote peer
- *
+ * @var peer_caps            peer capability flags
  */
 struct gnix_vc {
 	struct dlist_entry prog_list;	/* NIC VC progress list entry */

--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -250,7 +250,7 @@ int __smsg_rma_data(void *data, void *msg)
 	struct gnix_fid_ep *ep = vc->ep;
 	gni_return_t status;
 
-	if (hdr->flags & FI_REMOTE_CQ_DATA && ep->recv_cq) {
+	if (GNIX_ALLOW_FI_REMOTE_CQ_DATA(hdr->flags, ep->caps) && ep->recv_cq) {
 		ret = _gnix_cq_add_event(ep->recv_cq, ep, NULL, hdr->user_flags,
 					 0, 0, hdr->user_data, 0,
 					 FI_ADDR_NOTAVAIL);
@@ -335,7 +335,7 @@ static int __gnix_rma_send_data_req(void *arg)
 	txd->completer_fn = __gnix_rma_txd_data_complete;
 	txd->rma_data_hdr.flags = 0;
 
-	if (req->flags & FI_REMOTE_CQ_DATA) {
+	if (GNIX_ALLOW_FI_REMOTE_CQ_DATA(req->flags, ep->caps)) {
 		txd->rma_data_hdr.flags |= FI_REMOTE_CQ_DATA;
 		txd->rma_data_hdr.user_flags = FI_RMA | FI_REMOTE_CQ_DATA;
 		if (req->type == GNIX_FAB_RQ_RDMA_WRITE) {
@@ -488,7 +488,7 @@ static int __gnix_rma_txd_complete(void *arg, gni_return_t tx_status)
 
 	_gnix_nic_tx_free(req->gnix_ep->nic, txd);
 
-	if (req->flags & FI_REMOTE_CQ_DATA ||
+	if (GNIX_ALLOW_FI_REMOTE_CQ_DATA(req->flags, req->gnix_ep->caps) ||
 	    req->vc->peer_caps & FI_RMA_EVENT) {
 		/* control message needed for imm. data or a counter event. */
 		req->tx_failures = 0;

--- a/prov/gni/test/api.c
+++ b/prov/gni/test/api.c
@@ -311,7 +311,8 @@ void rdm_api_check_cqe(struct fi_cq_tagged_entry *cqe, void *ctx,
 		cr_assert(cqe->len == len, "CQE length mismatch");
 		cr_assert(cqe->buf == addr, "CQE address mismatch");
 
-		if (GNIX_ALLOW_FI_REMOTE_CQ_DATA(flags, gnix_ep->caps))
+	/* TODO: Remove GNIX_ALLOW_FI_REMOTE_CQ_DATA and only check flags for FI_RMA_EVENT */
+	if (GNIX_ALLOW_FI_REMOTE_CQ_DATA(flags, gnix_ep->caps))
 			cr_assert(cqe->data == data, "CQE data mismatch");
 	} else {
 		cr_assert(cqe->len == 0, "Invalid CQE length");

--- a/prov/gni/test/api.c
+++ b/prov/gni/test/api.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
+ *                         All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -50,6 +51,8 @@
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
 #include "fi_ext_gni.h"
+#include "gnix_util.h"
+#include "common.h"
 
 #if 1
 #define dbg_printf(...)
@@ -297,8 +300,10 @@ int rdm_api_check_data(char *buf1, char *buf2, int len)
 
 void rdm_api_check_cqe(struct fi_cq_tagged_entry *cqe, void *ctx,
 		      uint64_t flags, void *addr, size_t len,
-		      uint64_t data)
+		      uint64_t data, struct fid_ep *fid_ep)
 {
+	struct gnix_fid_ep *gnix_ep = get_gnix_ep(fid_ep);
+
 	cr_assert(cqe->op_context == ctx, "CQE Context mismatch");
 	cr_assert(cqe->flags == flags, "CQE flags mismatch");
 
@@ -306,7 +311,7 @@ void rdm_api_check_cqe(struct fi_cq_tagged_entry *cqe, void *ctx,
 		cr_assert(cqe->len == len, "CQE length mismatch");
 		cr_assert(cqe->buf == addr, "CQE address mismatch");
 
-		if (flags & FI_REMOTE_CQ_DATA)
+		if (GNIX_ALLOW_FI_REMOTE_CQ_DATA(flags, gnix_ep->caps))
 			cr_assert(cqe->data == data, "CQE data mismatch");
 	} else {
 		cr_assert(cqe->len == 0, "Invalid CQE length");

--- a/prov/gni/test/common.h
+++ b/prov/gni/test/common.h
@@ -40,6 +40,7 @@
 #include <criterion/criterion.h>
 #include <criterion/logging.h>
 #include "gnix_rdma_headers.h"
+#include "gnix.h"
 
 #define BLUE "\x1b[34m"
 #define COLOR_RESET "\x1b[0m"
@@ -51,5 +52,10 @@ extern int supported_fetch_atomic_ops[FI_ATOMIC_OP_LAST][FI_DATATYPE_LAST];
 void calculate_time_difference(struct timeval *start, struct timeval *end,
 		int *secs_out, int *usec_out);
 int dump_cq_error(struct fid_cq *cq, void *context, uint64_t flags);
+
+static inline struct gnix_fid_ep *get_gnix_ep(struct fid_ep *fid_ep)
+{
+	return container_of(fid_ep, struct gnix_fid_ep, ep_fid);
+}
 
 #endif /* PROV_GNI_TEST_COMMON_H_ */

--- a/prov/gni/test/rdm_dgram_rma.c
+++ b/prov/gni/test/rdm_dgram_rma.c
@@ -669,6 +669,7 @@ void rdm_rma_check_tcqe(struct fi_cq_tagged_entry *tcqe, void *ctx,
 	cr_assert(tcqe->op_context == ctx, "CQE Context mismatch");
 	cr_assert(tcqe->flags == flags, "CQE flags mismatch");
 
+	/* TODO: Remove GNIX_ALLOW_FI_REMOTE_CQ_DATA and only check flags for FI_RMA_EVENT */
 	if (GNIX_ALLOW_FI_REMOTE_CQ_DATA(flags, gnix_ep->caps)) {
 		cr_assert(tcqe->data == data, "CQE data invalid");
 	} else {

--- a/prov/gni/test/rdm_dgram_rma.c
+++ b/prov/gni/test/rdm_dgram_rma.c
@@ -53,6 +53,7 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
+#include "common.h"
 
 #if 1
 #define dbg_printf(...)
@@ -99,6 +100,7 @@ static uint64_t writes[2] = {0}, reads[2] = {0}, write_errs[2] = {0},
 	read_errs[2] = {0};
 #define MLOOPS 1000
 static int dgm_fail;
+static bool fi_more_set;
 
 void common_setup(void)
 {
@@ -491,6 +493,7 @@ void rdm_rma_setup(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 	hints->ep_attr->type = FI_EP_RDM;
+	hints->caps = FI_RMA_EVENT;
 	common_setup();
 }
 
@@ -499,6 +502,7 @@ void dgram_setup(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 	hints->ep_attr->type = FI_EP_DGRAM;
+	hints->caps = FI_RMA_EVENT;
 	common_setup();
 }
 
@@ -507,6 +511,7 @@ void dgram_setup_1dom(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 	hints->ep_attr->type = FI_EP_DGRAM;
+	hints->caps = FI_RMA_EVENT;
 	common_setup_1dom();
 }
 
@@ -657,12 +662,14 @@ int check_data(char *buf1, char *buf2, int len)
 }
 
 void rdm_rma_check_tcqe(struct fi_cq_tagged_entry *tcqe, void *ctx,
-			uint64_t flags, uint64_t data)
+			uint64_t flags, uint64_t data, struct fid_ep *fid_ep)
 {
+	struct gnix_fid_ep *gnix_ep = get_gnix_ep(fid_ep);
+
 	cr_assert(tcqe->op_context == ctx, "CQE Context mismatch");
 	cr_assert(tcqe->flags == flags, "CQE flags mismatch");
 
-	if (flags & FI_REMOTE_CQ_DATA) {
+	if (GNIX_ALLOW_FI_REMOTE_CQ_DATA(flags, gnix_ep->caps)) {
 		cr_assert(tcqe->data == data, "CQE data invalid");
 	} else {
 		cr_assert(tcqe->data == 0, "CQE data invalid");
@@ -701,11 +708,20 @@ void rdm_rma_check_cntrs(uint64_t w[2], uint64_t r[2], uint64_t w_e[2],
 	cr_assert(fi_cntr_readerr(read_cntr[1]) == read_errs[1],
 		  "Bad read err count");
 
-	if (hints->caps & FI_RMA_EVENT) {
+	/*
+	 * These tests should be refactored and all occurrences of
+	 * fi_more_set should be removed.
+	 *
+	 * When fi_more_set is true, we do not want to check the rwrite and
+	 * rread counters since they are not being used within the provider.
+	 */
+	if (hints->caps & FI_RMA_EVENT && fi_more_set == false) {
 		cr_assert(fi_cntr_read(rwrite_cntr) == writes[0],
-			  "Bad rwrite count");
+			  "Bad rwrite count: expected(%lu) actual(%lu)",
+			  writes[0], fi_cntr_read(rwrite_cntr));
 		cr_assert(fi_cntr_read(rread_cntr) == reads[0],
-			  "Bad rread count");
+			  "Bad rread count: expected(%lu) actual(%lu)",
+			  reads[0], fi_cntr_read(rread_cntr));
 		cr_assert(fi_cntr_readerr(rwrite_cntr) == 0,
 			  "Bad rwrite err count");
 		cr_assert(fi_cntr_readerr(rread_cntr) == 0,
@@ -776,7 +792,7 @@ void do_write(int len)
 		return;
 	}
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0, ep[0]);
 
 	w[0] = 1;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -851,7 +867,7 @@ void do_writev(int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0, ep[0]);
 
 	w[0] = 1;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -937,7 +953,7 @@ void do_writemsg(int len)
 		return;
 	}
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0, ep[0]);
 
 	w[0] = 1;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -1040,14 +1056,14 @@ void do_writemsg_more(int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0, ep[0]);
 
 	while ((ret = fi_cq_read(send_cq[0], &cqe, 1)) == -FI_EAGAIN) {
 		pthread_yield();
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, target2, FI_RMA | FI_WRITE, 0);
+	rdm_rma_check_tcqe(&cqe, target2, FI_RMA | FI_WRITE, 0, ep[0]);
 
 
         w[0] = 2;
@@ -1062,7 +1078,9 @@ void do_writemsg_more(int len)
 
 Test(rdm_rma, writemsgmore)
 {
+	fi_more_set = true;
 	xfer_for_each_size(do_writemsg_more, 8, BUF_SZ);
+	fi_more_set = false;
 }
 
 void do_mixed_more(int len)
@@ -1203,7 +1221,7 @@ void do_write_fence(int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0, ep[0]);
 
 	/* reset cqe */
 	cqe.op_context = cqe.buf = (void *) -1;
@@ -1215,7 +1233,7 @@ void do_write_fence(int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0, ep[0]);
 
 	w[0] = 2;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -1355,7 +1373,7 @@ void do_writedata(int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0, ep[0]);
 
 	w[0] = 1;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -1371,7 +1389,7 @@ void do_writedata(int len)
 
 	rdm_rma_check_tcqe(&dcqe, NULL,
 			   (FI_RMA | FI_REMOTE_WRITE | FI_REMOTE_CQ_DATA),
-			   WRITE_DATA);
+			   WRITE_DATA, ep[1]);
 }
 
 Test(rdm_rma, writedata)
@@ -1452,7 +1470,7 @@ void do_inject_writedata(int len)
 
 	rdm_rma_check_tcqe(&dcqe, NULL,
 			   (FI_RMA | FI_REMOTE_WRITE | FI_REMOTE_CQ_DATA),
-			   INJECTWRITE_DATA);
+			   INJECTWRITE_DATA, ep[1]);
 }
 
 Test(rdm_rma, inject_writedata)
@@ -1513,7 +1531,7 @@ void do_read(int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, (void *)READ_CTX, FI_RMA | FI_READ, 0);
+	rdm_rma_check_tcqe(&cqe, (void *)READ_CTX, FI_RMA | FI_READ, 0, ep[0]);
 
 	r[0] = 1;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -1568,7 +1586,7 @@ void do_readv(int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_READ, 0);
+	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_READ, 0, ep[0]);
 
 	r[0] = 1;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -1636,7 +1654,7 @@ void do_readmsg(int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_READ, 0);
+	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_READ, 0, ep[0]);
 
 	r[0] = 1;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -1742,14 +1760,14 @@ void do_readmsg_more(int len, void *s, void *t, int len2, void *s2, void *t2)
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, t, FI_RMA | FI_READ, 0);
+	rdm_rma_check_tcqe(&cqe, t, FI_RMA | FI_READ, 0, ep[0]);
 
 	while ((ret = fi_cq_read(send_cq[0], &cqe, 1)) == -FI_EAGAIN) {
 		pthread_yield();
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, t2, FI_RMA | FI_READ, 0);
+	rdm_rma_check_tcqe(&cqe, t2, FI_RMA | FI_READ, 0, ep[0]);
 
 	r[0] = 2;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -1840,7 +1858,9 @@ void do_read_alignment_more(void)
 
 Test(rdm_rma, readmsgmore)
 {
+	fi_more_set = true;
 	do_read_alignment_more();
+	fi_more_set = false;
 }
 
 void inject_common(void)
@@ -1885,7 +1905,7 @@ void inject_common(void)
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0, ep[0]);
 
 	w[0] = 1;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -1931,7 +1951,7 @@ void do_write_autoreg(int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0, ep[0]);
 
 	w[0] = 1;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -1976,7 +1996,7 @@ void do_write_autoreg_uncached(int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0, ep[0]);
 
 	w[0] = 1;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -2153,7 +2173,7 @@ void do_read_buf(void *s, void *t, int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, (void *)READ_CTX, FI_RMA | FI_READ, 0);
+	rdm_rma_check_tcqe(&cqe, (void *)READ_CTX, FI_RMA | FI_READ, 0, ep[0]);
 
 	r[0] = 1;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -2227,7 +2247,7 @@ void do_write_buf(void *s, void *t, int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, t, FI_RMA | FI_WRITE, 0);
+	rdm_rma_check_tcqe(&cqe, t, FI_RMA | FI_WRITE, 0, ep[0]);
 
 	w[0] = 1;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -2344,7 +2364,7 @@ void do_trigger(int len)
 
 		cr_assert_eq(ret, 1);
 
-		rdm_rma_check_tcqe(&cqe, ctxs[i], FI_RMA | FI_WRITE, 0);
+		rdm_rma_check_tcqe(&cqe, ctxs[i], FI_RMA | FI_WRITE, 0, ep[0]);
 	}
 
 	sz = fi_cntr_set(write_cntr[0], 0);

--- a/prov/gni/test/rdm_dgram_stx.c
+++ b/prov/gni/test/rdm_dgram_stx.c
@@ -53,6 +53,7 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
+#include "common.h"
 
 #if 1
 #define dbg_printf(...)
@@ -517,6 +518,7 @@ static void rdm_rma_setup(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 	hints->ep_attr->type = FI_EP_RDM;
+	hints->caps = FI_RMA_EVENT;
 	common_setup_stx();
 }
 
@@ -525,6 +527,7 @@ static void dgram_setup(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 	hints->ep_attr->type = FI_EP_DGRAM;
+	hints->caps = FI_RMA_EVENT;
 	common_setup_stx();
 }
 
@@ -533,6 +536,7 @@ static void dgram_setup_1dom(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 	hints->ep_attr->type = FI_EP_DGRAM;
+	hints->caps = FI_RMA_EVENT;
 	common_setup_stx_1dom();
 }
 
@@ -661,12 +665,15 @@ static int check_data(char *buf1, char *buf2, int len)
 }
 
 static void rdm_rma_check_tcqe(struct fi_cq_tagged_entry *tcqe, void *ctx,
-				uint64_t flags, uint64_t data)
+				uint64_t flags, uint64_t data,
+			       struct fid_ep *fid_ep)
 {
+	struct gnix_fid_ep *gnix_ep = get_gnix_ep(fid_ep);
+
 	cr_assert(tcqe->op_context == ctx, "CQE Context mismatch");
 	cr_assert(tcqe->flags == flags, "CQE flags mismatch");
 
-	if (flags & FI_REMOTE_CQ_DATA) {
+	if (GNIX_ALLOW_FI_REMOTE_CQ_DATA(flags, gnix_ep->caps)) {
 		cr_assert(tcqe->data == data, "CQE data invalid");
 	} else {
 		cr_assert(tcqe->data == 0, "CQE data invalid");
@@ -781,7 +788,7 @@ static void do_write(int len)
 		return;
 	}
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0, ep[0]);
 
 	w[0] = 1;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -856,7 +863,7 @@ static void do_writev(int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0, ep[0]);
 
 	w[0] = 1;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -942,7 +949,7 @@ static void do_writemsg(int len)
 		return;
 	}
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0, ep[0]);
 
 	w[0] = 1;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -1048,7 +1055,7 @@ static void do_write_fence(int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0, ep[0]);
 
 	/* reset cqe */
 	cqe.op_context = cqe.buf = (void *) -1;
@@ -1060,7 +1067,7 @@ static void do_write_fence(int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0, ep[0]);
 
 	w[0] = 2;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -1200,7 +1207,7 @@ static void do_writedata(int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0, ep[0]);
 
 	w[0] = 1;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -1216,7 +1223,7 @@ static void do_writedata(int len)
 
 	rdm_rma_check_tcqe(&dcqe, NULL,
 			   (FI_RMA | FI_REMOTE_WRITE | FI_REMOTE_CQ_DATA),
-			   WRITE_DATA);
+			   WRITE_DATA, ep[1]);
 }
 
 Test(rdm_rma_stx, writedata)
@@ -1297,7 +1304,7 @@ static void do_inject_writedata(int len)
 
 	rdm_rma_check_tcqe(&dcqe, NULL,
 			   (FI_RMA | FI_REMOTE_WRITE | FI_REMOTE_CQ_DATA),
-			   INJECTWRITE_DATA);
+			   INJECTWRITE_DATA, ep[1]);
 }
 
 Test(rdm_rma_stx, inject_writedata)
@@ -1358,7 +1365,7 @@ static void do_read(int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, (void *)READ_CTX, FI_RMA | FI_READ, 0);
+	rdm_rma_check_tcqe(&cqe, (void *)READ_CTX, FI_RMA | FI_READ, 0, ep[0]);
 
 	r[0] = 1;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -1413,7 +1420,7 @@ static void do_readv(int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_READ, 0);
+	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_READ, 0, ep[0]);
 
 	r[0] = 1;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -1481,7 +1488,7 @@ static void do_readmsg(int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_READ, 0);
+	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_READ, 0, ep[0]);
 
 	r[0] = 1;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -1570,7 +1577,7 @@ static void inject_common(void)
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0, ep[0]);
 
 	w[0] = 1;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -1616,7 +1623,7 @@ static void do_write_autoreg(int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0, ep[0]);
 
 	w[0] = 1;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -1661,7 +1668,7 @@ static void do_write_autoreg_uncached(int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0, ep[0]);
 
 	w[0] = 1;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -1840,7 +1847,7 @@ static void do_read_buf(void *s, void *t, int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, (void *)READ_CTX, FI_RMA | FI_READ, 0);
+	rdm_rma_check_tcqe(&cqe, (void *)READ_CTX, FI_RMA | FI_READ, 0, ep[0]);
 
 	r[0] = 1;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -1910,7 +1917,7 @@ static void do_write_buf(void *s, void *t, int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, t, FI_RMA | FI_WRITE, 0);
+	rdm_rma_check_tcqe(&cqe, t, FI_RMA | FI_WRITE, 0, ep[0]);
 
 	w[0] = 1;
 	rdm_rma_check_cntrs(w, r, w_e, r_e);
@@ -2027,7 +2034,7 @@ static void do_trigger(int len)
 
 		cr_assert_eq(ret, 1);
 
-		rdm_rma_check_tcqe(&cqe, ctxs[i], FI_RMA | FI_WRITE, 0);
+		rdm_rma_check_tcqe(&cqe, ctxs[i], FI_RMA | FI_WRITE, 0, ep[0]);
 	}
 
 	sz = fi_cntr_set(write_cntr[0], 0);

--- a/prov/gni/test/rdm_dgram_stx.c
+++ b/prov/gni/test/rdm_dgram_stx.c
@@ -673,6 +673,7 @@ static void rdm_rma_check_tcqe(struct fi_cq_tagged_entry *tcqe, void *ctx,
 	cr_assert(tcqe->op_context == ctx, "CQE Context mismatch");
 	cr_assert(tcqe->flags == flags, "CQE flags mismatch");
 
+	/* TODO: Remove GNIX_ALLOW_FI_REMOTE_CQ_DATA and only check flags for FI_RMA_EVENT */
 	if (GNIX_ALLOW_FI_REMOTE_CQ_DATA(flags, gnix_ep->caps)) {
 		cr_assert(tcqe->data == data, "CQE data invalid");
 	} else {

--- a/prov/gni/test/rdm_sr.c
+++ b/prov/gni/test/rdm_sr.c
@@ -48,6 +48,7 @@
 #include "gnix_cm_nic.h"
 #include "gnix_hashtable.h"
 #include "gnix_rma.h"
+#include "common.h"
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
@@ -548,8 +549,11 @@ static inline void rdm_sr_check_err_cqe(struct fi_cq_err_entry *cqe, void *ctx,
 
 static inline void rdm_sr_check_cqe(struct fi_cq_tagged_entry *cqe, void *ctx,
 				    uint64_t flags, void *addr, size_t len,
-				    uint64_t data, bool buf_is_non_null)
+				    uint64_t data, bool buf_is_non_null,
+				    struct fid_ep *fid_ep)
 {
+	struct gnix_fid_ep *gnix_ep = get_gnix_ep(fid_ep);
+
 	cr_assert(cqe->op_context == ctx, "CQE Context mismatch");
 	cr_assert(cqe->flags == flags, "CQE flags mismatch");
 
@@ -562,7 +566,7 @@ static inline void rdm_sr_check_cqe(struct fi_cq_tagged_entry *cqe, void *ctx,
 			cr_assert(cqe->buf == NULL, "CQE address mismatch");
 
 
-		if (flags & FI_REMOTE_CQ_DATA)
+		if (GNIX_ALLOW_FI_REMOTE_CQ_DATA(flags, gnix_ep->caps))
 			cr_assert(cqe->data == data, "CQE data mismatch");
 	} else {
 		cr_assert(cqe->len == 0, "Invalid CQE length");
@@ -747,14 +751,14 @@ void do_send(int len)
 				     target, len, 0, false);
 	else
 		rdm_sr_check_cqe(&d_cqe, source, (FI_MSG|FI_RECV), target, len,
-				 0, false);
+				 0, false, ep[1]);
 
 	if (scanceled)
 		rdm_sr_check_err_cqe(&s_err_cqe, target, (FI_MSG|FI_SEND), 0,
 				     0, 0, false);
 	else
 		rdm_sr_check_cqe(&s_cqe, target, (FI_MSG|FI_SEND), 0, 0, 0,
-				 false);
+				 false, ep[0]);
 
 	s[0] = 1; r[1] = 1;
 	rdm_sr_check_cntrs(s, r, s_e, r_e);
@@ -851,9 +855,9 @@ void do_sendv(int len)
 		} while (!(source_done && dest_done));
 
 		rdm_sr_check_cqe(&s_cqe, iov_dest_buf, (FI_MSG|FI_SEND), 0, 0, 0,
-				false);
+				false, ep[0]);
 		rdm_sr_check_cqe(&d_cqe, src_iov, (FI_MSG|FI_RECV), iov_dest_buf,
-				 len * iov_cnt, 0, false);
+				 len * iov_cnt, 0, false, ep[1]);
 
 		s[0] = 1; r[1] = 1;
 		rdm_sr_check_cntrs(s, r, s_e, r_e);
@@ -926,9 +930,10 @@ void do_sendmsg(int len)
 		}
 	} while (!(source_done && dest_done));
 
-	rdm_sr_check_cqe(&s_cqe, target, (FI_MSG|FI_SEND), 0, 0, 0, false);
+	rdm_sr_check_cqe(&s_cqe, target, (FI_MSG|FI_SEND), 0, 0, 0, false,
+			 ep[0]);
 	rdm_sr_check_cqe(&d_cqe, source, (FI_MSG|FI_RECV), target, len, 0,
-			false);
+			false, ep[1]);
 
 	s[0] = 1; r[1] = 1;
 	rdm_sr_check_cntrs(s, r, s_e, r_e);
@@ -999,9 +1004,10 @@ void do_sendmsgdata(int len)
 		}
 	} while (!(source_done && dest_done));
 
-	rdm_sr_check_cqe(&s_cqe, target, (FI_MSG|FI_SEND), 0, 0, 0, false);
-	rdm_sr_check_cqe(&d_cqe, source, (FI_MSG|FI_RECV|FI_REMOTE_CQ_DATA),
-			 target, len, (uint64_t)source, false);
+	rdm_sr_check_cqe(&s_cqe, target, (FI_MSG|FI_SEND), 0, 0, 0, false, ep[0]);
+	rdm_sr_check_cqe(&d_cqe, source,
+			 (FI_MSG|FI_RECV|FI_REMOTE_CQ_DATA),
+			 target, len, (uint64_t)source, false, ep[1]);
 
 	s[0] = 1; r[1] = 1;
 	rdm_sr_check_cntrs(s, r, s_e, r_e);
@@ -1053,7 +1059,7 @@ void do_inject(int len)
 
 	cr_assert_eq(ret, 1);
 	rdm_sr_check_cqe(&cqe, source, (FI_MSG|FI_RECV),
-			 target, len, (uint64_t)source, false);
+			 target, len, (uint64_t)source, false, ep[1]);
 
 	dbg_printf("got recv context event!\n");
 
@@ -1111,7 +1117,7 @@ Test(rdm_sr, inject_progress)
 
 	cr_assert_eq(ret, 1);
 	rdm_sr_check_cqe(&cqe, source, (FI_MSG|FI_RECV),
-			 target, len, (uint64_t)source, false);
+			 target, len, (uint64_t)source, false, ep[1]);
 
 	dbg_printf("got recv context event!\n");
 
@@ -1168,9 +1174,10 @@ void do_senddata(int len)
 		}
 	} while (!(source_done && dest_done));
 
-	rdm_sr_check_cqe(&s_cqe, target, (FI_MSG|FI_SEND), 0, 0, 0, false);
-	rdm_sr_check_cqe(&d_cqe, source, (FI_MSG|FI_RECV|FI_REMOTE_CQ_DATA),
-			 target, len, (uint64_t)source, false);
+	rdm_sr_check_cqe(&s_cqe, target, (FI_MSG|FI_SEND), 0, 0, 0, false, ep[0]);
+	rdm_sr_check_cqe(&d_cqe, source,
+			 (FI_MSG|FI_RECV|FI_REMOTE_CQ_DATA),
+			 target, len, (uint64_t)source, false, ep[1]);
 
 	s[0] = 1; r[1] = 1;
 	rdm_sr_check_cntrs(s, r, s_e, r_e);
@@ -1220,7 +1227,7 @@ void do_injectdata(int len)
 	}
 
 	rdm_sr_check_cqe(&cqe, source, (FI_MSG|FI_RECV|FI_REMOTE_CQ_DATA),
-			 target, len, (uint64_t)source, false);
+			 target, len, (uint64_t)source, false, ep[1]);
 
 	dbg_printf("got recv context event!\n");
 
@@ -1301,9 +1308,10 @@ void do_recvv(int len)
 			}
 		} while (!(source_done && dest_done));
 
-		rdm_sr_check_cqe(&s_cqe, dest_iov, (FI_MSG|FI_SEND), 0, 0, 0, false);
+		rdm_sr_check_cqe(&s_cqe, dest_iov, (FI_MSG|FI_SEND), 0, 0, 0,
+				 false, ep[0]);
 		rdm_sr_check_cqe(&d_cqe, iov_src_buf, (FI_MSG|FI_RECV), dest_iov,
-				 len * iov_cnt, 0, false);
+				 len * iov_cnt, 0, false, ep[1]);
 
 		s[0] = 1; r[1] = 1;
 		rdm_sr_check_cntrs(s, r, s_e, r_e);
@@ -1376,9 +1384,10 @@ void do_recvmsg(int len)
 		}
 	} while (!(source_done && dest_done));
 
-	rdm_sr_check_cqe(&s_cqe, target, (FI_MSG|FI_SEND), 0, 0, 0, false);
+	rdm_sr_check_cqe(&s_cqe, target, (FI_MSG|FI_SEND), 0, 0, 0, false,
+			 ep[0]);
 	rdm_sr_check_cqe(&d_cqe, source, (FI_MSG|FI_RECV), target, len, 0,
-			false);
+			false, ep[1]);
 
 	s[0] = 1; r[1] = 1;
 	rdm_sr_check_cntrs(s, r, s_e, r_e);
@@ -1437,9 +1446,10 @@ void do_send_autoreg(int len)
 		}
 	} while (!(source_done && dest_done));
 
-	rdm_sr_check_cqe(&s_cqe, target, (FI_MSG|FI_SEND), 0, 0, 0, false);
+	rdm_sr_check_cqe(&s_cqe, target, (FI_MSG|FI_SEND), 0, 0, 0, false,
+			 ep[0]);
 	rdm_sr_check_cqe(&d_cqe, source, (FI_MSG|FI_RECV), target, len, 0,
-			false);
+			false, ep[1]);
 
 	s[0] = 1; r[1] = 1;
 	rdm_sr_check_cntrs(s, r, s_e, r_e);
@@ -1493,9 +1503,10 @@ void do_send_autoreg_uncached(int len)
 		}
 	} while (!(source_done && dest_done));
 
-	rdm_sr_check_cqe(&s_cqe, uc_target, (FI_MSG|FI_SEND), 0, 0, 0, false);
+	rdm_sr_check_cqe(&s_cqe, uc_target, (FI_MSG|FI_SEND), 0, 0, 0, false,
+			 ep[0]);
 	rdm_sr_check_cqe(&d_cqe, uc_source, (FI_MSG|FI_RECV),
-			 uc_target, len, 0, false);
+			 uc_target, len, 0, false, ep[1]);
 
 	s[0] = 1; r[1] = 1;
 	rdm_sr_check_cntrs(s, r, s_e, r_e);
@@ -1606,9 +1617,10 @@ void do_send_autoreg_uncached_nolazydereg(int len)
 		}
 	} while (!(source_done && dest_done));
 
-	rdm_sr_check_cqe(&s_cqe, uc_target, (FI_MSG|FI_SEND), 0, 0, 0, false);
+	rdm_sr_check_cqe(&s_cqe, uc_target, (FI_MSG|FI_SEND), 0, 0, 0, false,
+			 ep[0]);
 	rdm_sr_check_cqe(&d_cqe, uc_source, (FI_MSG|FI_RECV),
-			 uc_target, len, 0, false);
+			 uc_target, len, 0, false, ep[1]);
 
 	s[0] = 1; r[1] = 1;
 	rdm_sr_check_cntrs(s, r, s_e, r_e);
@@ -1661,8 +1673,8 @@ Test(rdm_sr, send_readfrom)
 		}
 	} while (!(source_done && dest_done));
 
-	rdm_sr_check_cqe(&s_cqe, target, (FI_MSG|FI_SEND), 0, 0, 0, false);
-	rdm_sr_check_cqe(&d_cqe, source, (FI_MSG|FI_RECV), target, len, 0, false);
+	rdm_sr_check_cqe(&s_cqe, target, (FI_MSG|FI_SEND), 0, 0, 0, false, ep[0]);
+	rdm_sr_check_cqe(&d_cqe, source, (FI_MSG|FI_RECV), target, len, 0, false, ep[1]);
 
 	s[0] = 1; r[1] = 1;
 	rdm_sr_check_cntrs(s, r, s_e, r_e);
@@ -1707,8 +1719,8 @@ void do_send_buf(void *p, void *t, int len)
 		}
 	} while (!(source_done && dest_done));
 
-	rdm_sr_check_cqe(&s_cqe, t, (FI_MSG|FI_SEND), 0, 0, 0, false);
-	rdm_sr_check_cqe(&d_cqe, p, (FI_MSG|FI_RECV), t, len, 0, false);
+	rdm_sr_check_cqe(&s_cqe, t, (FI_MSG|FI_SEND), 0, 0, 0, false, ep[0]);
+	rdm_sr_check_cqe(&d_cqe, p, (FI_MSG|FI_RECV), t, len, 0, false, ep[1]);
 
 	s[0] = 1; r[1] = 1;
 	rdm_sr_check_cntrs(s, r, s_e, r_e);
@@ -1779,8 +1791,8 @@ void do_sendrecv_buf(void *p, void *t, int send_len, int recv_len)
 	} while (!(source_done && dest_done));
 
 	xfer_len = MIN(send_len, recv_len);
-	rdm_sr_check_cqe(&s_cqe, t, (FI_MSG|FI_SEND), 0, 0, 0, false);
-	rdm_sr_check_cqe(&d_cqe, p, (FI_MSG|FI_RECV), t, xfer_len, 0, false);
+	rdm_sr_check_cqe(&s_cqe, t, (FI_MSG|FI_SEND), 0, 0, 0, false, ep[0]);
+	rdm_sr_check_cqe(&d_cqe, p, (FI_MSG|FI_RECV), t, xfer_len, 0, false, ep[1]);
 
 	s[0] = 1; r[1] = 1;
 	rdm_sr_check_cntrs(s, r, s_e, r_e);
@@ -1853,9 +1865,11 @@ void do_sendvrecv_alignment(int slen, int dlen, int offset)
 			}
 		} while (!(source_done && dest_done));
 
-		rdm_sr_check_cqe(&s_cqe, (void *) iov_d_buf, (FI_MSG|FI_SEND), 0, 0, 0, false);
-		rdm_sr_check_cqe(&d_cqe, s_iov, (FI_MSG|FI_RECV), (void *) iov_d_buf,
-				 (dlen - offset) * iov_cnt, 0, false);
+		rdm_sr_check_cqe(&s_cqe, (void *) iov_d_buf, (FI_MSG|FI_SEND),
+				 0, 0, 0, false, ep[0]);
+		rdm_sr_check_cqe(&d_cqe, s_iov, (FI_MSG|FI_RECV),
+				 (void *) iov_d_buf, (dlen - offset) * iov_cnt,
+				 0, false, ep[1]);
 
 		s[0] = 1; r[1] = 1;
 		rdm_sr_check_cntrs(s, r, s_e, r_e);
@@ -1917,9 +1931,12 @@ void do_sendrecvv_alignment(int slen, int dlen, int offset)
 			}
 		} while (!(source_done && dest_done));
 
-		rdm_sr_check_cqe(&s_cqe, d_iov, (FI_MSG|FI_SEND), 0, 0, 0, false);
-		rdm_sr_check_cqe(&d_cqe, (void *) iov_s_buf, (FI_MSG|FI_RECV), d_iov,
-				 MIN((slen - offset) * iov_cnt, (dlen - offset) * iov_cnt), 0, false);
+		rdm_sr_check_cqe(&s_cqe, d_iov, (FI_MSG|FI_SEND), 0, 0, 0,
+				 false, ep[0]);
+		rdm_sr_check_cqe(&d_cqe, (void *) iov_s_buf, (FI_MSG|FI_RECV),
+				 d_iov,
+				 MIN((slen - offset) * iov_cnt, (dlen -
+					 offset) * iov_cnt), 0, false, ep[1]);
 
 		s[0] = 1; r[1] = 1;
 		rdm_sr_check_cntrs(s, r, s_e, r_e);
@@ -2087,7 +2104,7 @@ void do_multirecv(int len)
 			if (ret == 1) {
 				rdm_sr_check_cqe(&s_cqe, target,
 						 (FI_MSG|FI_SEND),
-						 0, 0, 0, false);
+						 0, 0, 0, false, ep[iep]);
 				s[iep]++;
 				sends_done++;
 			}
@@ -2111,7 +2128,7 @@ void do_multirecv(int len)
 			rdm_sr_check_cqe(&d_cqe, source,
 					 flags,
 					 (void *) expected_addrs[j],
-					 len, 0, true);
+					 len, 0, true, ep[dest_ep]);
 			cr_assert(rdm_sr_check_data(source, d_cqe.buf, len),
 				  "Data mismatch");
 			r[dest_ep]++;
@@ -2198,7 +2215,7 @@ void do_multirecv_send_first(int len)
 			if (ret == 1) {
 				rdm_sr_check_cqe(&s_cqe, target,
 						 (FI_MSG|FI_SEND),
-						 0, 0, 0, false);
+						 0, 0, 0, false, ep[iep]);
 				s[iep]++;
 				sends_done++;
 			}
@@ -2238,7 +2255,7 @@ void do_multirecv_send_first(int len)
 			if (ret == 1) {
 				rdm_sr_check_cqe(&s_cqe, target,
 						 (FI_MSG|FI_SEND),
-						 0, 0, 0, false);
+						 0, 0, 0, false, ep[iep]);
 				s[iep]++;
 				sends_done++;
 			}
@@ -2262,7 +2279,7 @@ void do_multirecv_send_first(int len)
 			rdm_sr_check_cqe(&d_cqe, source,
 					 flags,
 					 (void *)expected_addrs[j],
-					 len, 0, true);
+					 len, 0, true, ep[dest_ep]);
 			cr_assert(rdm_sr_check_data(source, d_cqe.buf, len),
 				  "Data mismatch");
 			r[dest_ep]++;
@@ -2357,7 +2374,7 @@ void do_multirecv_trunc_last(int len)
 		if (ret == 1) {
 			rdm_sr_check_cqe(&s_cqe, target,
 					 (FI_MSG|FI_SEND),
-					 0, 0, 0, false);
+					 0, 0, 0, false, ep[0]);
 			s[0]++;
 		}
 
@@ -2377,7 +2394,7 @@ void do_multirecv_trunc_last(int len)
 			rdm_sr_check_cqe(&d_cqe, source,
 					 flags,
 					 (void *) expected_addrs[j],
-					 len, 0, true);
+					 len, 0, true, ep[dest_ep]);
 			cr_assert(rdm_sr_check_data(source, d_cqe.buf, len),
 				  "Data mismatch");
 			r[dest_ep]++;
@@ -2403,7 +2420,7 @@ void do_multirecv_trunc_last(int len)
 		if (ret == 1) {
 			rdm_sr_check_cqe(&s_cqe, target,
 					 (FI_MSG|FI_SEND),
-					 0, 0, 0, false);
+					 0, 0, 0, false, ep[0]);
 			s[0]++;
 		}
 

--- a/prov/gni/test/rdm_sr.c
+++ b/prov/gni/test/rdm_sr.c
@@ -566,7 +566,8 @@ static inline void rdm_sr_check_cqe(struct fi_cq_tagged_entry *cqe, void *ctx,
 			cr_assert(cqe->buf == NULL, "CQE address mismatch");
 
 
-		if (GNIX_ALLOW_FI_REMOTE_CQ_DATA(flags, gnix_ep->caps))
+	/* TODO: Remove GNIX_ALLOW_FI_REMOTE_CQ_DATA and only check flags for FI_RMA_EVENT */
+	if (GNIX_ALLOW_FI_REMOTE_CQ_DATA(flags, gnix_ep->caps))
 			cr_assert(cqe->data == data, "CQE data mismatch");
 	} else {
 		cr_assert(cqe->len == 0, "Invalid CQE length");

--- a/prov/gni/test/sep.c
+++ b/prov/gni/test/sep.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
+ *                         All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -105,7 +106,8 @@ void sep_setup_common(int av_type)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 	hints->ep_attr->type = FI_EP_RDM;
-	hints->caps = FI_ATOMIC | FI_RMA | FI_MSG | FI_NAMED_RX_CTX | FI_TAGGED;
+	hints->caps = FI_RMA_EVENT | FI_ATOMIC | FI_RMA | FI_MSG |
+		      FI_NAMED_RX_CTX | FI_TAGGED;
 	hints->mode = FI_LOCAL_MR;
 	hints->domain_attr->cq_data_size = NUMEPS * 2;
 	hints->domain_attr->data_progress = FI_PROGRESS_AUTO;
@@ -500,8 +502,10 @@ xfer_each_size(void (*xfer)(int index, int len), int index, int slen, int elen)
 static void
 sep_check_cqe(struct fi_cq_tagged_entry *cqe, void *ctx,
 		uint64_t flags, void *addr, size_t len,
-		uint64_t data, bool buf_is_non_null, uint64_t tag)
+		uint64_t data, bool buf_is_non_null, uint64_t tag,
+		struct fid_ep *fid_ep)
 {
+	struct gnix_fid_ep *gnix_ep = get_gnix_ep(fid_ep);
 	cr_assert(cqe->op_context == ctx, "CQE Context mismatch");
 	cr_assert(cqe->flags == flags,
 		  "CQE flags mismatch cqe flags:0x%lx, flags:0x%lx", cqe->flags,
@@ -516,7 +520,7 @@ sep_check_cqe(struct fi_cq_tagged_entry *cqe, void *ctx,
 			cr_assert(cqe->buf == NULL, "CQE address mismatch");
 
 
-		if (flags & FI_REMOTE_CQ_DATA)
+		if (GNIX_ALLOW_FI_REMOTE_CQ_DATA(flags, gnix_ep->caps))
 			cr_assert(cqe->data == data, "CQE data mismatch");
 	} else {
 		cr_assert(cqe->len == 0, "Invalid CQE length");
@@ -530,12 +534,14 @@ sep_check_cqe(struct fi_cq_tagged_entry *cqe, void *ctx,
 
 static void
 sep_check_tcqe(struct fi_cq_tagged_entry *tcqe, void *ctx,
-	       uint64_t flags, uint64_t data)
+	       uint64_t flags, uint64_t data, struct fid_ep *fid_ep)
 {
+	struct gnix_fid_ep *gnix_ep = get_gnix_ep(fid_ep);
+
 	cr_assert(tcqe->op_context == ctx, "CQE Context mismatch");
 	cr_assert(tcqe->flags == flags, "CQE flags mismatch");
 
-	if (flags & FI_REMOTE_CQ_DATA) {
+	if (GNIX_ALLOW_FI_REMOTE_CQ_DATA(flags, gnix_ep->caps)) {
 		cr_assert(tcqe->data == data, "CQE data invalid");
 	} else {
 		cr_assert(tcqe->data == 0, "CQE data invalid");
@@ -771,9 +777,9 @@ static void sep_sendv(int index, int len)
 
 		wait_for_cqs(tx_cq[0][index], rx_cq[1][index], &s_cqe, &d_cqe);
 		sep_check_cqe(&s_cqe, iov_dest_buf, (FI_MSG|FI_SEND),
-				 0, 0, 0, false, 0);
+				 0, 0, 0, false, 0, tx_ep[0][index]);
 		sep_check_cqe(&d_cqe, src_iov, (FI_MSG|FI_RECV), iov_dest_buf,
-				 len * iov_cnt, 0, false, 0);
+				 len * iov_cnt, 0, false, 0, rx_ep[1][index]);
 
 		s[0] = 1; r[1] = 1;
 		sep_check_cntrs(s, r, s_e, r_e);
@@ -814,10 +820,10 @@ static void sep_tsendv(int index, int len)
 
 		wait_for_cqs(tx_cq[0][index], rx_cq[1][index], &s_cqe, &d_cqe);
 		sep_check_cqe(&s_cqe, iov_dest_buf, (FI_MSG|FI_SEND|FI_TAGGED),
-				 0, 0, 0, false, 0);
+				 0, 0, 0, false, 0, tx_ep[0][index]);
 		sep_check_cqe(&d_cqe, src_iov, (FI_MSG|FI_RECV|FI_TAGGED),
 			      iov_dest_buf, len * iov_cnt, 0, false,
-			      len * iov_cnt);
+			      len * iov_cnt, rx_ep[1][index]);
 
 		s[0] = 1; r[1] = 1;
 		sep_check_cntrs(s, r, s_e, r_e);
@@ -861,9 +867,10 @@ static void sep_recvv(int index, int len)
 
 		wait_for_cqs(tx_cq[0][index], rx_cq[1][index], &s_cqe, &d_cqe);
 		sep_check_cqe(&s_cqe, iov_dest_buf, (FI_MSG|FI_SEND),
-				 0, 0, 0, false, 0);
+				 0, 0, 0, false, 0, tx_ep[0][index]);
 		sep_check_cqe(&d_cqe, iov_src_buf, (FI_MSG|FI_RECV),
-				iov_dest_buf, len * iov_cnt, 0, false, 0);
+				iov_dest_buf, len * iov_cnt, 0, false, 0,
+			      rx_ep[1][index]);
 
 		s[0] = 1; r[1] = 1;
 		sep_check_cntrs(s, r, s_e, r_e);
@@ -926,9 +933,10 @@ static void _sendmsg(int index, int len, bool tagged)
 	cr_assert_eq(sz, 0);
 
 	wait_for_cqs(tx_cq[0][index], rx_cq[1][index], &s_cqe, &d_cqe);
-	sep_check_cqe(&s_cqe, target, sflags, 0, 0, 0, false, 0);
+	sep_check_cqe(&s_cqe, target, sflags, 0, 0, 0, false, 0,
+		      tx_ep[0][index]);
 	sep_check_cqe(&d_cqe, source, dflags, target, len, 0,
-			false, tagged ? len : 0);
+			false, tagged ? len : 0, rx_ep[1][index]);
 
 	s[0] = 1; r[1] = 1;
 	sep_check_cntrs(s, r, s_e, r_e);
@@ -994,9 +1002,10 @@ void sep_sendmsgdata(int index, int len)
 	cr_assert_eq(sz, 0);
 
 	wait_for_cqs(tx_cq[0][index], rx_cq[1][index], &s_cqe, &d_cqe);
-	sep_check_cqe(&s_cqe, target, (FI_MSG|FI_SEND), 0, 0, 0, false, 0);
+	sep_check_cqe(&s_cqe, target, (FI_MSG|FI_SEND), 0, 0, 0, false, 0,
+		      tx_ep[0][index]);
 	sep_check_cqe(&d_cqe, source, (FI_MSG|FI_RECV|FI_REMOTE_CQ_DATA),
-		      target, len, (uint64_t)source, false, 0);
+		      target, len, (uint64_t)source, false, 0, rx_ep[1][index]);
 
 	s[0] = 1; r[1] = 1;
 	sep_check_cntrs(s, r, s_e, r_e);
@@ -1031,7 +1040,8 @@ void sep_inject(int index, int len)
 
 	cr_assert_eq(ret, 1);
 	sep_check_cqe(&cqe, source, (FI_MSG|FI_RECV),
-			 target, len, (uint64_t)source, false, 0);
+			 target, len, (uint64_t)source, false, 0,
+		      rx_ep[1][index]);
 
 	/* do progress until send counter is updated */
 	while (fi_cntr_read(send_cntr[0]) < 1) {
@@ -1072,7 +1082,8 @@ void sep_tinject(int index, int len)
 
 	cr_assert_eq(ret, 1);
 	sep_check_cqe(&cqe, source, (FI_MSG|FI_RECV|FI_TAGGED),
-			 target, len, (uint64_t)source, false, len);
+			 target, len, (uint64_t)source, false, len,
+		      rx_ep[1][index]);
 
 	/* do progress until send counter is updated */
 	while (fi_cntr_read(send_cntr[0]) < 1) {
@@ -1108,9 +1119,11 @@ void sep_senddata(int index, int len)
 	cr_assert_eq(sz, 0);
 
 	wait_for_cqs(tx_cq[0][index], rx_cq[1][index], &s_cqe, &d_cqe);
-	sep_check_cqe(&s_cqe, target, (FI_MSG|FI_SEND), 0, 0, 0, false, 0);
+	sep_check_cqe(&s_cqe, target, (FI_MSG|FI_SEND), 0, 0, 0, false, 0,
+		      tx_ep[0][index]);
 	sep_check_cqe(&d_cqe, source, (FI_MSG|FI_RECV|FI_REMOTE_CQ_DATA),
-			 target, len, (uint64_t)source, false, 0);
+			 target, len, (uint64_t)source, false, 0,
+		      rx_ep[1][index]);
 
 	s[0] = 1; r[1] = 1;
 	sep_check_cntrs(s, r, s_e, r_e);
@@ -1140,10 +1153,11 @@ void sep_tsenddata(int index, int len)
 
 	wait_for_cqs(tx_cq[0][index], rx_cq[1][index], &s_cqe, &d_cqe);
 	sep_check_cqe(&s_cqe, target, (FI_MSG|FI_SEND|FI_TAGGED), 0, 0, 0,
-		      false, 0);
+		      false, 0, tx_ep[0][index]);
 	sep_check_cqe(&d_cqe, source,
 		      (FI_MSG|FI_RECV|FI_REMOTE_CQ_DATA|FI_TAGGED),
-		      target, len, (uint64_t)source, false, len);
+		      target, len, (uint64_t)source, false, len,
+		      rx_ep[1][index]);
 
 	s[0] = 1; r[1] = 1;
 	sep_check_cntrs(s, r, s_e, r_e);
@@ -1176,7 +1190,8 @@ void sep_injectdata(int index, int len)
 		fi_cq_read(tx_cq[0][index], &cqe, 1);
 	}
 	sep_check_cqe(&cqe, source, (FI_MSG|FI_RECV|FI_REMOTE_CQ_DATA),
-			 target, len, (uint64_t)source, false, 0);
+			 target, len, (uint64_t)source, false, 0,
+		      rx_ep[1][index]);
 
 	/* don't progress until send counter is updated */
 	while (fi_cntr_read(send_cntr[0]) < 1) {
@@ -1218,7 +1233,8 @@ void sep_tinjectdata(int index, int len)
 	}
 	sep_check_cqe(&cqe, source,
 		      (FI_MSG|FI_RECV|FI_REMOTE_CQ_DATA|FI_TAGGED),
-		      target, len, (uint64_t)source, false, len);
+		      target, len, (uint64_t)source, false, len,
+		      rx_ep[1][index]);
 
 	/* don't progress until send counter is updated */
 	while (fi_cntr_read(send_cntr[0]) < 1) {
@@ -1255,7 +1271,7 @@ void sep_read(int index, int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	sep_check_tcqe(&cqe, (void *)READ_CTX, FI_RMA | FI_READ, 0);
+	sep_check_tcqe(&cqe, (void *)READ_CTX, FI_RMA | FI_READ, 0, tx_ep[0][index]);
 
 	r[0] = 1;
 	sep_check_cntrs(w, r, w_e, r_e);
@@ -1286,7 +1302,7 @@ void sep_readv(int index, int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	sep_check_tcqe(&cqe, target, FI_RMA | FI_READ, 0);
+	sep_check_tcqe(&cqe, target, FI_RMA | FI_READ, 0, tx_ep[0][index]);
 
 	r[0] = 1;
 	sep_check_cntrs(w, r, w_e, r_e);
@@ -1331,7 +1347,7 @@ void sep_readmsg(int index, int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	sep_check_tcqe(&cqe, target, FI_RMA | FI_READ, 0);
+	sep_check_tcqe(&cqe, target, FI_RMA | FI_READ, 0, tx_ep[0][index]);
 
 	r[0] = 1;
 	sep_check_cntrs(w, r, w_e, r_e);
@@ -1358,7 +1374,7 @@ void sep_write(int index, int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	sep_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+	sep_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0, tx_ep[0][index]);
 
 	w[0] = 1;
 	sep_check_cntrs(w, r, w_e, r_e);
@@ -1390,7 +1406,7 @@ void sep_writev(int index, int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	sep_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+	sep_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0, tx_ep[0][index]);
 
 	w[0] = 1;
 	sep_check_cntrs(w, r, w_e, r_e);
@@ -1434,7 +1450,7 @@ void sep_writemsg(int index, int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	sep_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+	sep_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0, tx_ep[0][index]);
 
 	w[0] = 1;
 	sep_check_cntrs(w, r, w_e, r_e);
@@ -1490,7 +1506,7 @@ void sep_writedata(int index, int len)
 	}
 
 	cr_assert_eq(ret, 1);
-	sep_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
+	sep_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0, tx_ep[0][index]);
 
 	w[0] = 1;
 	sep_check_cntrs(w, r, w_e, r_e);
@@ -1503,7 +1519,7 @@ void sep_writedata(int index, int len)
 
 	sep_check_tcqe(&dcqe, NULL,
 		       (FI_RMA | FI_REMOTE_WRITE | FI_REMOTE_CQ_DATA),
-		       WRITE_DATA);
+		       WRITE_DATA, rx_ep[1][index]);
 }
 
 #define INJECTWRITE_DATA 0xdededadadeadbeaf
@@ -1541,7 +1557,7 @@ void sep_inject_writedata(int index, int len)
 
 	sep_check_tcqe(&dcqe, NULL,
 		      (FI_RMA | FI_REMOTE_WRITE | FI_REMOTE_CQ_DATA),
-		      INJECTWRITE_DATA);
+		      INJECTWRITE_DATA, rx_ep[1][index]);
 }
 
 #define SOURCE_DATA	0xBBBB0000CCCCULL
@@ -1568,7 +1584,7 @@ void sep_atomic(int index)
 	}
 
 	cr_assert_eq(ret, 1);
-	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_WRITE, 0);
+	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_WRITE, 0, tx_ep[0][index]);
 
 	w[0] = 1;
 	sep_check_cntrs(w, r, w_e, r_e);
@@ -1604,7 +1620,7 @@ void sep_atomic_v(int index)
 	}
 
 	cr_assert_eq(ret, 1);
-	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_WRITE, 0);
+	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_WRITE, 0, tx_ep[0][index]);
 
 	w[0] = 1;
 	sep_check_cntrs(w, r, w_e, r_e);
@@ -1656,7 +1672,7 @@ void sep_atomic_msg(int index)
 	}
 
 	cr_assert_eq(ret, 1);
-	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_WRITE, 0);
+	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_WRITE, 0, tx_ep[0][index]);
 
 	w[0] = 1;
 	sep_check_cntrs(w, r, w_e, r_e);
@@ -1719,7 +1735,7 @@ void sep_atomic_rw(int index)
 	}
 
 	cr_assert_eq(ret, 1);
-	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_READ, 0);
+	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_READ, 0, tx_ep[0][index]);
 
 	r[0] = 1;
 	sep_check_cntrs(w, r, w_e, r_e);
@@ -1760,7 +1776,7 @@ void sep_atomic_rwv(int index)
 	}
 
 	cr_assert_eq(ret, 1);
-	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_READ, 0);
+	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_READ, 0, tx_ep[0][index]);
 
 	r[0] = 1;
 	sep_check_cntrs(w, r, w_e, r_e);
@@ -1815,7 +1831,7 @@ void sep_atomic_rwmsg(int index)
 	}
 
 	cr_assert_eq(ret, 1);
-	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_READ, 0);
+	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_READ, 0, tx_ep[0][index]);
 
 	r[0] = 1;
 	sep_check_cntrs(w, r, w_e, r_e);
@@ -1855,7 +1871,7 @@ void sep_atomic_compwrite(int index)
 	}
 
 	cr_assert_eq(ret, 1);
-	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_READ, 0);
+	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_READ, 0, tx_ep[0][index]);
 
 	r[0] = 1;
 	sep_check_cntrs(w, r, w_e, r_e);
@@ -1907,7 +1923,7 @@ void sep_atomic_compwritev(int index)
 	}
 
 	cr_assert_eq(ret, 1);
-	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_READ, 0);
+	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_READ, 0, tx_ep[0][index]);
 	r[0] = 1;
 	sep_check_cntrs(w, r, w_e, r_e);
 	ret = *((double *)target) == (double)SOURCE_DATA_FP;
@@ -1963,7 +1979,7 @@ void sep_atomic_compwritemsg(int index)
 	}
 
 	cr_assert_eq(ret, 1);
-	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_READ, 0);
+	sep_check_tcqe(&cqe, target, FI_ATOMIC | FI_READ, 0, tx_ep[0][index]);
 	r[0] = 1;
 	sep_check_cntrs(w, r, w_e, r_e);
 	ret = *((uint64_t *)target) == SOURCE_DATA;

--- a/prov/gni/test/sep.c
+++ b/prov/gni/test/sep.c
@@ -520,7 +520,8 @@ sep_check_cqe(struct fi_cq_tagged_entry *cqe, void *ctx,
 			cr_assert(cqe->buf == NULL, "CQE address mismatch");
 
 
-		if (GNIX_ALLOW_FI_REMOTE_CQ_DATA(flags, gnix_ep->caps))
+	/* TODO: Remove GNIX_ALLOW_FI_REMOTE_CQ_DATA and only check flags for FI_RMA_EVENT */
+	if (GNIX_ALLOW_FI_REMOTE_CQ_DATA(flags, gnix_ep->caps))
 			cr_assert(cqe->data == data, "CQE data mismatch");
 	} else {
 		cr_assert(cqe->len == 0, "Invalid CQE length");
@@ -541,6 +542,7 @@ sep_check_tcqe(struct fi_cq_tagged_entry *tcqe, void *ctx,
 	cr_assert(tcqe->op_context == ctx, "CQE Context mismatch");
 	cr_assert(tcqe->flags == flags, "CQE flags mismatch");
 
+	/* TODO: Remove GNIX_ALLOW_FI_REMOTE_CQ_DATA and only check flags for FI_RMA_EVENT */
 	if (GNIX_ALLOW_FI_REMOTE_CQ_DATA(flags, gnix_ep->caps)) {
 		cr_assert(tcqe->data == data, "CQE data invalid");
 	} else {


### PR DESCRIPTION
- Ensure that FI_REMOTE_CQ_DATA is only used when
FI_RMA_EVENT is also set.

- Added macro to check the previous condition.

- Updated rma source and unit tests to reflect these
changes.

- Updated VC struct doxy comment.

Note: I'm not sure we should be ORing in the FI_RMA_EVENT
flag in the changes I made for gnix_ep.c and the rdm* unit
tests. Also, the macro names might need some work.

Fixes #1190 and #1240.

Signed-off-by: Evan Harvey <eharvey@lanl.gov>