### PR TITLE
prov/gni: criterion tests - initialize stack variable

### DIFF
--- a/prov/gni/test/rdm_dgram_rma.c
+++ b/prov/gni/test/rdm_dgram_rma.c
@@ -2121,7 +2121,7 @@ void do_write_error(int len)
 	int ret;
 	ssize_t sz;
 	struct fi_cq_tagged_entry cqe;
-	struct fi_cq_err_entry err_cqe;
+	struct fi_cq_err_entry err_cqe = {0};
 
 	err_cqe.err_data_size = 0;
 	uint64_t w[2] = {0}, r[2] = {0}, w_e[2] = {0}, r_e[2] = {0};
@@ -2196,7 +2196,7 @@ void do_read_error(int len)
 	int ret;
 	ssize_t sz;
 	struct fi_cq_tagged_entry cqe;
-	struct fi_cq_err_entry err_cqe;
+	struct fi_cq_err_entry err_cqe = {0};
 	uint64_t w[2] = {0}, r[2] = {0}, w_e[2] = {0}, r_e[2] = {0};
 
 	init_data(source, len, 0);

--- a/prov/gni/test/rdm_dgram_stx.c
+++ b/prov/gni/test/rdm_dgram_stx.c
@@ -1701,7 +1701,7 @@ static void do_write_error(int len)
 	int ret;
 	ssize_t sz;
 	struct fi_cq_tagged_entry cqe;
-	struct fi_cq_err_entry err_cqe;
+	struct fi_cq_err_entry err_cqe = {0};
 
 	err_cqe.err_data_size = 0;
 	uint64_t w[2] = {0}, r[2] = {0}, w_e[2] = {0}, r_e[2] = {0};
@@ -1776,7 +1776,7 @@ static void do_read_error(int len)
 	int ret;
 	ssize_t sz;
 	struct fi_cq_tagged_entry cqe;
-	struct fi_cq_err_entry err_cqe;
+	struct fi_cq_err_entry err_cqe = {0};
 
 	err_cqe.err_data_size = 0;
 	uint64_t w[2] = {0}, r[2] = {0}, w_e[2] = {0}, r_e[2] = {0};

--- a/prov/gni/test/rdm_sr.c
+++ b/prov/gni/test/rdm_sr.c
@@ -1695,7 +1695,7 @@ void do_send_err(int len)
 {
 	int ret;
 	struct fi_cq_tagged_entry s_cqe;
-	struct fi_cq_err_entry err_cqe;
+	struct fi_cq_err_entry err_cqe = {0};
 	ssize_t sz;
 	uint64_t s[NUMEPS] = {0}, r[NUMEPS] = {0}, s_e[NUMEPS] = {0};
 	uint64_t r_e[NUMEPS] = {0};


### PR DESCRIPTION
Per the fi_cq man page, the err_data field in the CQE error
structure is an option for a provider to provide additional
information, not something that has to be non-NULL.

Prior to support for the FI_SOURCE feature, the GNI provider
happened to always have this field set (though not having
any useful information in most cases).  Now we are getting
random "Bad provider data..."

Change the criterion tests to only check for non-NULL err_data
field in CQEs when the err_data_size field is non-zero.

Fixes ofi-cray/libfabric-cray#1374

Signed-off-by: Howard Pritchard <howardp@lanl.gov>