### PR TITLE
prov/gni: Remove ref count check of deleted nic

### DIFF
--- a/prov/gni/test/mr.c
+++ b/prov/gni/test/mr.c
@@ -389,7 +389,6 @@ Test(mr_internal_bare, bug_1086)
 	
 	ret = fi_close(&mr->fid);
 	cr_assert(ret == FI_SUCCESS);
-	cr_assert(atomic_get(&g_nic->ref_cnt.references) == 0);
 }
 
 /* Test invalid flags to fi_mr_reg */


### PR DESCRIPTION
This was reading the ref count in the field of a deleted struct.

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>