### PR TITLE
Add domain op to enable trans. CQ IRQs

### DIFF
--- a/prov/gni/include/fi_ext_gni.h
+++ b/prov/gni/include/fi_ext_gni.h
@@ -66,6 +66,7 @@ typedef enum dom_ops_val { GNI_MSG_RENDEZVOUS_THRESHOLD,
 			   GNI_MR_HARD_STALE_REG_LIMIT,
 			   GNI_XPMEM_ENABLE,
 			   GNI_DGRAM_PROGRESS_TIMEOUT,
+			   GNI_EAGER_AUTO_PROGRESS,
 			   GNI_NUM_DOM_OPS
 } dom_ops_val_t;
 
@@ -125,6 +126,7 @@ struct gnix_ops_domain {
 	int32_t err_inject_count;
 	bool xpmem_enabled;
 	uint32_t dgram_progress_timeout;
+	uint32_t eager_auto_progress;
 };
 
 struct fi_gni_ops_fab {

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -285,6 +285,7 @@ static const uint32_t default_tx_cq_size = 2048;
 static const uint32_t default_max_retransmits = 5;
 static const int32_t default_err_inject_count; /* static var is zeroed */
 static const uint32_t default_dgram_progress_timeout = 100;
+static const uint32_t default_eager_auto_progress = 0;
 
 static int __gnix_string_to_mr_type(const char *name)
 {
@@ -399,6 +400,9 @@ __gnix_dom_ops_get_val(struct fid *fid, dom_ops_val_t t, void *val)
 	case GNI_DGRAM_PROGRESS_TIMEOUT:
 		*(uint32_t *)val = domain->params.dgram_progress_timeout;
 		break;
+	case GNI_EAGER_AUTO_PROGRESS:
+		*(uint32_t *)val = domain->params.eager_auto_progress;
+		break;
 	default:
 		GNIX_WARN(FI_LOG_DOMAIN, ("Invalid dom_ops_val\n"));
 		return -FI_EINVAL;
@@ -510,6 +514,9 @@ __gnix_dom_ops_set_val(struct fid *fid, dom_ops_val_t t, void *val)
 		break;
 	case GNI_DGRAM_PROGRESS_TIMEOUT:
 		domain->params.dgram_progress_timeout = *(uint32_t *)val;
+		break;
+	case GNI_EAGER_AUTO_PROGRESS:
+		domain->params.eager_auto_progress = *(uint32_t *)val;
 		break;
 	default:
 		GNIX_WARN(FI_LOG_DOMAIN, ("Invalid dom_ops_val\n"));
@@ -637,6 +644,7 @@ DIRECT_FN int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	domain->params.xpmem_enabled = false;
 #endif
 	domain->params.dgram_progress_timeout = default_dgram_progress_timeout;
+	domain->params.eager_auto_progress = default_eager_auto_progress;
 
 	domain->gni_cq_modes = gnix_def_gni_cq_modes;
 	_gnix_ref_init(&domain->ref_cnt, 1, __domain_destruct);

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -3015,12 +3015,11 @@ ssize_t _gnix_send(struct gnix_fid_ep *ep, uint64_t loc_addr, size_t len,
 	req->msg.send_info[0].send_len = len;
 	req->msg.cum_send_len = len;
 	req->msg.imm = data;
-	req->flags = 0;
+	req->flags = flags;
 
 	if (flags & FI_INJECT) {
 		memcpy(req->inject_buf, (void *)loc_addr, len);
 		req->msg.send_info[0].send_addr = (uint64_t)req->inject_buf;
-		req->flags |= FI_INJECT;
 	} else {
 		req->msg.send_info[0].send_addr = loc_addr;
 	}
@@ -3387,7 +3386,7 @@ ssize_t _gnix_sendv(struct gnix_fid_ep *ep, const struct iovec *iov,
 	req->gnix_ep = ep;
 	req->user_context = context;
 	req->work_fn = _gnix_send_req;
-	req->flags = 0; /* Flags that apply to all message types? */
+	req->flags = flags;
 	req->msg.send_flags = flags;
 	req->msg.imm = 0;
 

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -150,7 +150,7 @@ try_again:
 		/*
 		 * first dequeue RX CQEs
 		 */
-		if (which == 1) {
+		if (nic->rx_cq_blk != nic->rx_cq && which == 1) {
 			do {
 				status = GNI_CqGetEvent(nic->rx_cq_blk,
 							&cqe);
@@ -563,7 +563,7 @@ int _gnix_nic_progress(void *arg)
 	if (unlikely(ret != FI_SUCCESS))
 		return ret;
 
-	if (nic->tx_cq_blk) {
+	if (nic->tx_cq_blk && nic->tx_cq_blk != nic->tx_cq) {
 		ret =  __nic_tx_progress(nic, nic->tx_cq_blk);
 		if (unlikely(ret != FI_SUCCESS))
 			return ret;
@@ -785,6 +785,17 @@ static void __nic_destruct(void *obj)
 
 	assert(nic->gni_cdm_hndl != NULL);
 
+	if (nic->rx_cq != NULL && nic->rx_cq != nic->rx_cq_blk) {
+		status = GNI_CqDestroy(nic->rx_cq);
+		if (status != GNI_RC_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "GNI_CqDestroy returned %s\n",
+				 gni_err_str[status]);
+			ret = gnixu_to_fi_errno(status);
+			goto err;
+		}
+	}
+
 	if (nic->rx_cq_blk != NULL) {
 		status = GNI_CqDestroy(nic->rx_cq_blk);
 		if (status != GNI_RC_SUCCESS) {
@@ -796,8 +807,8 @@ static void __nic_destruct(void *obj)
 		}
 	}
 
-	if (nic->rx_cq != NULL) {
-		status = GNI_CqDestroy(nic->rx_cq);
+	if (nic->tx_cq != NULL && nic->tx_cq != nic->tx_cq_blk) {
+		status = GNI_CqDestroy(nic->tx_cq);
 		if (status != GNI_RC_SUCCESS) {
 			GNIX_WARN(FI_LOG_EP_CTRL,
 				  "GNI_CqDestroy returned %s\n",
@@ -809,17 +820,6 @@ static void __nic_destruct(void *obj)
 
 	if (nic->tx_cq_blk != NULL) {
 		status = GNI_CqDestroy(nic->tx_cq_blk);
-		if (status != GNI_RC_SUCCESS) {
-			GNIX_WARN(FI_LOG_EP_CTRL,
-				  "GNI_CqDestroy returned %s\n",
-				 gni_err_str[status]);
-			ret = gnixu_to_fi_errno(status);
-			goto err;
-		}
-	}
-
-	if (nic->tx_cq != NULL) {
-		status = GNI_CqDestroy(nic->tx_cq);
 		if (status != GNI_RC_SUCCESS) {
 			GNIX_WARN(FI_LOG_EP_CTRL,
 				  "GNI_CqDestroy returned %s\n",
@@ -1009,24 +1009,6 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 
 		status = GNI_CqCreate(nic->gni_nic_hndl,
 					domain->params.tx_cq_size,
-					0,                  /* no delay count */
-					GNI_CQ_NOBLOCK |
-					domain->gni_cq_modes,
-					NULL,              /* useless handler */
-					NULL,               /* useless handler
-								context */
-					&nic->tx_cq);
-		if (status != GNI_RC_SUCCESS) {
-			GNIX_WARN(FI_LOG_EP_CTRL,
-				  "GNI_CqCreate returned %s\n",
-				  gni_err_str[status]);
-			_gnix_dump_gni_res(domain->ptag);
-			ret = gnixu_to_fi_errno(status);
-			goto err1;
-		}
-
-		status = GNI_CqCreate(nic->gni_nic_hndl,
-					domain->params.tx_cq_size,
 					0,
 					GNI_CQ_BLOCKING |
 						domain->gni_cq_modes,
@@ -1042,26 +1024,32 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 			goto err1;
 		}
 
+		/* Use blocking CQs for all operations if eager_auto_progress
+		 * is used.  */
+		if (domain->params.eager_auto_progress) {
+			nic->tx_cq = nic->tx_cq_blk;
+		} else {
+			status = GNI_CqCreate(nic->gni_nic_hndl,
+						domain->params.tx_cq_size,
+						0, /* no delay count */
+						domain->gni_cq_modes,
+						NULL, /* useless handler */
+						NULL, /* useless handler ctx */
+						&nic->tx_cq);
+			if (status != GNI_RC_SUCCESS) {
+				GNIX_WARN(FI_LOG_EP_CTRL,
+					  "GNI_CqCreate returned %s\n",
+					  gni_err_str[status]);
+				_gnix_dump_gni_res(domain->ptag);
+				ret = gnixu_to_fi_errno(status);
+				goto err1;
+			}
+		}
+
+
 		/*
 		 * create RX CQs - first polling, then blocking
 		 */
-
-		status = GNI_CqCreate(nic->gni_nic_hndl,
-					domain->params.rx_cq_size,
-					0,
-					GNI_CQ_NOBLOCK |
-						domain->gni_cq_modes,
-					NULL,
-					NULL,
-					&nic->rx_cq);
-		if (status != GNI_RC_SUCCESS) {
-			GNIX_WARN(FI_LOG_EP_CTRL,
-				  "GNI_CqCreate returned %s\n",
-				  gni_err_str[status]);
-			_gnix_dump_gni_res(domain->ptag);
-			ret = gnixu_to_fi_errno(status);
-			goto err1;
-		}
 
 		status = GNI_CqCreate(nic->gni_nic_hndl,
 					domain->params.rx_cq_size,
@@ -1078,6 +1066,28 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 			_gnix_dump_gni_res(domain->ptag);
 			ret = gnixu_to_fi_errno(status);
 			goto err1;
+		}
+
+		/* Use blocking CQs for all operations if eager_auto_progress
+		 * is used.  */
+		if (domain->params.eager_auto_progress) {
+			nic->rx_cq = nic->rx_cq_blk;
+		} else {
+			status = GNI_CqCreate(nic->gni_nic_hndl,
+						domain->params.rx_cq_size,
+						0,
+						domain->gni_cq_modes,
+						NULL,
+						NULL,
+						&nic->rx_cq);
+			if (status != GNI_RC_SUCCESS) {
+				GNIX_WARN(FI_LOG_EP_CTRL,
+					  "GNI_CqCreate returned %s\n",
+					  gni_err_str[status]);
+				_gnix_dump_gni_res(domain->ptag);
+				ret = gnixu_to_fi_errno(status);
+				goto err1;
+			}
 		}
 
 		nic->device_addr = device_addr;
@@ -1296,14 +1306,14 @@ err:
 			_gnix_mbox_allocator_destroy(nic->s_rdma_buf_hndl);
 		if (nic->mbox_hndl != NULL)
 			_gnix_mbox_allocator_destroy(nic->mbox_hndl);
+		if (nic->rx_cq != NULL && nic->rx_cq != nic->rx_cq_blk)
+			GNI_CqDestroy(nic->rx_cq);
 		if (nic->rx_cq_blk != NULL)
 			GNI_CqDestroy(nic->rx_cq_blk);
-		if (nic->rx_cq != NULL)
-			GNI_CqDestroy(nic->rx_cq);
+		if (nic->tx_cq != NULL && nic->tx_cq != nic->tx_cq_blk)
+			GNI_CqDestroy(nic->tx_cq);
 		if (nic->tx_cq_blk != NULL)
 			GNI_CqDestroy(nic->tx_cq_blk);
-		if (nic->tx_cq != NULL)
-			GNI_CqDestroy(nic->tx_cq);
 		if ((nic->gni_cdm_hndl != NULL) && (nic->allocd_gni_res &
 		    GNIX_NIC_CDM_ALLOCD))
 			GNI_CdmDestroy(nic->gni_cdm_hndl);


### PR DESCRIPTION
Enabling CQ IRQs in GNI allows the data auto progress thread to complete all
transaction asynchronously.

Fixes ofi-cray/libfabric-cray#1036

Signed-off-by: Zach <ztiffany@cray.com>