### PR TITLE
prov/gni: add issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,7 @@
+Thank you for taking the time to submit an issue to our downstream Cray libfabric repo.
+
+However, don't submit your issue here, rather submit on the [upstream repo issue list](https://github.com/ofiwg/libfabric/issues)
+and annotate the issue with the gni provider tag.
+
+
+


### PR DESCRIPTION
we don't want users to open issues on our now orphaned
downstream repo, but rather open on the canonical
upstream repo.

So add a template to stop this.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>