### PR TITLE
prov/gni: swat compiler/config problems

### DIFF
--- a/prov/gni/configure.m4
+++ b/prov/gni/configure.m4
@@ -204,7 +204,8 @@ dnl Note kdreg only supplies an include file, no library
 
         AM_CONDITIONAL([HAVE_CRITERION], [test "x$have_criterion" = "xtrue"])
         AS_IF([test "x$have_criterion" = "xtrue"],
-              [AC_DEFINE_UNQUOTED([HAVE_CRITERION], [1], [Define to 1 if criterion requested and available])])
+              [AC_DEFINE_UNQUOTED([HAVE_CRITERION], [1], [Define to 1 if criterion requested and available])],
+              [AC_DEFINE_UNQUOTED([HAVE_CRITERION], [0], [Define to 1 if criterion requested and available])])
 
         AC_SUBST(gni_CPPFLAGS)
         AC_SUBST(gni_LDFLAGS)

--- a/prov/gni/src/gnix_buddy_allocator.c
+++ b/prov/gni/src/gnix_buddy_allocator.c
@@ -245,13 +245,14 @@ int _gnix_buddy_allocator_create(void *base, uint32_t len, uint32_t max,
 {
 	char err_buf[256] = {0}, *error = NULL;
 	int fi_errno;
+	uint32_t size_check = len / MIN_BLOCK_SIZE * 2;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
 	/* Ensure parameters are valid */
 	if (OFI_UNLIKELY(!base || !len || !max || max > len || !alloc_handle ||
 			 IS_NOT_POW_TWO(max) || (len % max) ||
-			 !(len / MIN_BLOCK_SIZE * 2))) {
+			 !size_check)) {
 
 		GNIX_WARN(FI_LOG_EP_CTRL,
 			  "Invalid parameter to _gnix_buddy_allocator_create."


### PR DESCRIPTION
the gcc 7.1.0 compiler brought up a warning with mixing boolean
and "*" ops together.  Fixed that.

embarrassing configury problem with not defining HAVE_CRITERION
in config.h if --with-criterion was not used when configuring.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>