### PR TITLE
prov/gni: runtime checks for version with authkeys

### DIFF
--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -539,7 +539,6 @@ __gnix_dom_ops_set_val(struct fid *fid, dom_ops_val_t t, void *val)
 	return FI_SUCCESS;
 }
 
-
 static struct fi_gni_ops_domain gnix_ops_domain = {
 	.set_val = __gnix_dom_ops_set_val,
 	.get_val = __gnix_dom_ops_get_val,
@@ -579,11 +578,9 @@ DIRECT_FN int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 
 	fabric_priv = container_of(fabric, struct gnix_fid_fabric, fab_fid);
 
-#if 0 /* TODO: Enable after 1.5 version update */
 	if (FI_VERSION_LT(fabric->api_version, FI_VERSION(1, 5)) &&
 		(info->domain_attr->auth_key_size || info->domain_attr->auth_key))
 			return -FI_EINVAL;
-#endif
 
 	auth_key = GNIX_GET_AUTH_KEY(info->domain_attr->auth_key,
 			info->domain_attr->auth_key_size);

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -527,7 +527,7 @@ int _gnix_ep_init_vc(struct gnix_fid_ep *ep_priv)
 		GNIX_DEBUG(FI_LOG_EP_CTRL,
 			   "ep_priv->vc_table = %p, ep_priv->vc_table->vector = %p\n",
 			   ep_priv->vc_table, ep_priv->vc_table->vector);
-                if (ret != FI_SUCCESS) {
+		if (ret != FI_SUCCESS) {
 			GNIX_WARN(FI_LOG_EP_CTRL, "_gnix_vec_init returned %s\n",
 				  fi_strerror(ret));
 			goto err;
@@ -709,7 +709,6 @@ gnix_ep_msg_injectdata(struct fid_ep *ep, const void *buf, size_t len,
 	return _gnix_send(gnix_ep, (uint64_t)buf, len, NULL, dest_addr,
 			  NULL, flags, data, 0);
 }
-
 
 /*******************************************************************************
  * EP RMA API function implementations.
@@ -1061,7 +1060,6 @@ DIRECT_FN STATIC ssize_t gnix_ep_tinjectdata(struct fid_ep *ep, const void *buf,
 	return _ep_inject(ep, buf, len, data, dest_addr,
 			  FI_TAGGED | FI_REMOTE_CQ_DATA, tag);
 }
-
 
 /*******************************************************************************
  * EP atomic API implementation.
@@ -1468,7 +1466,6 @@ DIRECT_FN STATIC ssize_t gnix_ep_atomic_compwritemsg(struct fid_ep *ep,
  * Base EP API function implementations.
  ******************************************************************************/
 
-
 DIRECT_FN STATIC int gnix_ep_control(fid_t fid, int command, void *arg)
 {
 	int ret = FI_SUCCESS;
@@ -1531,7 +1528,6 @@ DIRECT_FN STATIC int gnix_ep_control(fid_t fid, int command, void *arg)
 err:
 	return ret;
 }
-
 
 static int __destruct_tag_storages(struct gnix_fid_ep *ep)
 {
@@ -2245,12 +2241,10 @@ DIRECT_FN int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 
 	domain_priv = container_of(domain, struct gnix_fid_domain, domain_fid);
 
-#if 0 /* TODO: Enable after 1.5 version update */
 	if (FI_VERSION_LT(domain_priv->fabric->fab_fid.api_version,
 		FI_VERSION(1, 5)) &&
 		(info->ep_attr->auth_key || info->ep_attr->auth_key_size))
 		return -FI_EINVAL;
-#endif
 
 	if (info->ep_attr->auth_key_size) {
 		auth_key = GNIX_GET_AUTH_KEY(info->ep_attr->auth_key,

--- a/prov/gni/src/gnix_mr.c
+++ b/prov/gni/src/gnix_mr.c
@@ -289,7 +289,6 @@ DIRECT_FN int gnix_mr_regv(struct fid *fid, const struct iovec *iov,
 	return gnix_mr_regattr(fid, &attr, flags, mr);
 }
 
-
 DIRECT_FN int gnix_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	uint64_t flags, struct fid_mr **mr)
 {
@@ -305,13 +304,10 @@ DIRECT_FN int gnix_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	if (domain->mr_iov_limit < attr->iov_count)
 		return -FI_EOPNOTSUPP;
 
-#if 0 /* TODO: Enable after 1.5 version update */
 	if (FI_VERSION_LT(domain->fabric->fab_fid.api_version,
 		FI_VERSION(1, 5)) &&
 		(attr->auth_key || attr->auth_key_size))
 		return -FI_EINVAL;
-#endif
-
 
 	if (attr->auth_key_size) {
 		auth_key = GNIX_GET_AUTH_KEY(attr->auth_key, attr->auth_key_size);
@@ -419,7 +415,7 @@ static inline void *__gnix_generic_register(
 		}
 		_gnix_ref_get(nic);
 		pthread_mutex_unlock(&gnix_nic_list_lock);
-        }
+	    }
 
 	COND_ACQUIRE(nic->requires_lock, &nic->lock);
 	grc = GNI_MemRegister(nic->gni_nic_hndl, (uint64_t) address,
@@ -522,7 +518,6 @@ static int __gnix_destruct_registration(void *context)
 	return GNI_RC_SUCCESS;
 }
 
-
 #ifdef HAVE_UDREG
 void *__udreg_register(void *addr, uint64_t length, void *context)
 {
@@ -547,7 +542,6 @@ void *__udreg_register(void *addr, uint64_t length, void *context)
 		GNI_MEM_READWRITE, -1, auth_key);
 }
 
-
 uint32_t __udreg_deregister(void *registration, void *context)
 {
 	gni_return_t grc;
@@ -559,11 +553,10 @@ uint32_t __udreg_deregister(void *registration, void *context)
 	return (grc == GNI_RC_SUCCESS) ? 0 : 1;
 }
 
-
 /* Called via dreg when a cache is destroyed. */
 void __udreg_cache_destructor(void *context)
 {
-    /*  Nothing needed here. */
+	/*  Nothing needed here. */
 }
 
 static int __udreg_init(struct gnix_fid_domain *domain,
@@ -882,7 +875,6 @@ struct gnix_mr_ops cache_mr_ops = {
 	.flush_cache = __cache_flush,
 };
 
-
 static int __basic_mr_init(struct gnix_fid_domain *domain,
 		struct gnix_auth_key *auth_key)
 {
@@ -948,7 +940,6 @@ struct gnix_mr_ops basic_mr_ops = {
 	.flush_cache = NULL, // unsupported since there is no caching here
 };
 
-
 int _gnix_open_cache(struct gnix_fid_domain *domain, int type)
 {
 	if (type < 0 || type >= GNIX_MR_MAX_TYPE)
@@ -972,7 +963,6 @@ int _gnix_open_cache(struct gnix_fid_domain *domain, int type)
 	domain->mr_cache_type = type;
 	return FI_SUCCESS;
 }
-
 
 int _gnix_flush_registration_cache(struct gnix_fid_domain *domain)
 {

--- a/prov/gni/test/dom.c
+++ b/prov/gni/test/dom.c
@@ -38,7 +38,6 @@
 #include <time.h>
 #include <string.h>
 
-
 #include "gnix.h"
 
 #include <criterion/criterion.h>
@@ -47,7 +46,7 @@
 static struct fid_fabric *fabric;
 static struct fi_info *fi;
 
-static void setup(void)
+static void _setup(uint32_t version)
 {
 	int ret;
 	struct fi_info *hints;
@@ -57,13 +56,23 @@ static void setup(void)
 
 	hints->fabric_attr->prov_name = strdup("gni");
 
-	ret = fi_getinfo(fi_version(), NULL, 0, 0, hints, &fi);
+	ret = fi_getinfo(version, NULL, 0, 0, hints, &fi);
 	cr_assert(ret == FI_SUCCESS, "fi_getinfo");
 
 	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	cr_assert(ret == FI_SUCCESS, "fi_fabric");
 
 	fi_freeinfo(hints);
+}
+
+static void setup(void)
+{
+	_setup(fi_version());
+}
+
+static void setup_1_0(void)
+{
+	_setup(FI_VERSION(1, 0));
 }
 
 static void teardown(void)
@@ -77,6 +86,60 @@ static void teardown(void)
 }
 
 TestSuite(domain, .init = setup, .fini = teardown);
+TestSuite(domain_1_0, .init = setup_1_0, .fini = teardown);
+
+Test(domain_1_0, no_dom_auth_key_support)
+{
+	int ret;
+	struct fid_domain *dom;
+	void *old_auth_key = fi->domain_attr->auth_key;
+	int old_auth_key_size = fi->domain_attr->auth_key_size;
+
+	fi->domain_attr->auth_key = (void *) 0xdeadbeef;
+	fi->domain_attr->auth_key_size = 47;
+
+	ret = fi_domain(fabric, fi, &dom, NULL);
+	cr_assert(ret == -FI_EINVAL, "fi_domain, ret=%d expected=%d",
+		ret, -FI_EINVAL);
+
+	fi->domain_attr->auth_key = old_auth_key;
+	fi->domain_attr->auth_key_size = old_auth_key_size;
+}
+
+Test(domain_1_0, no_mr_auth_key_support)
+{
+	int ret;
+	struct fid_mr *mr;
+	struct fid_domain *dom;
+
+	struct iovec iov = {
+		.iov_base = (void *) 0xabbaabba,
+		.iov_len = 1024,
+	};
+	struct fi_mr_attr mr_attr = {
+		.mr_iov = &iov,
+		.iov_count = 1,
+		.access = (FI_REMOTE_READ | FI_REMOTE_WRITE
+				| FI_READ | FI_WRITE),
+		.offset = 0,
+		.requested_key = 0,
+		.context = NULL,
+		.auth_key = (void *) 0xdeadbeef,
+		.auth_key_size = 47,
+	};
+
+	ret = fi_domain(fabric, fi, &dom, NULL);
+	cr_assert(ret == FI_SUCCESS, "fi_domain, ret=%d expected=%d",
+		ret, FI_SUCCESS);
+
+	ret = fi_mr_regattr(dom, &mr_attr, 0, &mr);
+	cr_assert(ret == -FI_EINVAL, "fi_mr_regattr, ret=%d expected=%d",
+		ret, -FI_EINVAL);
+
+	ret = fi_close(&dom->fid);
+	cr_assert(ret == FI_SUCCESS, "fi_close, ret=%d expected=%d",
+		ret, FI_SUCCESS);
+}
 
 Test(domain, many_domains)
 {

--- a/prov/gni/test/ep.c
+++ b/prov/gni/test/ep.c
@@ -50,7 +50,7 @@ static struct fi_info *fi;
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
 
-static void setup(void)
+static void _setup(uint32_t version)
 {
 	int ret;
 
@@ -59,7 +59,7 @@ static void setup(void)
 
 	hints->fabric_attr->prov_name = strdup("gni");
 
-	ret = fi_getinfo(fi_version(), NULL, 0, 0, hints, &fi);
+	ret = fi_getinfo(version, NULL, 0, 0, hints, &fi);
 	cr_assert(!ret, "fi_getinfo");
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
@@ -67,7 +67,16 @@ static void setup(void)
 
 	ret = fi_domain(fab, fi, &dom, NULL);
 	cr_assert(!ret, "fi_domain");
+}
 
+static void setup(void)
+{
+	_setup(fi_version());
+}
+
+static void setup_1_0(void)
+{
+	_setup(FI_VERSION(1, 0));
 }
 
 static void teardown(void)
@@ -85,6 +94,25 @@ static void teardown(void)
 }
 
 TestSuite(endpoint, .init = setup, .fini = teardown);
+TestSuite(endpoint_1_0, .init = setup_1_0, .fini = teardown);
+
+Test(endpoint_1_0, no_auth_key_support)
+{
+	int ret;
+	struct fid_ep *ep;
+	void *old_auth_key = fi->ep_attr->auth_key;
+	int old_auth_key_size = fi->ep_attr->auth_key_size;
+
+	fi->ep_attr->auth_key = (void *) 0xdeadbeef;
+	fi->ep_attr->auth_key_size = 47;
+
+	ret = fi_endpoint(dom, fi, &ep, NULL);
+	cr_assert(ret == -FI_EINVAL, "fi_endpoint, ret=%d expected=%d",
+		ret, -FI_EINVAL);
+
+	fi->ep_attr->auth_key = old_auth_key;
+	fi->ep_attr->auth_key_size = old_auth_key_size;
+}
 
 Test(endpoint_info, info)
 {
@@ -280,7 +308,6 @@ Test(endpoint, getsetopt_gni_ep)
 	cr_assert_eq(ep_priv->posted_recv_queue.attr.type, GNIX_TAG_HLIST);
 	cr_assert_eq(ep_priv->tagged_unexp_recv_queue.attr.type, GNIX_TAG_HLIST);
 	cr_assert_eq(ep_priv->tagged_posted_recv_queue.attr.type, GNIX_TAG_HLIST);
-
 
 	val = 0; // reset the value
 	ret = ep_ops->get_val(&ep->fid, GNI_HASH_TAG_IMPL, &val);


### PR DESCRIPTION
Added runtime checks to domain open, endpoint open, and
mr_regattr functions to ensure that auth keys are not provided
when the application has requested api version less than 1.5

Signed-off-by: James Swaro <jswaro@cray.com>

closes #1228 