### PR TITLE
prov/gni: Do a noop for setup and teardown for null hints.

### DIFF
--- a/prov/gni/test/api.c
+++ b/prov/gni/test/api.c
@@ -218,6 +218,14 @@ void rdm_api_setup(void)
 	}
 }
 
+void api_setup(void)
+{
+}
+
+void api_teardown(void)
+{
+}
+
 static void rdm_api_teardown_common(bool unreg)
 {
 	int ret = 0, i = 0;
@@ -843,7 +851,9 @@ Test(rdm_api, amo_write_read_w_msg)
 	api_write_read(BUF_SZ);
 }
 
-Test(rdm_api, getinfo_w_null_hints)
+TestSuite(api, .init = api_setup, .fini = api_teardown, .disabled = false);
+
+Test(api, getinfo_w_null_hints)
 {
 	int ret;
 


### PR DESCRIPTION
gnitest is reporting:  `[----] Warning! The test `rdm_api::getinfo_w_null_hints` crashed during its setup or teardown.`

This PR puts getinfo_w_null_hints in its own test suite.

Fixes #1281.

Signed-off-by: Evan Harvey <eharvey@lanl.gov>