### PR TITLE
prov/gni: add in FI_SOURCE_ERR ep cap

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -188,7 +188,7 @@
 #define GNIX_EP_SEC_CAPS (FI_MULTI_RECV | FI_TRIGGER | FI_FENCE)
 
 /* Secondary capabilities that introduce overhead.  Must be requested. */
-#define GNIX_EP_SEC_CAPS_OH (FI_SOURCE | FI_RMA_EVENT)
+#define GNIX_EP_SEC_CAPS_OH (FI_SOURCE | FI_RMA_EVENT | FI_SOURCE_ERR)
 
 /* FULL set of capabilities for the provider.  */
 #define GNIX_EP_CAPS_FULL (GNIX_EP_PRIMARY_CAPS | \


### PR DESCRIPTION
The PR ofi-cray/libfabric-cray#1179 implemented the FI_SOURCE_ERR
capability but this wasn't included in the EP caps.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>