### PR TITLE
prov/gni: fix gnix wait stalls

### DIFF
--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -165,6 +165,7 @@ struct gnix_nic_attr {
 struct gnix_nic {
 	struct dlist_entry gnix_nic_list; /* global NIC list */
 	struct dlist_entry ptag_nic_list; /* global PTAG NIC list */
+	struct dlist_entry gnix_nic_prog_list; /* temporary list for nic progression */
 	fastlock_t lock;
 	uint32_t allocd_gni_res;
 	gni_cdm_handle_t gni_cdm_hndl;


### PR DESCRIPTION
The wait subsystem could deadlock with the MR
code as they both took the gnix_nic_list_lock.
Another cause of deadlock was gni can issue
completions so fast that the fd becomes full.

Refactored wait_thread_func to build a list
with a ref on the nic then iterate over those
nic's without the lock.

Change wait write_fd to be non_blocking so
when the pipeline is full it doesnt get stuck.

Signed-off-by: James Shimek <jshimek@cray.com>

Fixes #1319 and #1337