### PR TITLE
Remove #define of cr_log_info needed for v2.2.2

### DIFF
--- a/prov/gni/test/common.h
+++ b/prov/gni/test/common.h
@@ -43,7 +43,6 @@
 
 #define BLUE "\x1b[34m"
 #define COLOR_RESET "\x1b[0m"
-#define cr_log_info criterion_info
 
 /* defined in rdm_atomic.c */
 extern int supported_compare_atomic_ops[FI_ATOMIC_OP_LAST][FI_DATATYPE_LAST];


### PR DESCRIPTION
After this commit, you will need to use Criterion v2.3.0 or later.

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>