### PR TITLE
prov/gni: Fix SOS auto VC connect in shmem

### DIFF
--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -2065,6 +2065,13 @@ int _gnix_vc_tx_schedule(struct gnix_vc *vc)
  * Note: EP must be locked. */
 int _gnix_vc_sched_new_conn(struct gnix_vc *vc)
 {
+	int ret;
+
+	ret = __gnix_vc_push_tx_reqs(vc);
+	if (ret != FI_SUCCESS) {
+		GNIX_WARN(FI_LOG_EP_DATA, "__gnix_vc_push_tx_reqs failed: %d\n",
+			  ret);
+	}
 	return _gnix_vc_schedule(vc);
 }
 


### PR DESCRIPTION
Locking changes in a8ccd9fa broke shmem apps.  Re-add the following changes:
-Do CM progress before returning from a PUT
-Push TX queue after VC connect

Signed-off-by: Zach <ztiffany@cray.com>

Testing:

-gnitest passing
-SOS 'make check' mostly passing (I've now seen up to 5 test fail)
-2 proc OSU suite passing.  Performance mostly similar to upstream.

@hppritcha @sungeunchoi 