### PR TITLE
Fix race condition in GNIX_GET_AUTH_KEY

### DIFF
--- a/prov/gni/include/gnix_auth_key.h
+++ b/prov/gni/include/gnix_auth_key.h
@@ -175,9 +175,14 @@ int _gnix_auth_key_insert(
 			_tmp = _gnix_auth_key_create( \
 				(auth_key), (auth_key_size)); \
 			if (!_tmp) { \
-				GNIX_WARN(FI_LOG_FABRIC, \
+				GNIX_DEBUG(FI_LOG_FABRIC, \
 					"failed to create new " \
-					"authorization key\n"); \
+					"authorization key, "\
+					"another thread beat us to the insert " \
+					"- searching again\n"); \
+				_tmp = _gnix_auth_key_lookup((auth_key), \
+					(auth_key_size)); \
+				assert(_tmp); \
 			} \
 			_tmp_ret = _gnix_auth_key_enable(_tmp); \
 			if (_tmp_ret) { \


### PR DESCRIPTION
If one thread beats another to auth key creation, it could attempt to enable
a null pointer. This patch addresses it by re-fetching the auth-key under
lock and enables the key, if not already enabled.

Signed-off-by: James Swaro <jswaro@cray.com>