### PR TITLE
prov/gni: address issue 1311

### DIFF
--- a/prov/gni/src/gnix_cntr.c
+++ b/prov/gni/src/gnix_cntr.c
@@ -335,7 +335,6 @@ DIRECT_FN STATIC uint64_t gnix_cntr_read(struct fid_cntr *cntr)
 		return -FI_EINVAL;
 
 	cntr_priv = container_of(cntr, struct gnix_fid_cntr, cntr_fid);
-	v = atomic_get(&cntr_priv->cnt);
 
 	if (cntr_priv->wait)
 		gnix_wait_wait((struct fid_wait *)cntr_priv->wait, 0);
@@ -344,6 +343,8 @@ DIRECT_FN STATIC uint64_t gnix_cntr_read(struct fid_cntr *cntr)
 	if (ret != FI_SUCCESS)
 		GNIX_WARN(FI_LOG_CQ, " __gnix_cntr_progress returned %d.\n",
 			  ret);
+
+	v = atomic_get(&cntr_priv->cnt);
 
 	return (uint64_t)v;
 }

--- a/prov/gni/test/rdm_tagged_sr.c
+++ b/prov/gni/test/rdm_tagged_sr.c
@@ -535,7 +535,7 @@ void do_tinject(int len)
 	cr_assert(rdm_tagged_sr_check_data(source, target, len), "Data mismatch");
 }
 
-Test(rdm_tagged_sr, tinject)
+Test(rdm_tagged_sr, tinject, .disabled = false)
 {
 	rdm_tagged_sr_xfer_for_each_size(do_tinject, 1, INJECT_SIZE);
 }


### PR DESCRIPTION
It turns out that some of the GNI provider criterion tests
don't currently test TX counters correctly when using the
fi_inject and related paths.  The method taken to progress
the TX side when using inject isn't sufficient, and depending
on timing, the TX counter values read aren't the "expected" ones.

To avoid the many false failures we are currently seeing in nightly
jenkins tests, disable these tests.  An issue ofi-cray/libfabric-cray#1330
has been opened to track this.

Fixes ofi-cray/libfabric-cray#1311
Fixes ofi-cray/libfabric-cray#1095

Signed-off-by: Howard Pritchard <howardp@lanl.gov>