### PR TITLE
prov/gni: Enable smrn tests when kdreg is present

### DIFF
--- a/prov/gni/test/smrn.c
+++ b/prov/gni/test/smrn.c
@@ -42,6 +42,12 @@
 
 #define GNIX_DEFAULT_RQ_CNT 4
 
+#if HAVE_KDREG
+# define KDREG_CHECK false
+#else
+# define KDREG_CHECK true
+#endif
+
 static struct gnix_smrn *smrn;
 static struct gnix_smrn_rq *rqs[GNIX_DEFAULT_RQ_CNT];
 static void **memory_regions;
@@ -89,7 +95,8 @@ static void smrn_teardown(void)
 
 TestSuite(smrn,
 	  .init = smrn_setup,
-	  .fini = smrn_teardown);
+	  .fini = smrn_teardown,
+	  .disabled = KDREG_CHECK);
 
 #define RQ_ENTRIES 21
 #define REGIONS (GNIX_DEFAULT_RQ_CNT * RQ_ENTRIES)
@@ -98,7 +105,7 @@ struct test_structure {
 	int pending;
 };
 
-Test(smrn, simple, .disabled = true)
+Test(smrn, simple)
 {
 	const int regions = REGIONS;
 	void *addresses[REGIONS];
@@ -214,7 +221,7 @@ static void *thread_func(void *context)
 }
 
 
-Test(smrn, threaded, .disabled = true)
+Test(smrn, threaded)
 {
 	const int regions = REGIONS;
 	void *addresses[REGIONS];


### PR DESCRIPTION
Enables test when the pre-requisite library and functionality is
present.

Signed-off-by: James Swaro <jswaro@cray.com>

closes #1415 