### PR TITLE
prov/gni: add toggle for disabling logging

### DIFF
--- a/prov/gni/configure.m4
+++ b/prov/gni/configure.m4
@@ -71,6 +71,11 @@ AC_DEFUN([FI_GNI_CONFIGURE],[
                                       [Enable static linking with uGNI.  Recommended for KNL.])],
                      )
 
+        AC_ARG_ENABLE([gni-logging],
+                      [AS_HELP_STRING([--enable-gni-logging],
+                                      [Enable logging. Enabled by default.])],
+                     )
+
         AS_IF([test x"$enable_gni" != x"no"],
                [FI_PKG_CHECK_MODULES([CRAY_GNI_HEADERS], [cray-gni-headers],
                                  [gni_header_happy=1
@@ -118,6 +123,10 @@ AC_DEFUN([FI_GNI_CONFIGURE],[
                       ],
                       [AC_DEFINE_UNQUOTED([HAVE_XPMEM], [0], [Define to 1 if xpmem available])
                       ])
+
+               AS_IF([test x"$enable_gni_logging" != x"no"],
+                      [AC_DEFINE_UNQUOTED([ENABLE_GNI_LOGGING], [1], [Define to 1 if disabling GNI logging])],
+                      [AC_DEFINE_UNQUOTED([ENABLE_GNI_LOGGING], [0], [Define to 1 if disabling GNI logging])])
 
                gni_path_to_gni_pub=${CRAY_GNI_HEADERS_CFLAGS:2}
 dnl looks like we need to get rid of some white space

--- a/prov/gni/include/gnix_util.h
+++ b/prov/gni/include/gnix_util.h
@@ -93,6 +93,7 @@ extern ofi_atomic32_t gnix_debug_next_tid;
 
 #endif
 
+#if ENABLE_GNI_LOGGING
 #define GNIX_WARN(subsystem, ...)                                              \
 	GNIX_LOG_INTERNAL(FI_WARN, FI_LOG_WARN, subsystem, __VA_ARGS__)
 #define GNIX_TRACE(subsystem, ...)                                             \
@@ -103,6 +104,13 @@ extern ofi_atomic32_t gnix_debug_next_tid;
 	GNIX_LOG_INTERNAL(FI_DBG, FI_LOG_DEBUG, subsystem, __VA_ARGS__)
 #define GNIX_ERR(subsystem, ...)                                               \
 	GNIX_LOG_INTERNAL(GNIX_FI_PRINT, FI_LOG_WARN, subsystem, __VA_ARGS__)
+#else
+#define GNIX_WARN(subsystem, ...)
+#define GNIX_TRACE(subsystem, ...)
+#define GNIX_INFO(subsystem, ...)
+#define GNIX_DEBUG(subsystem, ...)
+#define GNIX_ERR(subsystem, ...)
+#endif
 #define GNIX_FATAL(subsystem, ...)                                             \
 	do { \
 		GNIX_LOG_INTERNAL(GNIX_FI_PRINT, FI_LOG_WARN, subsystem, __VA_ARGS__); \

--- a/prov/gni/src/gnix_buddy_allocator.c
+++ b/prov/gni/src/gnix_buddy_allocator.c
@@ -243,7 +243,8 @@ static inline uint32_t __gnix_buddy_coalesce(gnix_buddy_alloc_handle_t *alloc_ha
 int _gnix_buddy_allocator_create(void *base, uint32_t len, uint32_t max,
 				 gnix_buddy_alloc_handle_t **alloc_handle)
 {
-	char err_buf[256] = {0}, *error = NULL;
+	char err_buf[256] = {0};
+	char *error  __attribute__ ((unused));
 	int fi_errno;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");

--- a/prov/gni/src/gnix_cm.c
+++ b/prov/gni/src/gnix_cm.c
@@ -547,7 +547,8 @@ static int __gnix_ep_connresp(struct gnix_fid_ep *ep,
 /* Check for a connection response on an FI_EP_MSG. */
 int _gnix_ep_progress(struct gnix_fid_ep *ep)
 {
-	int ret, bytes_read, errno_keep;
+	int ret, bytes_read;
+	int errno_keep __attribute__ ((unused));
 	struct gnix_pep_sock_connresp resp;
 
 	/* No lock, fast exit. */
@@ -593,7 +594,8 @@ int _gnix_ep_progress(struct gnix_fid_ep *ep)
 DIRECT_FN STATIC int gnix_connect(struct fid_ep *ep, const void *addr,
 				  const void *param, size_t paramlen)
 {
-	int ret, errno_keep;
+	int ret;
+	int errno_keep __attribute__ ((unused));
 	struct gnix_fid_ep *ep_priv;
 	struct sockaddr_in saddr;
 	struct gnix_pep_sock_connreq req;
@@ -745,7 +747,8 @@ err_unlock:
 DIRECT_FN STATIC int gnix_accept(struct fid_ep *ep, const void *param,
 				 size_t paramlen)
 {
-	int ret, errno_keep;
+	int ret;
+	int errno_keep __attribute__ ((unused));
 	struct gnix_vc *vc;
 	struct gnix_fid_ep *ep_priv;
 	struct gnix_pep_sock_conn *conn;
@@ -1001,7 +1004,8 @@ static int __gnix_pep_connreq(struct gnix_fid_pep *pep, int fd)
 /* Process incoming connection requests on a listening PEP. */
 int _gnix_pep_progress(struct gnix_fid_pep *pep)
 {
-	int accept_fd, ret, errno_keep;
+	int accept_fd, ret;
+	int errno_keep __attribute__ ((unused));
 
 	fastlock_acquire(&pep->lock);
 
@@ -1107,7 +1111,8 @@ DIRECT_FN int gnix_pep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 
 DIRECT_FN int gnix_pep_listen(struct fid_pep *pep)
 {
-	int ret, errno_keep;
+	int ret;
+	int errno_keep __attribute__ ((unused));
 	struct gnix_fid_pep *pep_priv;
 	struct sockaddr_in saddr;
 	int sockopt = 1;


### PR DESCRIPTION
except for GNI_FATAL.

It turns out KNL has a horrible time trying to decide which
way to go when it hits a branch.  Vtune showed that a simple
fi_send/fi_recv streaming write test was spending large amounts
of time in fi_log_enabled.

This PR adds a configury option for the GNI driver to completely disable
GNIX_WARN, etc macros, leaving only GNIX_FATAL.

Adding this option improves the 8-byte streaming send test by about 10%
on KNL:

(before)  215729.57 msgs/sec
(after)   236358.98 msgs/sec

User has to add an option to the configury line:
--disable-gni-logging

By default logging is enabled.

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>