### PR TITLE
prov/gni: add a cpus-per-task parameter to gnitest

### DIFF
--- a/prov/gni/test/run_gnitest
+++ b/prov/gni/test/run_gnitest
@@ -63,8 +63,11 @@ if [ ! -f "$gnitest_bin" ]; then
     exit -1
 fi
 
+#
+# need to ask for multi cpus for some slurm systems
+#
 if [ $launcher = "srun" ]; then
-    args="-N1 --exclusive --cpu_bind=none -t00:20:00 --ntasks=1"
+    args="-N1 --exclusive --cpu_bind=none -t00:20:00 --ntasks=1 --cpus-per-task=16"
 else
     args="-n1 -N1 -j0 -cc none -t1200"
 fi


### PR DESCRIPTION
script.

For some SLURM systems, the default resource allocation,
etc.  don't work well with our criterion tests.

Add a --cpus-per-task=16 to the srun argument to fix this.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>