### PR TITLE
prov/gni: be more accurate about nic allocation

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -418,6 +418,7 @@ struct gnix_fid_domain {
 #ifdef HAVE_UDREG
 	udreg_cache_handle_t udreg_cache;
 #endif
+	uint32_t num_allocd_stxs;
 };
 
 /**

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -152,7 +152,8 @@ DIRECT_FN STATIC int gnix_stx_open(struct fid_domain *dom,
 	 * a TX context (aka gnix nic) that can be shared
 	 * explicitly amongst endpoints
 	 */
-	nic_attr.must_alloc = true;
+	nic_attr.must_alloc = (domain->num_allocd_stxs <
+					gnix_max_nics_per_ptag) ? true : false;
 	ret = gnix_nic_alloc(domain, &nic_attr, &nic);
 	if (ret != FI_SUCCESS) {
 		GNIX_WARN(FI_LOG_EP_CTRL,
@@ -170,6 +171,7 @@ DIRECT_FN STATIC int gnix_stx_open(struct fid_domain *dom,
 	stx_priv->stx_fid.fid.context = context;
 	stx_priv->stx_fid.fid.ops = &gnix_stx_ops;
 	stx_priv->stx_fid.ops = NULL;
+	domain->num_allocd_stxs++;
 
 	*stx = &stx_priv->stx_fid;
 

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -199,7 +199,12 @@ static struct fi_info *_gnix_allocinfo(void)
 	gnix_info->domain_attr->control_progress = FI_PROGRESS_AUTO;
 	gnix_info->domain_attr->data_progress = FI_PROGRESS_AUTO;
 	gnix_info->domain_attr->av_type = FI_AV_UNSPEC;
-	gnix_info->domain_attr->tx_ctx_cnt = gnix_max_nics_per_ptag;
+	/*
+	 * the cm_nic currently sucks up one of the gnix_nic's so
+	 * we have to subtract one from the gnix_max_nics_per_ptag.
+	 */
+	gnix_info->domain_attr->tx_ctx_cnt = (gnix_max_nics_per_ptag == 1) ?
+						1 : gnix_max_nics_per_ptag - 1;
 	gnix_info->domain_attr->rx_ctx_cnt = gnix_max_nics_per_ptag;
 	gnix_info->domain_attr->cntr_cnt = _gnix_get_cq_limit() / 2;
 

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -261,13 +261,16 @@ static int __nic_teardown_irq_cq(struct gnix_nic *nic)
 	if (nic->irq_mmap_addr == NULL)
 		return ret;
 
-	status = GNI_MemDeregister(nic->gni_nic_hndl,
-				  &nic->irq_mem_hndl);
-	if (status != GNI_RC_SUCCESS) {
-		ret = gnixu_to_fi_errno(status);
-		GNIX_WARN(FI_LOG_EP_CTRL,
-			  "GNI_MemDeregister returned %s\n",
-			  gni_err_str[status]);
+	if ((nic->irq_mem_hndl.qword1) ||
+		(nic->irq_mem_hndl.qword2)) {
+		status = GNI_MemDeregister(nic->gni_nic_hndl,
+					  &nic->irq_mem_hndl);
+		if (status != GNI_RC_SUCCESS) {
+			ret = gnixu_to_fi_errno(status);
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "GNI_MemDeregister returned %s\n",
+				  gni_err_str[status]);
+		}
 	}
 
 	munmap(nic->irq_mmap_addr,
@@ -767,6 +770,11 @@ static void __nic_destruct(void *obj)
 			  "_gnix_mbox_allocator_destroy returned %s\n",
 			  fi_strerror(-ret));
 
+	/*
+	 * see comments in the nic constructor about why
+	 * the following code section is currently stubbed out.
+	 */
+#if 0
 	ret = _gnix_mbox_allocator_destroy(nic->s_rdma_buf_hndl);
 	if (ret != FI_SUCCESS)
 		GNIX_WARN(FI_LOG_EP_CTRL,
@@ -778,6 +786,7 @@ static void __nic_destruct(void *obj)
 		GNIX_WARN(FI_LOG_EP_CTRL,
 			  "_gnix_mbox_allocator_destroy returned %s\n",
 			  fi_strerror(-ret));
+#endif
 
 	if (!nic->gni_cdm_hndl) {
 		GNIX_WARN(FI_LOG_EP_CTRL, "No CDM attached to nic, nic=%p");
@@ -1203,8 +1212,11 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 		 * TODO: hardwired constants, uff
 		 * TODO: better to use a buddy allocator or some other
 		 * allocator
+		 * Disable these for now as we're not using and they
+		 * chew up a lot of IOMMU space per nic.
 		 */
 
+#if 0
 		ret = _gnix_mbox_allocator_create(nic,
 						  NULL,
 						  GNIX_PAGE_2MB,
@@ -1215,6 +1227,7 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 			GNIX_WARN(FI_LOG_EP_CTRL,
 				  "_gnix_mbox_alloc returned %s\n",
 				  fi_strerror(-ret));
+			_gnix_dump_gni_res(domain->ptag);
 			goto err1;
 		}
 
@@ -1228,14 +1241,17 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 			GNIX_WARN(FI_LOG_EP_CTRL,
 				  "_gnix_mbox_alloc returned %s\n",
 				  fi_strerror(-ret));
+			_gnix_dump_gni_res(domain->ptag);
 			goto err1;
 		}
+#endif
 
 		ret =  __nic_setup_irq_cq(nic);
 		if (ret != FI_SUCCESS) {
 			GNIX_WARN(FI_LOG_EP_CTRL,
 				  "__nic_setup_irq_cq returned %s\n",
 				  fi_strerror(-ret));
+			_gnix_dump_gni_res(domain->ptag);
 			goto err1;
 		}
 


### PR DESCRIPTION
when using shared TX contexts.

Also, improve the cleanup code in the error path
when we fail to allocate a gnix_nic due to underlying
resource constraints.

Also, since they chew up IOMMU space and aren't being
used currently, if def out code to allocate send/receive
buffers when allocating a gnix_nic.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>