### PR TITLE
prov/gni: Refactor GNI provider FI_MULTI_RECV

### DIFF
--- a/man/fi_gni.7.md
+++ b/man/fi_gni.7.md
@@ -267,6 +267,12 @@ address format. In order to populate the remote peer's address vector
 with this mechanism, the application must call fi_cq_readerr to get the
 source address followed by fi_av_insert on the populated err_data member.
 
+For FI_MULTI_RECV, the GNI provider generates a separate FI_MULTI_RECV CQ event
+once the receive buffer has been consumed.  Also, owing to the out-or-order nature
+of the Cray network, the CQ events associated with individual messages arriving in the
+receive buffer may be generated out of order with respect to the offset into the buffer
+into which the messages were received.
+
 # KNOWN BUGS
 
 The GNI provider currently treats the fi_shutdown() interface as a strictly

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -750,9 +750,9 @@ struct gnix_fab_req_msg {
 	size_t                       send_iov_cnt;
 	uint64_t                     send_flags;
 	size_t			     cum_send_len;
-	struct gnix_fab_req 	 *parent;
-	size_t                   mr_space_left;
-	uint64_t                 mr_buf_addr;
+	struct gnix_fab_req 	     *parent;
+	size_t                       mrecv_space_left;
+	uint64_t                     mrecv_buf_addr;
 
 	struct recv_info_t {
 		uint64_t	 recv_addr;

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -153,7 +153,6 @@
 
 #define GNIX_MSG_RENDEZVOUS		(1ULL << 61)	/* MSG only flag */
 #define GNIX_MSG_GET_TAIL		(1ULL << 62)	/* MSG only flag */
-#define GNIX_MSG_MULTI_RECV_SUP		(1ULL << 63)	/* MSG only flag */
 
 /*
  * Cray gni provider supported flags for fi_getinfo argument for now, needs
@@ -712,6 +711,7 @@ enum gnix_fab_req_type {
 	GNIX_FAB_RQ_RECVV,
 	GNIX_FAB_RQ_TRECV,
 	GNIX_FAB_RQ_TRECVV,
+	GNIX_FAB_RQ_MRECV,
 	GNIX_FAB_RQ_AMO,
 	GNIX_FAB_RQ_FAMO,
 	GNIX_FAB_RQ_CAMO,
@@ -750,6 +750,9 @@ struct gnix_fab_req_msg {
 	size_t                       send_iov_cnt;
 	uint64_t                     send_flags;
 	size_t			     cum_send_len;
+	struct gnix_fab_req 	 *parent;
+	size_t                   mr_space_left;
+	uint64_t                 mr_buf_addr;
 
 	struct recv_info_t {
 		uint64_t	 recv_addr;
@@ -995,6 +998,9 @@ static inline int gnix_ops_allowed(struct gnix_fid_ep *ep,
  * @var work_fn	     the function called by the nic progress loop to initiate
  * the fabric request.
  * @var flags	      a set of bit patterns that apply to all message types
+ * @cb                optional call back to be invoked when ref cnt on this
+ *                    object drops to zero
+ * @ref_cnt           ref cnt for this object
  * @var iov_txds      A list of pending Rdma/CtFma GET txds.
  * @var iov_txd_cnt   The count of outstanding iov txds.
  * @var tx_failures   tx failure bits.
@@ -1011,6 +1017,8 @@ struct gnix_fab_req {
 	struct gnix_vc            *vc;
 	int                       (*work_fn)(void *);
 	uint64_t                  flags;
+	void                      (*cb)(void *);
+	struct gnix_reference     ref_cnt;
 
 	struct slist_entry           *int_tx_buf_e;
 	uint8_t                      *int_tx_buf;
@@ -1026,9 +1034,9 @@ struct gnix_fab_req {
 
 	/* common to rma/amo/msg */
 	union {
-		struct gnix_fab_req_rma rma;
-		struct gnix_fab_req_msg msg;
-		struct gnix_fab_req_amo amo;
+		struct gnix_fab_req_rma   rma;
+		struct gnix_fab_req_msg   msg;
+		struct gnix_fab_req_amo   amo;
 	};
 	char inject_buf[GNIX_INJECT_SIZE];
 };

--- a/prov/gni/include/gnix_ep.h
+++ b/prov/gni/include/gnix_ep.h
@@ -236,11 +236,11 @@ _gnix_fr_alloc(struct gnix_fid_ep *ep)
 		fr->gnix_ep = ep;
 		dlist_init(&fr->dlist);
 		dlist_init(&fr->msg.tle.free);
-	}
 
-	/* reset common fields */
-	fr->tx_failures = 0;
-	_gnix_ref_get(ep);
+		/* reset common fields */
+		fr->tx_failures = 0;
+		_gnix_ref_get(ep);
+	}
 
 	return fr;
 }
@@ -262,11 +262,11 @@ _gnix_fr_alloc_w_cb(struct gnix_fid_ep *ep, void (*cb)(void *))
 		_gnix_ref_init(&fr->ref_cnt, 1, cb);
 		dlist_init(&fr->dlist);
 		dlist_init(&fr->msg.tle.free);
-	}
 
-	/* reset common fields */
-	fr->tx_failures = 0;
-	_gnix_ref_get(ep);
+		/* reset common fields */
+		fr->tx_failures = 0;
+		_gnix_ref_get(ep);
+	}
 
 	return fr;
 }

--- a/prov/gni/include/gnix_ep.h
+++ b/prov/gni/include/gnix_ep.h
@@ -245,6 +245,32 @@ _gnix_fr_alloc(struct gnix_fid_ep *ep)
 	return fr;
 }
 
+static inline struct gnix_fab_req *
+_gnix_fr_alloc_w_cb(struct gnix_fid_ep *ep, void (*cb)(void *))
+{
+	struct dlist_entry *de = NULL;
+	struct gnix_fab_req *fr = NULL;
+	int ret = _gnix_fl_alloc(&de, &ep->fr_freelist);
+
+	while (unlikely(ret == -FI_EAGAIN))
+		ret = _gnix_fl_alloc(&de, &ep->fr_freelist);
+
+	if (ret == FI_SUCCESS) {
+		fr = container_of(de, struct gnix_fab_req, dlist);
+		fr->gnix_ep = ep;
+		fr->cb = cb;
+		_gnix_ref_init(&fr->ref_cnt, 1, cb);
+		dlist_init(&fr->dlist);
+		dlist_init(&fr->msg.tle.free);
+	}
+
+	/* reset common fields */
+	fr->tx_failures = 0;
+	_gnix_ref_get(ep);
+
+	return fr;
+}
+
 static inline void
 _gnix_fr_free(struct gnix_fid_ep *ep, struct gnix_fab_req *fr)
 {

--- a/prov/gni/include/gnix_msg.h
+++ b/prov/gni/include/gnix_msg.h
@@ -36,7 +36,11 @@
 
 ssize_t _gnix_recv(struct gnix_fid_ep *ep, uint64_t buf, size_t len, void *desc,
 		   uint64_t src_addr, void *context, uint64_t flags,
-		   uint64_t tag, uint64_t ignore);
+		   uint64_t tag, uint64_t ignore, struct gnix_fab_req *req);
+
+ssize_t _gnix_recv_mr(struct gnix_fid_ep *ep, uint64_t buf, size_t len, void *desc,
+		      uint64_t src_addr, void *context, uint64_t flags,
+		      uint64_t tag, uint64_t ignore);
 
 ssize_t _gnix_send(struct gnix_fid_ep *ep, uint64_t loc_addr, size_t len,
 		   void *mdesc, uint64_t dest_addr, void *context,

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -337,8 +337,27 @@ ssize_t _ep_recv(struct fid_ep *ep, void *buf, size_t len,
 	ep_priv = container_of(ep, struct gnix_fid_ep, ep_fid);
 	assert(GNIX_EP_RDM_DGM_MSG(ep_priv->type));
 
-	return _gnix_recv(ep_priv, (uint64_t)buf, len, desc, src_addr, context,
-			  ep_priv->op_flags | flags, tag, ignore);
+	if (!(ep_priv->op_flags & FI_MULTI_RECV)) {
+		return _gnix_recv(ep_priv,
+				  (uint64_t)buf,
+				  len, desc,
+				  src_addr,
+				  context,
+				  ep_priv->op_flags | flags,
+				  tag,
+				  ignore,
+				  NULL);
+	 } else {
+		return _gnix_recv_mr(ep_priv,
+				     buf,
+				     len,
+				     desc,
+				     src_addr,
+				     context,
+				     ep_priv->op_flags | flags,
+				     tag,
+				     ignore);
+	}
 }
 
 ssize_t _ep_recvv(struct fid_ep *ep, const struct iovec *iov,
@@ -356,10 +375,28 @@ ssize_t _ep_recvv(struct fid_ep *ep, const struct iovec *iov,
 	assert(GNIX_EP_RDM_DGM_MSG(ep_priv->type));
 
 	if (count <= 1) {
-		return _gnix_recv(ep_priv, (uint64_t)iov[0].iov_base,
-				  iov[0].iov_len, desc ? desc[0] : NULL,
-				  src_addr, context,
-				  ep_priv->op_flags | flags, tag, ignore);
+		if (!(ep_priv->op_flags & FI_MULTI_RECV)) {
+			return _gnix_recv(ep_priv,
+					  (uint64_t)iov[0].iov_base,
+					  iov[0].iov_len,
+					  desc ? desc[0] : NULL,
+					  src_addr,
+					  context,
+					  ep_priv->op_flags | flags,
+					  tag,
+					  ignore,
+					  NULL);
+		} else {
+			return _gnix_recv_mr(ep_priv,
+					  (uint64_t)iov[0].iov_base,
+					  iov[0].iov_len,
+					  desc ? desc[0] : NULL,
+					  src_addr,
+					  context,
+					  ep_priv->op_flags | flags,
+					  tag,
+					  ignore);
+		}
 	}
 
 	return _gnix_recvv(ep_priv, iov, desc, count, src_addr,
@@ -371,12 +408,28 @@ ssize_t _ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 		    uint64_t ignore)
 {
 	struct iovec iov;
+	struct gnix_fid_ep *ep_priv = container_of(ep, struct gnix_fid_ep, ep_fid);
+
+	ep_priv = container_of(ep, struct gnix_fid_ep, ep_fid);
+	assert(GNIX_EP_RDM_DGM_MSG(ep_priv->type));
 
 	iov.iov_base = NULL;
 	iov.iov_len = 0;
 
 	if (!msg) {
 		return -FI_EINVAL;
+	}
+
+	if (flags & FI_MULTI_RECV) {
+		return _gnix_recv_mr(ep_priv,
+				     (uint64_t)msg->msg_iov[0].iov_base,
+				     msg->msg_iov[0].iov_len,
+				     msg->desc[0],
+				     msg->addr,
+				     msg->context,
+				     ep_priv->op_flags | flags,
+				     tag,
+				     ignore);
 	}
 
 	/* msg_iov can be undefined when using FI_PEEK, etc. */

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -349,7 +349,7 @@ ssize_t _ep_recv(struct fid_ep *ep, void *buf, size_t len,
 				  NULL);
 	 } else {
 		return _gnix_recv_mr(ep_priv,
-				     buf,
+				     (uint64_t)buf,
 				     len,
 				     desc,
 				     src_addr,

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -278,22 +278,6 @@ static void __gnix_msg_copy_data_to_recv_addr(struct gnix_fab_req *req,
 	}
 }
 
-static struct gnix_fab_req *__gnix_msg_dup_req(struct gnix_fab_req *req)
-{
-	struct gnix_fab_req *new_req;
-
-	new_req = _gnix_fr_alloc(req->gnix_ep);
-	if (new_req == NULL) {
-		GNIX_WARN(FI_LOG_EP_DATA, "Failed to allocate request\n");
-		return NULL;
-	}
-
-	/* TODO: selectively copy fields. */
-	memcpy((void *)new_req, (void *)req, sizeof(*req));
-
-	return new_req;
-}
-
 static void __gnix_msg_queues(struct gnix_fid_ep *ep,
 			      int tagged,
 			      struct gnix_tag_storage **posted_queue,
@@ -357,7 +341,6 @@ static int __gnix_msg_recv_err(struct gnix_fid_ep *ep, struct gnix_fab_req *req)
 
 	flags |= req->msg.send_flags & FI_TAGGED;
 
-	/* TODO: Check for FI_MULTI_RECV? */
 	return __recv_err(ep, req->user_context, flags, req->msg.cum_recv_len,
 			  (void *)req->msg.recv_info[0].recv_addr, req->msg.imm,
 			  req->msg.tag, 0, FI_ECANCELED,
@@ -456,6 +439,29 @@ static int __recv_completion_src(
 	return FI_SUCCESS;
 }
 
+/*
+ * GNI provider generates a special CQE to indicate
+ * its releasing a FI_MULTI_RECV receive buffer back to
+ * the application.
+ */
+static void __gnix_msg_mrecv_completion(void *obj)
+{
+	int ret;
+	struct gnix_fab_req *req = (struct gnix_fab_req *)obj;
+
+	ret = __recv_completion(req->gnix_ep,
+				req,
+				FI_MULTI_RECV,
+				0UL,
+				NULL);
+	if (ret != FI_SUCCESS) {
+		GNIX_DEBUG(FI_LOG_EP_DATA,
+			  "__recv_completion failed for multi recv"
+			  " complete: %d\n",
+				  ret);
+	}
+}
+
 static inline int __gnix_msg_recv_completion(struct gnix_fid_ep *ep,
 					     struct gnix_fab_req *req)
 {
@@ -466,14 +472,7 @@ static inline int __gnix_msg_recv_completion(struct gnix_fid_ep *ep,
 	fi_addr_t src_addr;
 
 	flags |= req->msg.send_flags & (FI_TAGGED | FI_REMOTE_CQ_DATA);
-	flags |= req->msg.recv_flags & (FI_PEEK | FI_CLAIM | FI_DISCARD |
-					FI_MULTI_RECV);
-
-	/*
-	 * see fi_cq man page
-	 */
-	if (req->msg.recv_flags & GNIX_MSG_MULTI_RECV_SUP)
-		flags &= ~FI_MULTI_RECV;
+	flags |= req->msg.recv_flags & (FI_PEEK | FI_CLAIM | FI_DISCARD);
 
 	len = MIN(req->msg.cum_send_len, req->msg.cum_recv_len);
 
@@ -496,6 +495,13 @@ static inline int __gnix_msg_recv_completion(struct gnix_fid_ep *ep,
 					     src_addr);
 	}
 
+	/*
+	 * if i'm child of a FI_MULTI_RECV request, decrement
+	 * ref count
+	 */
+	if (req->msg.parent != NULL) {
+		_gnix_ref_put(req->msg.parent);
+	}
 	return ret;
 }
 
@@ -1868,7 +1874,7 @@ static int __smsg_eager_msg_w_data(void *data, void *msg)
 	struct gnix_vc *vc = (struct gnix_vc *)data;
 	struct gnix_smsg_eager_hdr *hdr = (struct gnix_smsg_eager_hdr *)msg;
 	struct gnix_fid_ep *ep;
-	struct gnix_fab_req *req = NULL;
+	struct gnix_fab_req *req = NULL, *mrecv_req = NULL;
 	void *data_ptr;
 	struct gnix_tag_storage *unexp_queue;
 	struct gnix_tag_storage *posted_queue;
@@ -1888,6 +1894,48 @@ static int __smsg_eager_msg_w_data(void *data, void *msg)
 	req = _gnix_match_tag(posted_queue, hdr->msg_tag, 0, FI_PEEK, NULL,
 			      &vc->peer_addr);
 	if (req) {
+		if (req->type == GNIX_FAB_RQ_MRECV) {
+
+			mrecv_req = req;
+			req = _gnix_fr_alloc(ep);
+			if (req == NULL) {
+				return -FI_ENOMEM;
+			}
+
+			/*
+			 * set recv related fields in request,
+			 * and adjust mrecv buffer pointer and
+			 * space remaining
+			 */
+
+			req->type = GNIX_FAB_RQ_RECV;
+			req->msg.recv_flags = mrecv_req->msg.recv_flags;
+			req->msg.recv_flags |= FI_MULTI_RECV;
+			req->msg.recv_info[0].recv_addr =
+				mrecv_req->msg.mr_buf_addr;
+			req->msg.recv_info[0].recv_len =
+				mrecv_req->msg.mr_space_left;
+			req->msg.cum_recv_len = mrecv_req->msg.mr_space_left;
+			req->user_context = mrecv_req->user_context;
+
+			req->msg.parent = mrecv_req;
+			_gnix_ref_get(mrecv_req);
+
+			mrecv_req->msg.mr_space_left -= hdr->len;
+			mrecv_req->msg.mr_buf_addr += hdr->len;
+
+			if ((int64_t)mrecv_req->msg.mr_space_left  <
+				ep->min_multi_recv) {
+				_gnix_remove_tag(posted_queue, mrecv_req);
+				_gnix_ref_put(mrecv_req);
+				_gnix_fr_free(ep, mrecv_req);
+				mrecv_req = NULL;
+			}
+
+			GNIX_DEBUG(FI_LOG_EP_DATA,
+				"Re-using multi-recv req: %p\n", mrecv_req);
+		}
+
 		req->addr = vc->peer_addr;
 		req->gnix_ep = ep;
 		req->vc = vc;
@@ -1904,31 +1952,15 @@ static int __smsg_eager_msg_w_data(void *data, void *msg)
 
 		__gnix_msg_copy_data_to_recv_addr(req, data_ptr);
 
-		if ((req->msg.recv_flags & FI_MULTI_RECV) &&
-		    ((req->msg.cum_recv_len - req->msg.cum_send_len) <
-			ep->min_multi_recv))
-			req->msg.recv_flags &= ~GNIX_MSG_MULTI_RECV_SUP;
-
 		__gnix_msg_recv_completion(ep, req);
 
-		/* Check if we're using FI_MULTI_RECV and there is space left
-		 * in the receive buffer. */
-		if ((req->msg.recv_flags & FI_MULTI_RECV) &&
-		    ((req->msg.cum_recv_len - req->msg.cum_send_len) >=
-			     ep->min_multi_recv)) {
-			GNIX_DEBUG(FI_LOG_EP_DATA, "Re-using req: %p\n", req);
+		GNIX_DEBUG(FI_LOG_EP_DATA, "Freeing req: %p\n", req);
 
-			/* Adjust receive buffer for the next match. */
-			req->msg.recv_info[0].recv_addr += req->msg.cum_send_len;
-			req->msg.recv_info[0].recv_len -= req->msg.cum_send_len;
-			req->msg.cum_recv_len = req->msg.recv_info[0].recv_len;
-		} else {
-			GNIX_DEBUG(FI_LOG_EP_DATA, "Freeing req: %p\n", req);
-
-			/* Dequeue and free the request. */
+		/* Dequeue and free the request. */
+		if (mrecv_req == NULL)
 			_gnix_remove_tag(posted_queue, req);
-			_gnix_fr_free(ep, req);
-		}
+		_gnix_fr_free(ep, req);
+
 	} else {
 		/* Add new unexpected receive request. */
 		req = _gnix_fr_alloc(ep);
@@ -1954,6 +1986,7 @@ static int __smsg_eager_msg_w_data(void *data, void *msg)
 		req->msg.send_flags = hdr->flags;
 		req->msg.tag = hdr->msg_tag;
 		req->msg.imm = hdr->imm;
+		req->msg.parent = NULL;
 
 		memcpy((void *)req->msg.send_info[0].send_addr, data_ptr, hdr->len);
 		req->addr = vc->peer_addr;
@@ -2037,7 +2070,7 @@ static int __smsg_rndzv_start(void *data, void *msg)
 	struct gnix_smsg_rndzv_start_hdr *hdr =
 			(struct gnix_smsg_rndzv_start_hdr *)msg;
 	struct gnix_fid_ep *ep;
-	struct gnix_fab_req *req = NULL, *dup_req;
+	struct gnix_fab_req *req = NULL, *mrecv_req = NULL;
 	struct gnix_tag_storage *unexp_queue;
 	struct gnix_tag_storage *posted_queue;
 	int tagged;
@@ -2054,6 +2087,49 @@ static int __smsg_rndzv_start(void *data, void *msg)
 			      &vc->peer_addr);
 
 	if (req) {
+		if (req->type == GNIX_FAB_RQ_MRECV) {
+
+			mrecv_req = req;
+			req = _gnix_fr_alloc(ep);
+			if (req == NULL) {
+				return -FI_ENOMEM;
+			}
+
+			/*
+			 * set recv related fields in request,
+			 * and adjust mrecv buffer pointer and
+			 * space remaining
+			 */
+
+			req->type = GNIX_FAB_RQ_RECV;
+			req->msg.recv_flags = mrecv_req->msg.recv_flags;
+			req->msg.recv_flags |= FI_MULTI_RECV;
+			req->msg.recv_info[0].recv_addr =
+				mrecv_req->msg.mr_buf_addr;
+			req->msg.recv_info[0].recv_len =
+				mrecv_req->msg.mr_space_left;
+			req->user_context = mrecv_req->user_context;
+			req->msg.cum_recv_len = mrecv_req->msg.mr_space_left;
+
+			req->msg.parent = mrecv_req;
+			if (req->msg.parent)
+				_gnix_ref_get(req->msg.parent);
+
+			mrecv_req->msg.mr_space_left -= hdr->len;
+			mrecv_req->msg.mr_buf_addr += hdr->len;
+
+			if ((int64_t)mrecv_req->msg.mr_space_left  <
+				ep->min_multi_recv) {
+				_gnix_remove_tag(posted_queue, mrecv_req);
+				_gnix_ref_put(mrecv_req);
+				_gnix_fr_free(ep, mrecv_req);
+				mrecv_req = NULL;
+			}
+
+			GNIX_DEBUG(FI_LOG_EP_DATA,
+				"Re-using multi-recv req: %p\n", mrecv_req);
+		}
+
 		req->addr = vc->peer_addr;
 		req->gnix_ep = ep;
 		req->vc = vc;
@@ -2099,34 +2175,8 @@ static int __smsg_rndzv_start(void *data, void *msg)
 			  req, req->msg.recv_info[0].recv_addr,
 			  req->msg.send_info[0].send_len);
 
-		/* Check if we're using FI_MULTI_RECV and there is space left
-		 * in the receive buffer. */
-		if (req->type == GNIX_FAB_RQ_RECV &&
-		    (req->msg.recv_flags & FI_MULTI_RECV) &&
-		    ((req->msg.cum_recv_len - req->msg.cum_send_len) >=
-			     ep->min_multi_recv)) {
-			/* Allocate new request for this transfer. */
-			dup_req = __gnix_msg_dup_req(req);
-			if (!dup_req) {
-				return -FI_ENOMEM;
-			}
-
-			/* Adjust receive buffer for the next match. */
-			req->msg.recv_info[0].recv_addr += req->msg.send_info[0].send_len;
-			req->msg.recv_info[0].recv_len -= req->msg.send_info[0].send_len;
-			req->msg.cum_recv_len = req->msg.recv_info[0].recv_len;
-
-			/* 'req' remains queued for more matches while the
-			 * duplicated request is processed. */
-			req = dup_req;
-		} else {
-			/*
-			 * doesn't hurt if its not FI_MULI_RECV
-			 */
-			req->msg.recv_flags &= ~GNIX_MSG_MULTI_RECV_SUP;
-			/* Dequeue the request. */
+		if (mrecv_req == NULL)
 			_gnix_remove_tag(posted_queue, req);
-		}
 
 		/* Queue request to initiate pull of source data. */
 		ret = _gnix_vc_queue_work_req(req);
@@ -2159,6 +2209,7 @@ static int __smsg_rndzv_start(void *data, void *msg)
 		req->msg.send_info[0].head = hdr->head;
 		req->msg.send_info[0].tail = hdr->tail;
 		ofi_atomic_initialize32(&req->msg.outstanding_txds, 0);
+		req->msg.parent = NULL;
 
 		_gnix_insert_tag(unexp_queue, req->msg.tag, req, ~0);
 
@@ -2242,6 +2293,7 @@ static int __smsg_rndzv_iov_start(void *data, void *msg)
 	req->msg.tag = hdr->msg_tag;
 	req->msg.send_iov_cnt = hdr->iov_cnt;
 	req->msg.rma_id = hdr->req_addr;
+	req->msg.parent = NULL;
 	memcpy(req->msg.send_info, data_ptr,
 	       sizeof(struct send_info_t) * hdr->iov_cnt);
 
@@ -2503,9 +2555,10 @@ static int __gnix_msg_addr_lookup(struct gnix_fid_ep *ep, uint64_t src_addr,
 
 ssize_t _gnix_recv(struct gnix_fid_ep *ep, uint64_t buf, size_t len,
 		   void *mdesc, uint64_t src_addr, void *context,
-		   uint64_t flags, uint64_t tag, uint64_t ignore)
+		   uint64_t flags, uint64_t tag, uint64_t ignore,
+		   struct gnix_fab_req *mrecv_req)
 {
-	int ret;
+	int ret = FI_SUCCESS;
 	struct gnix_fab_req *req = NULL;
 	struct gnix_address gnix_addr;
 	struct gnix_tag_storage *posted_queue = NULL;
@@ -2513,7 +2566,6 @@ ssize_t _gnix_recv(struct gnix_fid_ep *ep, uint64_t buf, size_t len,
 	uint64_t match_flags;
 	struct gnix_fid_mem_desc *md = NULL;
 	int tagged = !!(flags & FI_TAGGED);
-	bool try_again = false;
 
 	if (!ep->recv_cq && !ep->recv_cntr) {
 		return -FI_ENOCQ;
@@ -2527,11 +2579,11 @@ ssize_t _gnix_recv(struct gnix_fid_ep *ep, uint64_t buf, size_t len,
 			return -FI_EOPNOTSUPP;
 	}
 
-	match_flags = flags & (FI_CLAIM | FI_DISCARD | FI_PEEK);
-
 	ret = __gnix_msg_addr_lookup(ep, src_addr, &gnix_addr);
 	if (ret != FI_SUCCESS)
 		return ret;
+
+	match_flags = flags & (FI_CLAIM | FI_DISCARD | FI_PEEK);
 
 	__gnix_msg_queues(ep, tagged, &posted_queue, &unexp_queue);
 
@@ -2544,13 +2596,27 @@ ssize_t _gnix_recv(struct gnix_fid_ep *ep, uint64_t buf, size_t len,
 
 	COND_ACQUIRE(ep->requires_lock, &ep->vc_lock);
 
-retry_match:
-	try_again = false;
 	/* Look for a matching unexpected receive request. */
 	req = _gnix_match_tag(unexp_queue, tag, ignore,
 			      match_flags, context, &gnix_addr);
 	if (req) {
+		/*
+		 * if we posted a multi-recv buffer and we can't
+		 * hold the matched message, stop dequeuing and
+		 * return.
+		 */
+		if (unlikely(mrecv_req != NULL)) {
+
+			mrecv_req->msg.mr_space_left -=
+				req->msg.cum_send_len;
+			mrecv_req->msg.mr_buf_addr +=
+				req->msg.cum_send_len;
+			req->msg.parent = mrecv_req;
+			_gnix_ref_get(mrecv_req);
+		}
+
 		/* Found matching request, populate local fields. */
+
 		req->gnix_ep = ep;
 		req->user_context = context;
 		req->msg.recv_info[0].recv_addr = (uint64_t)buf;
@@ -2566,8 +2632,6 @@ retry_match:
 		req->msg.recv_md[0] = md;
 		req->msg.recv_iov_cnt = 1;
 		req->msg.recv_flags = flags;
-		if (flags & FI_MULTI_RECV)
-			req->msg.recv_flags |= GNIX_MSG_MULTI_RECV_SUP;
 		req->msg.ignore = ignore;
 
 		if ((flags & GNIX_SUPPRESS_COMPLETION) ||
@@ -2616,26 +2680,8 @@ retry_match:
 			req->work_fn = req->msg.send_iov_cnt == 1 ?
 				__gnix_rndzv_req : __gnix_rndzv_iov_req_build;
 
-
-			/*
-			 * Check if we're using FI_MULTI_RECV and there is
-			 * space left in the receive buffer.
-			 */
-
-			if ((req->msg.recv_flags & FI_MULTI_RECV) &&
-			    ((len - req->msg.cum_send_len) >= ep->min_multi_recv)) {
-
-				buf += req->msg.cum_send_len;
-				len -= req->msg.cum_send_len;
-				try_again = true;
-
-			} else {
-				req->msg.recv_flags &= ~GNIX_MSG_MULTI_RECV_SUP;
-			}
-
+			_gnix_remove_tag(unexp_queue, req);
 			ret = _gnix_vc_queue_work_req(req);
-			if (try_again)
-				goto retry_match;
 
 		} else {
 			/* Matched eager request.  Copy data and generate
@@ -2655,33 +2701,20 @@ retry_match:
 			       req->msg.send_info[0].send_len);
 			free((void *)req->msg.send_info[0].send_addr);
 
-			if ((req->msg.recv_flags & FI_MULTI_RECV) &&
-			    ((len - req->msg.cum_send_len) <
-						ep->min_multi_recv))
-				req->msg.recv_flags &= ~GNIX_MSG_MULTI_RECV_SUP;
-
+			_gnix_remove_tag(unexp_queue, req);
 			__gnix_msg_recv_completion(ep, req);
-
-			/* If using FI_MULTI_RECV and there is space left in
-			 * the receive buffer, try to match another unexpected
-			 * request. */
-			if ((req->msg.recv_flags & FI_MULTI_RECV) &&
-			    ((len - req->msg.cum_send_len) >= ep->min_multi_recv)) {
-				buf += req->msg.cum_send_len;
-				len -= req->msg.cum_send_len;
-				req->msg.recv_info[0].recv_addr = buf;
-				req->msg.recv_info[0].recv_len -= req->msg.cum_send_len;
-				req->msg.cum_recv_len = req->msg.recv_info[0].recv_len;
-				GNIX_DEBUG(FI_LOG_EP_DATA,
-					  "Attempting additional matches, "
-					  "req: %p (%p %u)\n",
-					  req, buf, len);
-				goto retry_match;
-			}
 
 			_gnix_fr_free(ep, req);
 		}
 	} else {
+
+		/*
+		 * if handling a multi receive request,
+		 * just return
+		 */
+		if (mrecv_req)
+			goto mrecv_exit;
+
 		/* if peek/claim/discard, we didn't find what we
 		 * were looking for, return FI_ENOMSG
 		 */
@@ -2697,7 +2730,6 @@ retry_match:
 			goto pdc_exit;
 		}
 
-		/* Add new posted receive request. */
 		req = _gnix_fr_alloc(ep);
 		if (req == NULL) {
 			ret = -FI_EAGAIN;
@@ -2727,8 +2759,6 @@ retry_match:
 		req->msg.recv_md[0] = md;
 		req->msg.send_iov_cnt = req->msg.recv_iov_cnt = 1;
 		req->msg.recv_flags = flags;
-		if (flags & FI_MULTI_RECV)
-			req->msg.recv_flags |= GNIX_MSG_MULTI_RECV_SUP;
 		req->msg.tag = tag;
 		req->msg.ignore = ignore;
 		ofi_atomic_initialize32(&req->msg.outstanding_txds, 0);
@@ -2743,9 +2773,108 @@ retry_match:
 		_gnix_insert_tag(posted_queue, tag, req, ignore);
 	}
 
+mrecv_exit:
 pdc_exit:
 err:
 	COND_RELEASE(ep->requires_lock, &ep->vc_lock);
+
+	return ret;
+}
+
+ssize_t _gnix_recv_mr(struct gnix_fid_ep *ep, uint64_t buf, size_t len,
+		      void *mdesc, uint64_t src_addr, void *context,
+		      uint64_t flags, uint64_t tag, uint64_t ignore)
+{
+	int ret;
+	int tagged = !!(flags & FI_TAGGED);
+	struct gnix_fab_req *mrecv_req = NULL;
+	struct gnix_address gnix_addr;
+	struct gnix_fid_mem_desc *md = NULL;
+	struct gnix_tag_storage *posted_queue = NULL;
+	struct gnix_tag_storage *unexp_queue = NULL;
+	uint64_t last_space_left;
+
+	assert(flags & FI_MULTI_RECV);
+
+	mrecv_req = _gnix_fr_alloc_w_cb(ep, __gnix_msg_mrecv_completion);
+	if (mrecv_req == NULL) {
+		return -FI_ENOMEM;
+	}
+
+	mrecv_req->type = GNIX_FAB_RQ_MRECV;
+
+	ret = __gnix_msg_addr_lookup(ep, src_addr, &gnix_addr);
+	if (ret != FI_SUCCESS)
+		return ret;
+
+	mrecv_req->addr = gnix_addr;
+	mrecv_req->gnix_ep = ep;
+	mrecv_req->user_context = context;
+
+	mrecv_req->msg.mr_buf_addr = (uint64_t)buf;
+	mrecv_req->msg.mr_space_left = len;
+
+	if (mdesc) {
+		md = container_of(mdesc,
+				struct gnix_fid_mem_desc,
+				mr_fid);
+
+		mrecv_req->msg.recv_info[0].mem_hndl = md->mem_hndl;
+	}
+
+	mrecv_req->msg.recv_md[0] = md;
+	mrecv_req->msg.recv_flags = flags;
+
+	if (!tagged) {
+		mrecv_req->msg.tag = 0;
+		mrecv_req->msg.ignore = ~0;
+	} else {
+		mrecv_req->msg.tag = tag;
+		mrecv_req->msg.ignore = ignore;
+	}
+
+	if ((flags & GNIX_SUPPRESS_COMPLETION) ||
+	    (ep->recv_selective_completion &&
+	    !(flags & FI_COMPLETION))) {
+		mrecv_req->msg.recv_flags &= ~FI_COMPLETION;
+	} else {
+		mrecv_req->msg.recv_flags |= FI_COMPLETION;
+	}
+
+	last_space_left = mrecv_req->msg.mr_space_left;
+
+	do {
+		ret = _gnix_recv(ep,
+				 mrecv_req->msg.mr_buf_addr,
+				 mrecv_req->msg.mr_space_left,
+				 mdesc,
+				 src_addr,
+				 context,
+				 mrecv_req->msg.recv_flags,
+				 mrecv_req->msg.tag,
+				 mrecv_req->msg.ignore,
+				 mrecv_req);
+		if (ret != FI_SUCCESS) {
+			_gnix_fr_free(ep, mrecv_req);
+			return ret;
+		}
+		if ((last_space_left == mrecv_req->msg.mr_space_left) ||
+			(mrecv_req->msg.mr_space_left < ep->min_multi_recv))
+			break;
+		last_space_left = mrecv_req->msg.mr_space_left;
+	} while (1);
+
+	/*
+	 * if space left in multi receive request
+	 * add to posted receive queue, else free request.
+	 */
+	if ((int64_t)mrecv_req->msg.mr_space_left > ep->min_multi_recv) {
+		__gnix_msg_queues(ep, tagged, &posted_queue, &unexp_queue);
+		_gnix_insert_tag(posted_queue, tag, mrecv_req, ignore);
+	} else {
+		_gnix_ref_put(mrecv_req);
+		_gnix_fr_free(ep, mrecv_req);
+	}
 
 	return ret;
 }

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -1956,10 +1956,14 @@ static int __smsg_eager_msg_w_data(void *data, void *msg)
 
 		GNIX_DEBUG(FI_LOG_EP_DATA, "Freeing req: %p\n", req);
 
-		/* Dequeue and free the request. */
-		if (mrecv_req == NULL)
+		/*
+		 * Dequeue and free the request if not
+		 * matching a FI_MULTI_RECV buffer.
+		 */
+		if (mrecv_req == NULL) {
 			_gnix_remove_tag(posted_queue, req);
-		_gnix_fr_free(ep, req);
+			_gnix_fr_free(ep, req);
+		}
 
 	} else {
 		/* Add new unexpected receive request. */

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -440,7 +440,7 @@ static int __recv_completion_src(
 }
 
 /*
- * GNI provider generates a special CQE to indicate
+ * GNI provider generates a separate CQE to indicate
  * its releasing a FI_MULTI_RECV receive buffer back to
  * the application.
  */

--- a/prov/gni/test/rdm_sr.c
+++ b/prov/gni/test/rdm_sr.c
@@ -63,7 +63,7 @@
  * The multirecv tests fail when NUMEPS are > 2 (GitHub issue #1116).
  * Increase this number when the issues is fixed.
  */
-#define NUMEPS 2
+#define NUMEPS 4
 #define NUM_MULTIRECVS 5
 
 /* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
@@ -2184,7 +2184,7 @@ void do_multirecv(int len)
 	const int nrecvs = NUM_MULTIRECVS;
 	const int dest_ep = NUMEPS-1;
 	uint64_t *expected_addrs;
-	bool *addr_recvd, found;
+	bool *addr_recvd, found, got_fi_multi_cqe = false;
 	int sends_done = 0;
 
 	rdm_sr_init_data(source, len, 0xab);
@@ -2264,8 +2264,6 @@ void do_multirecv(int len)
 			}
 			cr_assert(found == true, "Address not found");
 			flags = FI_MSG | FI_RECV;
-			flags = (j == (nrecvs - 1)) ? flags | FI_MULTI_RECV :
-							flags;
 			rdm_sr_check_cqe(&d_cqe, source,
 					 flags,
 					 (void *) expected_addrs[j],
@@ -2275,6 +2273,18 @@ void do_multirecv(int len)
 			r[dest_ep]++;
 		}
 	} while (sends_done < nrecvs || r[dest_ep] < nrecvs);
+
+	/*
+	 * now check for final FI_MULTI_RECV CQE on dest CQ
+	 */
+
+	do {
+		ret = fi_cq_read(msg_cq[dest_ep], &d_cqe, 1);
+		if (d_cqe.flags & FI_MULTI_RECV) {
+			got_fi_multi_cqe = true;
+			r[dest_ep]++;
+		}
+	} while (got_fi_multi_cqe == false);
 
 	rdm_sr_check_cntrs(s, r, s_e, r_e, false);
 
@@ -2312,6 +2322,7 @@ void do_multirecv_send_first(int len)
 	uint64_t *expected_addrs;
 	bool *addr_recvd, found;
 	int sends_done = 0;
+	bool got_fi_multi_cqe = false;
 
 	rdm_sr_init_data(source, len, 0xab);
 	rdm_sr_init_data(target, len, 0);
@@ -2376,7 +2387,7 @@ void do_multirecv_send_first(int len)
 	msg.context = source;
 	msg.data = (uint64_t)source;
 
-	sz = fi_recvmsg(ep[1], &msg, FI_MULTI_RECV);
+	sz = fi_recvmsg(ep[dest_ep], &msg, FI_MULTI_RECV);
 	cr_assert_eq(sz, 0);
 
 	/* need to progress both CQs simultaneously for rendezvous */
@@ -2415,8 +2426,6 @@ void do_multirecv_send_first(int len)
 			}
 			cr_assert(found == true, "Address not found");
 			flags = FI_MSG | FI_RECV;
-			flags = (j == (nrecvs - 1)) ? flags | FI_MULTI_RECV :
-							flags;
 			rdm_sr_check_cqe(&d_cqe, source,
 					 flags,
 					 (void *)expected_addrs[j],
@@ -2426,6 +2435,18 @@ void do_multirecv_send_first(int len)
 			r[dest_ep]++;
 		}
 	} while (sends_done < nrecvs || r[dest_ep] < nrecvs);
+
+	/*
+	 * now check for final FI_MULTI_RECV CQE on dest CQ
+	 */
+
+	do {
+		ret = fi_cq_read(msg_cq[dest_ep], &d_cqe, 1);
+		if (d_cqe.flags & FI_MULTI_RECV) {
+			got_fi_multi_cqe = true;
+			r[dest_ep]++;
+		}
+	} while (got_fi_multi_cqe == false);
 
 	rdm_sr_check_cntrs(s, r, s_e, r_e, false);
 


### PR DESCRIPTION
The GNI provider implementation of FI_MULTI_RECV had to
be refactored to fix numerous issues with the original implementation.

With this refactor, the provider now handles the case where
messages can be received into a FI_MULTI_RECV buffer from numerous
different EPs.

With this refactor, receives of messages using the provider's
rendezvous protocol now function correctly.  Previously an application
would not be correctly notified when all messages had been transfered
into the buffer in the case that some transfers used the rendezvous
protocol.

In order to correctly notify the application when the buffer has
been released, a separate FI_MULTI_RECV CQ event is now generated
without the FI_RECV flag set.  See description of FI_MULTI_RECV
CQs in the fi_cq man page.

Fixes ofi-cray/libfabric-cray#1003
Fixes ofi-cray/libfabric-cray#1116

This PR does not address a truncated message reporting issue.
That will be handled as a separate PR as its not directly related to
problems with the original FI_MULTI_RECV implementation.

Relates to ofi-cray/libfabric-cray#1119

Signed-off-by: Howard Pritchard <howardp@lanl.gov>