### PR TITLE
prov/gni: Clean up scalable endpoint leak

### DIFF
--- a/prov/gni/src/gnix_sep.c
+++ b/prov/gni/src/gnix_sep.c
@@ -417,7 +417,6 @@ DIRECT_FN STATIC int gnix_sep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 				return -FI_EINVAL;
 			}
 			ep->av = av;
-			_gnix_ep_init_vc(ep);
 			_gnix_ref_get(ep->av);
 		}
 


### PR DESCRIPTION
The call to _gnix_ep_init_vc in unnecessary in gnix_sep_bind

fixes ofi-cray/libfabric-cray#1270

Signed-off-by: Chuck Fossen <chuckf@cray.com>