### PR TITLE
prov/gni: Easier scalable key selection

### DIFF
--- a/man/fi_gni.7.md
+++ b/man/fi_gni.7.md
@@ -314,7 +314,7 @@ used within the GNI provider for message passing. FI_ADDR_STR is always
 parsed and converted to FI_ADDR_GNI for use within the GNI provider.
 
 *FI_ADDR_STR* is formatted as follows:
-gni;node;service;GNIX_AV_STR_ADDR_VERSION;device_addr;cdm_id;name_type;cm_nic_cdm_id;cookie;rx_ctx_cnt
+gni;node;service;GNIX_AV_STR_ADDR_VERSION;device_addr;cdm_id;name_type;cm_nic_cdm_id;cookie;rx_ctx_cnt;key_offset
 
 The GNI provider sets the domain attribute *cntr_cnt* to the the CQ limit divided by 2.
 

--- a/prov/gni/include/fi_ext_gni.h
+++ b/prov/gni/include/fi_ext_gni.h
@@ -141,6 +141,7 @@ typedef enum gnix_auth_key_opt {
 	GNIX_USER_KEY_LIMIT = 0,
 	GNIX_PROV_KEY_LIMIT,
 	GNIX_TOTAL_KEYS_NEEDED,
+	GNIX_USER_KEY_MAX_PER_RANK,
 	GNIX_MAX_AUTH_KEY_OPTS,
 } gnix_auth_key_opt_t;
 

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -311,7 +311,8 @@ struct gnix_ep_name {
 	};
 	struct {
 		uint32_t rx_ctx_cnt : 8;
-		uint32_t unused1 : 24;
+		uint32_t key_offset : 12;
+		uint32_t unused1 : 12;
 		uint32_t unused2;
 	};
 	uint64_t reserved[3];

--- a/prov/gni/include/gnix_auth_key.h
+++ b/prov/gni/include/gnix_auth_key.h
@@ -69,6 +69,8 @@ struct gnix_auth_key {
 	uint8_t ptag;
 	uint32_t cookie;
 	int using_vmdh;
+	uint32_t key_partition_size;
+	uint32_t key_offset;
 	gnix_bitmap_t *prov;
 	gnix_bitmap_t *user;
 };

--- a/prov/gni/include/gnix_av.h
+++ b/prov/gni/include/gnix_av.h
@@ -66,7 +66,8 @@ struct gnix_av_addr_entry {
 	};
 	struct {
 		uint32_t rx_ctx_cnt : 8;
-		uint32_t unused1 : 24;
+		uint32_t key_offset: 12;
+		uint32_t unused1 : 12;
 	};
 };
 

--- a/prov/gni/include/gnix_cm.h
+++ b/prov/gni/include/gnix_cm.h
@@ -55,6 +55,7 @@ struct gnix_pep_sock_connreq {
 	uint64_t peer_caps;
 	size_t cm_data_len;
 	char eqe_buf[GNIX_CM_EQE_BUF_SIZE];
+	uint32_t key_offset;
 };
 
 enum gnix_pep_sock_resp_cmd {
@@ -70,6 +71,7 @@ struct gnix_pep_sock_connresp {
 	uint64_t peer_caps;
 	size_t cm_data_len;
 	char eqe_buf[GNIX_CM_EQE_BUF_SIZE];
+	uint32_t key_offset;
 };
 
 struct gnix_pep_sock_conn {

--- a/prov/gni/include/gnix_mr.h
+++ b/prov/gni/include/gnix_mr.h
@@ -176,6 +176,18 @@ void _gnix_convert_key_to_mhdl(
 		gnix_mr_key_t    *key,
 		gni_mem_handle_t *mhdl);
 
+#define _GNIX_CONVERT_MR_KEY(scalable, offset, convert_func, key, mhdl) \
+	do { \
+		if (scalable) { \
+			gnix_mr_key_t _gnix_mr_key = { \
+				.value = ((gnix_mr_key_t *) (key))->value + (offset), \
+			}; \
+			convert_func(&_gnix_mr_key, (mhdl)); \
+		} else { \
+			convert_func((gnix_mr_key_t *) (key), (mhdl)); \
+		} \
+	} while (0)
+
 /**
  * @brief Converts a gni memory handle to a libfabric key
  *

--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -140,6 +140,7 @@ struct gnix_vc {
 	gni_mem_handle_t peer_irq_mem_hndl;
 	xpmem_apid_t peer_apid;
 	uint64_t peer_caps;
+	uint32_t peer_key_offset;
 };
 
 /*

--- a/prov/gni/src/gnix_atomic.c
+++ b/prov/gni/src/gnix_atomic.c
@@ -435,9 +435,11 @@ int _gnix_amo_post_req(void *data)
 
 	/* Mem handle CRC is not validated during FMA operations.  Skip this
 	 * costly calculation. */
-	_gnix_convert_key_to_mhdl_no_crc(
-			(gnix_mr_key_t *)&fab_req->amo.rem_mr_key,
-			&mdh);
+	_GNIX_CONVERT_MR_KEY(ep->auth_key->using_vmdh,
+			fab_req->vc->peer_key_offset,
+			_gnix_convert_key_to_mhdl_no_crc,
+			&fab_req->amo.rem_mr_key, &mdh);
+
 	loc_md = (struct gnix_fid_mem_desc *)fab_req->amo.loc_md;
 
 	txd->gni_desc.type = GNI_POST_AMO;

--- a/prov/gni/src/gnix_av.c
+++ b/prov/gni/src/gnix_av.c
@@ -192,6 +192,7 @@ static int table_insert(struct gnix_fid_av *av_priv, const void *addr,
 		av_priv->table[index].rx_ctx_cnt = ep_name.rx_ctx_cnt;
 		av_priv->table[index].cm_nic_cdm_id =
 			ep_name.cm_nic_cdm_id;
+		av_priv->table[index].key_offset = ep_name.key_offset;
 		if (fi_addr)
 			fi_addr[i] = index;
 

--- a/prov/gni/src/gnix_cm.c
+++ b/prov/gni/src/gnix_cm.c
@@ -473,6 +473,7 @@ static int __gnix_ep_connresp(struct gnix_fid_ep *ep,
 	switch (resp->cmd) {
 	case GNIX_PEP_SOCK_RESP_ACCEPT:
 		ep->vc->peer_caps = resp->peer_caps;
+		ep->vc->peer_key_offset = resp->key_offset;
 		ep->vc->peer_id = resp->vc_id;
 
 		/* Initialize the GNI connection. */
@@ -696,6 +697,7 @@ DIRECT_FN STATIC int gnix_connect(struct fid_ep *ep, const void *addr,
 	req.vc_mbox_attr.msg_maxsize = ep_priv->domain->params.mbox_msg_maxsize;
 	req.cq_irq_mdh = ep_priv->nic->irq_mem_hndl;
 	req.peer_caps = ep_priv->caps;
+	req.key_offset = ep_priv->auth_key->key_offset;
 
 	req.cm_data_len = paramlen;
 	if (paramlen) {
@@ -778,6 +780,7 @@ DIRECT_FN STATIC int gnix_accept(struct fid_ep *ep, const void *param,
 	}
 	ep_priv->vc = vc;
 	ep_priv->vc->peer_caps = conn->req.peer_caps;
+	ep_priv->vc->peer_key_offset = conn->req.key_offset;
 	ep_priv->vc->peer_id = conn->req.vc_id;
 
 	ret = _gnix_mbox_alloc(vc->ep->nic->mbox_hndl, &mbox);
@@ -816,6 +819,7 @@ DIRECT_FN STATIC int gnix_accept(struct fid_ep *ep, const void *param,
 			ep_priv->domain->params.mbox_msg_maxsize;
 	resp.cq_irq_mdh = ep_priv->nic->irq_mem_hndl;
 	resp.peer_caps = ep_priv->caps;
+	resp.key_offset = ep_priv->auth_key->key_offset;
 
 	resp.cm_data_len = paramlen;
 	if (paramlen) {

--- a/prov/gni/src/gnix_cm_nic.c
+++ b/prov/gni/src/gnix_cm_nic.c
@@ -635,7 +635,7 @@ int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 
 	/*
 	 * we have to force allocation of a new nic since we want
-	 * an a particulard cdm id
+	 * an a particular cdm id
 	 */
 	nic_attr.must_alloc = true;
 	nic_attr.use_cdm_id = true;

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -999,6 +999,11 @@ static int __gnix_auth_key_set_val(
 		GNIX_WARN(FI_LOG_FABRIC,
 			"GNIX_TOTAL_KEYS_NEEDED is not a definable value.\n");
 		return -FI_EOPNOTSUPP;
+	case GNIX_USER_KEY_MAX_PER_RANK:
+		GNIX_WARN(FI_LOG_FABRIC,
+			"GNIX_USER_KEY_MAX_PER_RANK is not a definable "
+			"value.\n");
+		return -FI_EOPNOTSUPP;
 	default:
 		GNIX_WARN(FI_LOG_FABRIC, ("Invalid fab_ops_val\n"));
 		return -FI_EINVAL;
@@ -1014,6 +1019,8 @@ static int __gnix_auth_key_get_val(
 	void *val)
 {
 	struct gnix_auth_key *info;
+	uint32_t pes_on_node;
+	int ret;
 
 	if (!val)
 		return -FI_EINVAL;
@@ -1037,7 +1044,20 @@ static int __gnix_auth_key_get_val(
 			info->attr.prov_key_limit) :
 			(gnix_default_user_registration_limit +
 			 gnix_default_prov_registration_limit));
-	break;
+		break;
+	case GNIX_USER_KEY_MAX_PER_RANK:
+		ret = _gnix_pes_on_node(&pes_on_node);
+		if (ret) {
+			GNIX_WARN(FI_LOG_FABRIC,
+				"failed to get pes on node count\n");
+			return -FI_EINVAL;
+		}
+
+		*(int *)val = ((info) ?
+			info->attr.user_key_limit :
+			gnix_default_user_registration_limit) /
+			pes_on_node;
+		break;
 	default:
 		GNIX_WARN(FI_LOG_FABRIC, ("Invalid fab_ops_val\n"));
 		return -FI_EINVAL;


### PR DESCRIPTION
This feature allows application writers to choose
keys that do not need to be unique between ranks on
the same node. Prior to this feature, memory keys chosen
by ranks on the same node were required to be unique.

Signed-off-by: James Swaro <jswaro@cray.com>

@hppritcha @chuckfossen 
closes #1244 