### PR TITLE
prov/gni: mr_mode changes for 1.5

### DIFF
--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -204,7 +204,7 @@ static struct fi_info *_gnix_allocinfo(void)
 
 	gnix_info->domain_attr->name = strdup(gnix_dom_name);
 	gnix_info->domain_attr->cq_data_size = sizeof(uint64_t);
-	gnix_info->domain_attr->mr_mode = FI_MR_BASIC;
+	gnix_info->domain_attr->mr_mode = OFI_MR_BASIC_MAP;
 	gnix_info->domain_attr->resource_mgmt = FI_RM_ENABLED;
 	gnix_info->domain_attr->mr_key_size = sizeof(uint64_t);
 	gnix_info->domain_attr->max_ep_tx_ctx = GNIX_SEP_MAX_CNT;
@@ -505,10 +505,14 @@ static int _gnix_ep_getinfo(enum fi_ep_type ep_type, uint32_t version,
 				gnix_info->domain_attr->data_progress =
 					hints->domain_attr->data_progress;
 
+
 			switch (hints->domain_attr->mr_mode) {
 			case FI_MR_UNSPEC:
 			case FI_MR_BASIC:
-				gnix_info->domain_attr->mr_mode = FI_MR_BASIC;
+				if (FI_VERSION_GE(version, FI_VERSION(1, 5))) {
+					hints->domain_attr->mr_mode =
+						OFI_MR_BASIC_MAP;
+				}
 				break;
 			case FI_MR_SCALABLE:
 				goto err;

--- a/prov/gni/test/api.c
+++ b/prov/gni/test/api.c
@@ -448,6 +448,12 @@ Test(api, dom_caps)
 	ret = fi_getinfo(fi_version(), NULL, 0, 0, hints[0], &fi[0]);
 	cr_assert_eq(ret, 0, "fi_getinfo");
 
+	fi_freeinfo(fi[0]);
+
+	hints[0]->domain_attr->mr_mode = FI_MR_UNSPEC;
+	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints[0], &fi[0]);
+	cr_assert_eq(ret, 0, "fi_getinfo");
+
 	fi_freeinfo(hints[0]);
 	fi_freeinfo(fi[0]);
 }


### PR DESCRIPTION
This is meant to fix the upstream test failures that ofi_check_mr_mode
introduced and is intended to be merged in coordination with the upstream
pull.

upstream merge of ofi-cray/libfabric-cray#1277

Signed-off-by: Chuck Fossen <chuckf@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@cb50df14ca256bd06d2fbb46fad544ff4961af00)